### PR TITLE
[ARGO-5184] - Add a new Tenants feature with list view and creation form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 VITE_KEYCLOAK_URL=http://localhost:58080
 VITE_KEYCLOAK_REALM=quarkus
 VITE_KEYCLOAK_CLIENT_ID=frontend-service
-VITE_KEYCLOAK_SCOPE="openid voperson_id"
+VITE_KEYCLOAK_SCOPE="openid voperson_id email profile entitlements"
 VITE_REDIRECT_URI=http://localhost:5173
 VITE_BACKEND_URI=http://localhost:8080
 

--- a/src/App.css
+++ b/src/App.css
@@ -57,3 +57,75 @@
 .custom-tab-content.active {
   display: block;
 }
+
+.page-title {
+  font-size: 1.75rem;
+  line-height: 2rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.page-subtitle {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.section-description {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.required {
+  color: #ef4444;
+}
+
+input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  color: #111827;
+  background: white;
+  transition: all 0.2s;
+}
+
+input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+}
+
+input::placeholder {
+  color: #9ca3af;
+}
+
+textarea {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  color: #111827;
+  background: white;
+  resize: vertical;
+  font-family: inherit;
+  transition: all 0.2s;
+  min-height: 80px;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+}
+
+textarea::placeholder {
+  color: #9ca3af;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import AuthProtected from './routing/AuthProtected'
 import { Profile } from './pages/Profile'
 import { Build } from './pages/Build'
 import { View } from './pages/View'
+import { Tenants } from './pages/Tenants'
+import { CreateTenant } from './pages/CreateTenant'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Status } from './pages/Status'
 import { AuthProvider } from './auth/AuthProvider'
@@ -53,6 +55,8 @@ function App() {
           <Route element={<AuthLayout />}>
             <Route element={<Layout />}>
               <Route index element={<Home />} />
+              <Route path="tenants/view" element={<Tenants />} />
+              <Route path="tenants/create" element={<CreateTenant />} />
               <Route
                 path="profile"
                 element={
@@ -69,8 +73,8 @@ function App() {
                   </AuthProtected>
                 }
               />
-              <Route path="build" element={<Build />} />
-              <Route path="view" element={<View />} />
+              <Route path="status-pages/build" element={<Build />} />
+              <Route path="status-pages/view" element={<View />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
           </Route>

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,9 +1,11 @@
 import { Link, NavLink, Outlet } from 'react-router'
 import { useAuth } from './auth/useAuth'
 import {
-  EyeIcon,
-  PencilSquareIcon,
   ArrowLeftStartOnRectangleIcon,
+  ServerStackIcon,
+  WrenchScrewdriverIcon,
+  RectangleStackIcon,
+  DocumentPlusIcon,
 } from '@heroicons/react/16/solid'
 import { squishEmail } from './utils/profile'
 import { Button } from './components/Button'
@@ -55,13 +57,21 @@ export default function Layout() {
         </div>
 
         <nav className="flex-1 py-4 flex flex-col gap-y-1">
-          <SidebarNavItem to="/build">
-            <PencilSquareIcon className="size-5" aria-hidden />
-            Build
+          <SidebarNavItem to="/tenants/view">
+            <ServerStackIcon className="size-5" aria-hidden />
+            Tenants
           </SidebarNavItem>
-          <SidebarNavItem to="/view">
-            <EyeIcon className="size-5" aria-hidden />
-            View
+          <SidebarNavItem to="/tenants/create">
+            <DocumentPlusIcon className="size-5" aria-hidden />
+            Create a Tenant
+          </SidebarNavItem>
+          <SidebarNavItem to="/status-pages/view">
+            <RectangleStackIcon className="size-5" aria-hidden />
+            Status Pages
+          </SidebarNavItem>
+          <SidebarNavItem to="/status-pages/build">
+            <WrenchScrewdriverIcon className="size-5" aria-hidden />
+            Build a Status Page
           </SidebarNavItem>
         </nav>
 

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -1,0 +1,45 @@
+import type { Tenant, TenantList } from '@/types/tenants'
+
+const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+export const fetchTenants = async (token: string): Promise<TenantList> => {
+  const response = await fetch(`${BACKEND_API}/v1/admin/tenants`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchCreateTenant = async (
+  data: Tenant,
+  token: string,
+): Promise<Tenant> => {
+  const response = await fetch(`${BACKEND_API}/v1/admin/tenants`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAuth } from '@/auth/useAuth'
+import { fetchTenants, fetchCreateTenant } from '@/api/tenants'
+import type { Tenant, TenantList } from '@/types/tenants'
+
+export const useGetTenants = () => {
+  const { token } = useAuth()
+
+  return useQuery<TenantList, Error>({
+    queryKey: ['tenants'],
+    queryFn: () => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      return fetchTenants(token)
+    },
+    retry: false,
+    enabled: !!token,
+  })
+}
+
+export const useCreateTenantMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<Tenant, Error, Tenant>({
+    mutationFn: (data: Tenant) => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      return fetchCreateTenant(data, token)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tenants'] })
+    },
+    onError: (error) => {
+      console.error('Tenant create error:', error)
+    },
+  })
+}

--- a/src/pages/Build.tsx
+++ b/src/pages/Build.tsx
@@ -382,14 +382,14 @@ export const Build = () => {
   return (
     <div>
       <Toaster richColors position="top-center" />
-      <div className="flex flex-col justify-center items-center">
+      <div className="flex flex-col justify-center items-center px-6">
         <div className="max-w-7xl w-full">
           <div className="pb-1 mb-3">
             <div>
-              <h1 className="text-3xl font-semibold text-gray-800">
+              <h1 className="page-title">
                 {isEditMode ? 'Edit Page' : 'Build New Page'}
               </h1>
-              <p className="text-md text-gray-500">
+              <p className="page-subtitle">
                 {isEditMode
                   ? 'Update your status page configuration and content'
                   : 'Create a new status page to monitor your services'}
@@ -461,8 +461,8 @@ export const Build = () => {
                 <div className="space-y-6">
                   <div className="grid grid-cols-[320px_1fr] gap-6 items-center">
                     <div>
-                      <h3 className="text-lg font-semibold">Page Settings</h3>
-                      <p className="text-sm text-gray-500">
+                      <h3 className="section-title">Page Settings</h3>
+                      <p className="section-description">
                         Basic information for your status page.
                       </p>
                     </div>
@@ -470,7 +470,7 @@ export const Build = () => {
                     <div className="bg-white border border-gray-200 rounded-lg p-6 space-y-4">
                       <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">
-                          Name <span className="text-red-500">*</span>
+                          Name <span className="required">*</span>
                         </label>
                         <input
                           type="text"
@@ -492,7 +492,7 @@ export const Build = () => {
 
                       <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">
-                          Path <span className="text-red-500">*</span>
+                          Path <span className="required">*</span>
                         </label>
                         <input
                           type="text"
@@ -511,8 +511,8 @@ export const Build = () => {
 
                   <div className="grid grid-cols-[320px_1fr] gap-6 items-center">
                     <div>
-                      <h3 className="text-lg font-semibold">Data Source</h3>
-                      <p className="text-sm text-gray-500">
+                      <h3 className="section-title">Data Source</h3>
+                      <p className="section-description">
                         Connect to your Argo-web-api endpoint.
                       </p>
                     </div>
@@ -587,10 +587,8 @@ export const Build = () => {
                 <div className="space-y-4">
                   <div>
                     <div className="border border-gray-200 rounded-lg px-5 py-4 space-y-3">
-                      <h3 className="text-lg font-semibold mb-0">
-                        Report Selection
-                      </h3>
-                      <p className="text-sm text-gray-500 mb-2">
+                      <h3 className="section-title mb-0">Report Selection</h3>
+                      <p className="section-description mb-2">
                         Choose a report and manage items.
                       </p>
                       {!reportsMutation.data && (
@@ -632,7 +630,7 @@ export const Build = () => {
 
                           {groupsMutation.data &&
                             (groupsMutation.data.length === 0 ? (
-                              <div className="text-sm text-red-500 p-2 mt-2 bg-red-50 border-red-400 border text-center rounded">
+                              <div className="text-sm required p-2 mt-2 bg-red-50 border-red-400 border text-center rounded">
                                 Report is empty!
                               </div>
                             ) : (
@@ -691,10 +689,10 @@ export const Build = () => {
                 <div className="space-y-4">
                   <div>
                     <div className="border border-gray-200 rounded-lg px-5 py-4 space-y-3">
-                      <h3 className="text-lg font-semibold mb-0">
+                      <h3 className="section-title mb-0">
                         Customize Appearance
                       </h3>
-                      <p className="text-sm text-gray-500 mb-2">
+                      <p className="section-description mb-2">
                         Customize colors, logo, and status display options.
                       </p>
                       <div className="bg-white rounded-lg py-2 space-y-4 mt-4">
@@ -707,7 +705,8 @@ export const Build = () => {
                               type="color"
                               value={color}
                               onChange={(e) => setColor(e.target.value)}
-                              className="w-12 h-10 rounded cursor-pointer border-2 border-gray-300"
+                              className="w-14 h-10 rounded cursor-pointer border-2 border-gray-300"
+                              style={{ padding: '0.3rem' }}
                             />
                             <input
                               type="text"

--- a/src/pages/CreateTenant.module.css
+++ b/src/pages/CreateTenant.module.css
@@ -1,0 +1,145 @@
+.container {
+  max-width: 1060px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.section {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 2rem;
+}
+
+.section-info {
+  padding-top: 0.5rem;
+}
+
+.section-content {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.25rem;
+}
+
+.dropzone {
+  border: 2px dashed #d1d5db;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  background: #fafafa;
+}
+
+.dropzone:hover {
+  border-color: #9ca3af;
+  background: #f3f4f6;
+}
+
+.dropzone-active {
+  border-color: #3b82f6;
+  background: #dbeafe;
+}
+
+.upload-icon {
+  width: 3rem;
+  height: 3rem;
+  color: #9ca3af;
+  margin: 0 auto 0.1rem;
+}
+
+.upload-text {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin: 0;
+}
+
+.image-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.preview-image {
+  max-width: 120px;
+  max-height: 120px;
+  border-radius: 0.5rem;
+  object-fit: contain;
+}
+
+.dropzone-text {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin: 0;
+}
+
+.or-divider {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  margin: 0.25rem 0;
+}
+
+.or-divider::before,
+.or-divider::after {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.or-divider span {
+  padding: 0 1rem;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 0 0.5rem;
+  }
+
+  .section {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .header {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: stretch;
+  }
+
+  .section-content {
+    padding: 1.5rem;
+  }
+}

--- a/src/pages/CreateTenant.tsx
+++ b/src/pages/CreateTenant.tsx
@@ -1,0 +1,307 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useDropzone } from 'react-dropzone'
+import { PhotoIcon } from '@heroicons/react/16/solid'
+import { useCreateTenantMutation } from '@/hooks/useTenants'
+import { toast, Toaster } from 'sonner'
+import { Button } from '../components/Button'
+import styles from './CreateTenant.module.css'
+
+export const CreateTenant = () => {
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    description: '',
+    website: '',
+    image: '',
+  })
+  const [imageUrl, setImageUrl] = useState('')
+  const [imagePreview, setImagePreview] = useState<string | null>(null)
+  const [nameError, setNameError] = useState('')
+  const [emailError, setEmailError] = useState('')
+  const [websiteError, setWebsiteError] = useState('')
+
+  const createMutation = useCreateTenantMutation()
+  const navigate = useNavigate()
+
+  const onDrop = useCallback((acceptedFiles: File[]) => {
+    const file = acceptedFiles[0]
+
+    if (!file.type.startsWith('image/')) {
+      toast.error('Only image files are supported')
+      return
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('Image size must be less than 5MB')
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = (event) => {
+      if (event.target?.result) {
+        const base64String = event.target.result as string
+        setFormData((prev) => ({ ...prev, image: base64String }))
+        setImagePreview(base64String)
+      }
+    }
+    reader.readAsDataURL(file)
+  }, [])
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: {
+      'image/png': ['.png'],
+      'image/jpeg': ['.jpg', '.jpeg'],
+      'image/svg+xml': ['.svg'],
+    },
+    maxFiles: 1,
+  })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (nameError || emailError || websiteError) {
+      toast.error('Please fix the validation errors before submitting')
+      return
+    }
+
+    const submitData = {
+      ...formData,
+      image: formData.image || imageUrl || undefined,
+    }
+
+    createMutation.mutate(
+      { info: submitData },
+      {
+        onSuccess: () => {
+          toast.success('Tenant created successfully!')
+          setTimeout(() => {
+            navigate('/tenants')
+          }, 2000)
+        },
+        onError: (error) => {
+          toast.error(`Failed to create tenant: ${error.message}`)
+        },
+      },
+    )
+  }
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target
+
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }))
+
+    if (name === 'name') {
+      // Allow only Latin uppercase letters (A-Z), spaces, and hyphen
+      const isValid = /^[A-Z\s-]*$/.test(value)
+      if (value && !isValid) {
+        setNameError(
+          'Only Latin uppercase letters, spaces, and hyphen (-) are allowed',
+        )
+      } else {
+        setNameError('')
+      }
+    }
+
+    if (name === 'email') {
+      // Email validation
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+      if (value && !emailRegex.test(value)) {
+        setEmailError('Please enter a valid email address')
+      } else {
+        setEmailError('')
+      }
+    }
+
+    if (name === 'website') {
+      // URL validation - must start with http:// or https://
+      const urlRegex = /^https?:\/\/.+\..+/
+      if (value && !urlRegex.test(value)) {
+        setWebsiteError(
+          'Please enter a valid URL (must start with http:// or https://)',
+        )
+      } else {
+        setWebsiteError('')
+      }
+    }
+  }
+
+  const handleImageUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const url = e.target.value
+    setImageUrl(url)
+    if (url) {
+      setImagePreview(url)
+      setFormData((prev) => ({ ...prev, image: url }))
+    }
+  }
+
+  return (
+    <>
+      <Toaster richColors position="top-center" />
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <div>
+            <h1 className="page-title">Create New Tenant</h1>
+            <p className="page-subtitle">
+              Fill in the details to create a new tenant
+            </p>
+          </div>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={handleSubmit}
+            disabled={
+              createMutation.isPending ||
+              !!nameError ||
+              !!emailError ||
+              !!websiteError
+            }
+          >
+            {createMutation.isPending ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <div className={styles.section}>
+            <div className={styles['section-info']}>
+              <h2 className="section-title">Tenant Information</h2>
+              <p className="section-description">
+                Basic information for the new tenant
+              </p>
+            </div>
+
+            <div className={styles['section-content']}>
+              <div className={styles.field}>
+                <label className={styles.label}>
+                  Name <span className="required">*</span>
+                </label>
+                <input
+                  type="text"
+                  name="name"
+                  value={formData.name}
+                  onChange={handleChange}
+                  className={styles.input}
+                  placeholder="Enter tenant name"
+                  required
+                />
+                {nameError && (
+                  <span className="text-red-400 text-sm mt-1">{nameError}</span>
+                )}
+              </div>
+
+              <div className={styles.field}>
+                <label className={styles.label}>
+                  Email <span className="required">*</span>
+                </label>
+                <input
+                  type="email"
+                  name="email"
+                  value={formData.email}
+                  onChange={handleChange}
+                  className={styles.input}
+                  placeholder="The email of the tenant that is responsible"
+                  required
+                />
+                {emailError && (
+                  <span className="text-red-400 text-sm mt-1">
+                    {emailError}
+                  </span>
+                )}
+              </div>
+
+              <div className={styles.field}>
+                <label className={styles.label}>
+                  Description <span className="required">*</span>
+                </label>
+                <textarea
+                  name="description"
+                  value={formData.description}
+                  onChange={handleChange}
+                  className={styles.textarea}
+                  placeholder="A small description about the tenant"
+                  rows={3}
+                  required
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className={styles.section}>
+            <div className={styles['section-info']}>
+              <h2 className="section-title">Additional Details</h2>
+              <p className="section-description">
+                Optional information for the tenant
+              </p>
+            </div>
+
+            <div className={styles['section-content']}>
+              <div className={styles.field}>
+                <label className={styles.label}>Image</label>
+                <div
+                  {...getRootProps()}
+                  className={`${styles.dropzone} ${isDragActive ? styles['dropzone-active'] : ''}`}
+                >
+                  <input {...getInputProps()} />
+                  {imagePreview ? (
+                    <div className={styles['image-preview']}>
+                      <img
+                        src={imagePreview}
+                        alt="Preview"
+                        className={styles['preview-image']}
+                      />
+                      <p className={styles['dropzone-text']}>
+                        Drop image here or click to upload
+                      </p>
+                    </div>
+                  ) : (
+                    <>
+                      <PhotoIcon className={styles['upload-icon']} />
+                      <p className={styles['upload-text']}>
+                        {isDragActive
+                          ? 'Drop image here'
+                          : 'Drop image here or click to upload'}
+                      </p>
+                    </>
+                  )}
+                </div>
+                <div className={styles['or-divider']}>
+                  <span>OR</span>
+                </div>
+                <input
+                  type="url"
+                  value={imageUrl}
+                  onChange={handleImageUrlChange}
+                  className={styles.input}
+                  placeholder="Enter image URL"
+                />
+              </div>
+
+              <div className={`${styles.field} mt-2`}>
+                <label className={styles.label}>Website</label>
+                <input
+                  type="url"
+                  name="website"
+                  value={formData.website}
+                  onChange={handleChange}
+                  className={styles.input}
+                  placeholder="Enter the project related URL"
+                />
+                {websiteError && (
+                  <span className="text-red-400 text-sm mt-1">
+                    {websiteError}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </>
+  )
+}

--- a/src/pages/Tenants.module.css
+++ b/src/pages/Tenants.module.css
@@ -1,0 +1,188 @@
+.container {
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 16rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+.card {
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-content {
+  padding: 1rem 1.25rem;
+  flex: 1;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.image-container {
+  flex-shrink: 0;
+  border-radius: 0.5rem;
+}
+
+.tenant-image {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.5rem;
+  object-fit: contain;
+  background-color: #f9fafb;
+  padding: 0.25rem;
+}
+
+.tenant-fallback {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.5rem;
+  background-color: #6c7788;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fallback-text {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: white;
+}
+
+.info-container {
+  flex: 1;
+  min-width: 0;
+}
+
+.tenant-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 0.125rem;
+}
+
+.tenant-email {
+  font-size: 0.75rem;
+  color: #6b7280;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tenant-description {
+  font-size: 0.875rem;
+  color: #4b5563;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-footer {
+  background-color: #f9fafb;
+  padding: 0.25rem 1rem;
+  border-top: 1px solid #f3f4f6;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.action-button {
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  transition: all 0.2s;
+  cursor: pointer;
+  border: none;
+  background: none;
+}
+
+.action-button.edit {
+  color: #4b5563;
+}
+
+.action-button.edit:hover {
+  background-color: #f3f4f6;
+}
+
+.action-button.delete {
+  color: #dc2626;
+}
+
+.action-button.delete:hover {
+  background-color: #fef2f2;
+}
+
+.action-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 2rem;
+  background-color: #f9fafb;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e7eb;
+}
+
+.empty-text {
+  color: #6b7280;
+  font-size: 1.125rem;
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 80rem;
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .action-button {
+    padding: 0.375rem;
+  }
+
+  .action-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 72rem;
+  }
+
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/src/pages/Tenants.tsx
+++ b/src/pages/Tenants.tsx
@@ -1,0 +1,113 @@
+import { useGetTenants } from '@/hooks/useTenants'
+import { useAuth } from '@/auth/useAuth'
+import { LoginPrompt } from '@/components/LoginPrompt'
+import {
+  ArrowPathIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from '@heroicons/react/16/solid'
+import { Button } from '@/components/Button'
+import { useNavigate } from 'react-router-dom'
+import styles from './Tenants.module.css'
+
+export const Tenants = () => {
+  const { authenticated, login } = useAuth()
+  const { data, isLoading } = useGetTenants()
+  const navigate = useNavigate()
+
+  const tenants =
+    data?.content?.map((tenant) => ({
+      ...tenant?.info,
+      id: tenant?.id,
+    })) || []
+
+  if (!authenticated) {
+    return (
+      <LoginPrompt
+        title="Manage Tenants"
+        description="Login to view and manage your tenants"
+        onLogin={login}
+      />
+    )
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div>
+          <h1 className="page-title">Tenants</h1>
+          <p className="page-subtitle">
+            Manage and create new tenants for the monitoring service
+          </p>
+        </div>
+        <Button
+          variant="primary"
+          size="md"
+          onClick={() => navigate('/tenants/create')}
+        >
+          Create New Tenant
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className={styles['loading-container']}>
+          <ArrowPathIcon className="animate-spin size-10 text-blue-500" />
+        </div>
+      ) : (
+        <div className={styles.grid}>
+          {tenants && tenants?.length > 0 ? (
+            tenants.map((tenant) => (
+              <div key={tenant.id} className={styles.card}>
+                <div className={styles['card-content']}>
+                  <div className={styles['card-header']}>
+                    <div className={styles['image-container']}>
+                      {tenant.image ? (
+                        <img
+                          className={styles['tenant-image']}
+                          src={tenant.image}
+                        />
+                      ) : (
+                        <div className={styles['tenant-fallback']}>
+                          <span className={styles['fallback-text']}>
+                            {tenant.name.charAt(0).toUpperCase()}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                    <div className={styles['info-container']}>
+                      <h3 className={styles['tenant-name']}>{tenant.name}</h3>
+                      <p className={styles['tenant-email']}>{tenant.email}</p>
+                    </div>
+                  </div>
+                  <p className={styles['tenant-description']}>
+                    {tenant.description}
+                  </p>
+                </div>
+                <div className={styles['card-footer']}>
+                  <button
+                    aria-label="Edit Tenant"
+                    className={`${styles['action-button']} ${styles.edit} tooltip`}
+                    data-tip="Edit"
+                  >
+                    <PencilSquareIcon className={styles['action-icon']} />
+                  </button>
+                  <button
+                    aria-label="Delete Tenant"
+                    className={`${styles['action-button']} ${styles.delete} tooltip`}
+                    data-tip="Delete"
+                  >
+                    <TrashIcon className={styles['action-icon']} />
+                  </button>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className={styles['empty-state']}>
+              <p className={styles['empty-text']}>No tenants found.</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -47,35 +47,30 @@ export const View = () => {
 
   return (
     <div className="flex flex-col justify-center items-center">
-      <div className="max-w-7xl w-full">
+      <div className="max-w-full md:max-w-5xl lg:max-w-6xl w-full">
         <div className="pb-1 mb-4 md:mb-6 px-2 md:px-0">
-          <h1 className="text-2xl md:text-3xl font-semibold text-gray-800">
-            Status Pages
-          </h1>
-          <p className="text-md text-gray-500">View and manage your pages</p>
+          <h1 className="page-title">Status Pages</h1>
+          <p className="page-subtitle">View and manage your pages</p>
         </div>
 
         <div className="bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden max-h-[calc(100vh-200px)] flex flex-col">
           <div className="overflow-auto flex-1">
-            <table className="w-full">
+            <table className="w-full table-fixed">
               <thead className="bg-gray-100 border-b border-gray-200">
                 <tr>
-                  <th className="px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
+                  <th className="w-[20%] px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
                     Name
                   </th>
-                  <th className="px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
+                  <th className="w-[20%] px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
                     Path
                   </th>
-                  <th className="hidden md:table-cell px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
+                  <th className="hidden md:table-cell w-[15%] px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
                     Report
                   </th>
-                  <th className="hidden lg:table-cell px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
-                    Endpoint
-                  </th>
-                  <th className="hidden sm:table-cell px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
+                  <th className="hidden sm:table-cell w-[15%] px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
                     Updated
                   </th>
-                  <th className="px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
+                  <th className="w-[10%] px-2 lg:px-4 py-3 text-left text-sm font-semibold text-gray-700 uppercase tracking-wider">
                     Actions
                   </th>
                 </tr>
@@ -88,40 +83,44 @@ export const View = () => {
                       key={item.id}
                       className="hover:bg-gray-50 transition-colors"
                     >
-                      <td className="px-2 lg:px-4 py-3 md:py-4 whitespace-nowrap">
-                        <span className="text-xs md:text-sm font-medium text-gray-900 truncate">
+                      <td className="px-2 lg:px-4 py-3 md:py-4">
+                        <span className="text-xs md:text-sm font-medium text-gray-900 break-words">
                           {item.name}
                         </span>
                       </td>
-                      <td className="px-2 lg:px-4 py-3 md:py-4 whitespace-nowrap">
-                        <span className="text-xs md:text-sm text-gray-700 font-mono">
+                      <td className="px-2 lg:px-4 py-3 md:py-4">
+                        <span className="text-xs md:text-sm text-gray-700 font-mono break-all">
                           {item.slug}
                         </span>
                       </td>
-                      <td className="hidden md:table-cell px-2 lg:px-4 py-4 whitespace-nowrap text-sm text-gray-700">
-                        {item.report}
-                      </td>
-                      <td className="hidden lg:table-cell px-4 py-4 whitespace-nowrap text-sm text-gray-700">
-                        {item.api || '-'}
+                      <td className="hidden md:table-cell px-2 lg:px-4 py-4 text-sm text-gray-700">
+                        <span className="break-words">{item.report}</span>
                       </td>
                       <td className="hidden sm:table-cell px-2 lg:px-4 py-3 md:py-4 whitespace-nowrap text-xs md:text-sm text-gray-500">
-                        {item.updated_at
-                          ? new Date(item.updated_at).toLocaleTimeString(
+                        {item?.updated_at
+                          ? new Date(item.updated_at).toLocaleDateString(
                               'en-GB',
                               {
                                 day: 'numeric',
                                 month: 'short',
                                 year: 'numeric',
-                                hour: '2-digit',
-                                minute: '2-digit',
                                 timeZone: 'UTC',
                               },
                             )
-                          : null}{' '}
-                        (UTC)
+                          : item?.created_at
+                            ? new Date(item.created_at).toLocaleDateString(
+                                'en-GB',
+                                {
+                                  day: 'numeric',
+                                  month: 'short',
+                                  year: 'numeric',
+                                  timeZone: 'UTC',
+                                },
+                              )
+                            : null}
                       </td>
-                      <td className="px-1 lg:px-3 py-3 md:py-4 whitespace-nowrap text-center">
-                        <div className="flex items-center gap-1 md:gap-3">
+                      <td className="px-1 lg:px-3 py-3 md:py-4 whitespace-nowrap">
+                        <div className="flex items-center gap-1">
                           <button
                             onClick={() => handlePageView(item.slug)}
                             className="tooltip p-1 md:p-1.5 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors cursor-pointer"
@@ -163,7 +162,7 @@ export const View = () => {
           </div>
         )}
 
-        {data && data.total_pages > 0 && (
+        {data?.content && data.content?.length > 0 && (
           <div className="flex items-center justify-between px-4 py-1 border border-gray-200 rounded-lg mt-2">
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-700">

--- a/src/types/tenants.ts
+++ b/src/types/tenants.ts
@@ -1,0 +1,23 @@
+export type TenantInfo = {
+  name: string
+  email: string
+  description: string
+  website?: string
+  image?: string
+  created_at?: string
+  updated_at?: string
+}
+
+export type Tenant = {
+  id?: string
+  info: TenantInfo
+  updated_by?: string
+}
+
+export type TenantList = {
+  content: Tenant[]
+  size_of_page: number
+  number_of_page: number
+  total_elements: number
+  total_pages: number
+}


### PR DESCRIPTION
**⚠️ This PR should not be merged before [ARGO-5179](https://github.com/ARGOeu/argo-mon-status-api/pull/12) is merged.**

This PR implements a Tenants management feature that enables users to view existing tenants in a card-based grid layout and create new tenants through a dedicated form with validation.

- Created Tenants list page with responsive card grid displaying tenant information and action buttons
- Built Create Tenant form with two-section layout and real-time validation for name, email, and website fields
- Implemented tenant management API for creating and viewing tenant records
- Integrated image upload functionality supporting drag-and-drop, URL input, and base64 encoding with 5MB limit
- Added global CSS classes for consistent typography across tenant pages and updated existing pages
- Updated sidebar navigation with new menu items using distinct icons for each section
- Extended Keycloak scope configuration to include the following keywords: "email", "profile", "entitlements"