### PR TITLE
[ARGO-5205] - Add Contacts Section to Tenant Creation Form

### DIFF
--- a/src/pages/CreateProject.tsx
+++ b/src/pages/CreateProject.tsx
@@ -322,13 +322,13 @@ const CreateProject = () => {
                     <label className={styles.label}>
                       Data Retention Policy <span className="required">*</span>
                     </label>
-                    <input
-                      type="text"
+                    <textarea
                       name="data_retention_policy"
                       value={formData.data_retention_policy}
                       onChange={handleChange}
                       className={styles.input}
                       placeholder="Enter data retention policy"
+                      rows={3}
                       required
                     />
                   </div>

--- a/src/pages/CreateTenant.tsx
+++ b/src/pages/CreateTenant.tsx
@@ -13,6 +13,8 @@ import styles from './CreateTenant.module.css'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
 const CreateTenant = () => {
   const { id: tenantId } = useParams<{ id?: string }>()
   const isEditMode = Boolean(tenantId)
@@ -25,11 +27,17 @@ const CreateTenant = () => {
     website: '',
     image: '',
   })
+  const [contact, setContact] = useState({
+    name: '',
+    email: '',
+    type: '',
+  })
   const [imageUrl, setImageUrl] = useState('')
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const [nameError, setNameError] = useState('')
   const [emailError, setEmailError] = useState('')
   const [websiteError, setWebsiteError] = useState('')
+  const [contactEmailError, setContactEmailError] = useState('')
 
   const createMutation = useCreateTenantMutation()
   const updateMutation = useUpdateTenantMutation()
@@ -47,6 +55,13 @@ const CreateTenant = () => {
         website: tenantData.info.website || '',
         image: tenantData.info.image || '',
       })
+      if (tenantData.contacts && tenantData.contacts.length > 0) {
+        setContact({
+          name: tenantData.contacts[0].name || '',
+          email: tenantData.contacts[0].email || '',
+          type: tenantData.contacts[0].type || '',
+        })
+      }
       if (tenantData.info.image) {
         setImagePreview(tenantData.info.image)
         if (!tenantData.info.image.includes(BACKEND_API)) {
@@ -97,10 +112,21 @@ const CreateTenant = () => {
       image: formData.image || imageUrl,
     }
 
+    const contacts =
+      contact.name.trim() && contact.email.trim()
+        ? [
+            {
+              name: contact.name,
+              email: contact.email,
+              type: contact.type || undefined,
+            },
+          ]
+        : []
+
     if (isEditMode && tenantId) {
       // Update existing tenant
       updateMutation.mutate(
-        { id: tenantId, data: { info: submitData } },
+        { id: tenantId, data: { info: submitData, contacts } },
         {
           onSuccess: () => {
             toast.success('Tenant updated successfully!')
@@ -126,7 +152,7 @@ const CreateTenant = () => {
     } else {
       // Create new tenant
       createMutation.mutate(
-        { info: submitData },
+        { info: submitData, contacts },
         {
           onSuccess: () => {
             toast.success('Tenant created successfully!')
@@ -176,7 +202,6 @@ const CreateTenant = () => {
 
     if (name === 'email') {
       // Email validation
-      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
       if (value && !emailRegex.test(value)) {
         setEmailError('Please enter a valid email address')
       } else {
@@ -193,6 +218,23 @@ const CreateTenant = () => {
         )
       } else {
         setWebsiteError('')
+      }
+    }
+  }
+
+  const handleContactChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+
+    setContact((prev) => ({
+      ...prev,
+      [name]: value,
+    }))
+
+    if (name === 'email') {
+      if (value && !emailRegex.test(value)) {
+        setContactEmailError('Please enter a valid email address')
+      } else {
+        setContactEmailError('')
       }
     }
   }
@@ -267,9 +309,12 @@ const CreateTenant = () => {
                   !!nameError ||
                   !!emailError ||
                   !!websiteError ||
+                  !!contactEmailError ||
                   !formData.name.trim() ||
                   !formData.email.trim() ||
-                  !formData.description.trim()
+                  !formData.description.trim() ||
+                  Boolean(contact.name.trim() && !contact.email.trim()) ||
+                  Boolean(!contact.name.trim() && contact.email.trim())
                 }
               >
                 {createMutation.isPending || updateMutation.isPending
@@ -285,7 +330,7 @@ const CreateTenant = () => {
                 <div className={styles['section-info']}>
                   <h2 className="section-title">Tenant Information</h2>
                   <p className="section-description">
-                    Basic information for the new tenant
+                    Basic details and identification
                   </p>
                 </div>
 
@@ -349,9 +394,65 @@ const CreateTenant = () => {
 
               <div className={styles.section}>
                 <div className={styles['section-info']}>
+                  <h2 className="section-title">Contact Information</h2>
+                  <p className="section-description">
+                    Contact details for the tenant
+                  </p>
+                </div>
+
+                <div className={styles['section-content']}>
+                  <div className={styles.field}>
+                    <label className={styles.label}>
+                      Contact Name <span className="required">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      name="name"
+                      value={contact.name}
+                      onChange={handleContactChange}
+                      className={styles.input}
+                      placeholder="Enter contact name"
+                    />
+                  </div>
+
+                  <div className={styles.field}>
+                    <label className={styles.label}>
+                      Contact Email <span className="required">*</span>
+                    </label>
+                    <input
+                      type="email"
+                      name="email"
+                      value={contact.email}
+                      onChange={handleContactChange}
+                      className={styles.input}
+                      placeholder="Enter contact email"
+                    />
+                    {contactEmailError && (
+                      <span className="text-red-400 text-sm mt-1">
+                        {contactEmailError}
+                      </span>
+                    )}
+                  </div>
+
+                  <div className={styles.field}>
+                    <label className={styles.label}>Contact Type</label>
+                    <input
+                      type="text"
+                      name="type"
+                      value={contact.type}
+                      onChange={handleContactChange}
+                      className={styles.input}
+                      placeholder="Enter contact type (e.g., Admin, Operations, Security)"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div className={styles.section}>
+                <div className={styles['section-info']}>
                   <h2 className="section-title">Additional Details</h2>
                   <p className="section-description">
-                    Optional information for the tenant
+                    Optional media and website links
                   </p>
                 </div>
 

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -216,7 +216,7 @@ const Projects = () => {
       )}
 
       {data?.content && data.content.length > 0 && (
-        <div className="flex items-center justify-between px-4 py-1 border border-gray-200 rounded-lg mt-3">
+        <div className="flex items-center justify-between px-4 py-1 border border-gray-200 rounded-lg my-4">
           <div className="flex items-center gap-2">
             <span className="text-sm text-gray-700">
               Page {currentPage} of {data.total_pages}

--- a/src/pages/Tenants.module.css
+++ b/src/pages/Tenants.module.css
@@ -161,6 +161,28 @@
   overflow: hidden;
 }
 
+.contact-info {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #f3f4f6;
+}
+
+.contact-name {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #374151;
+  margin: 0 0 0.25rem 0;
+}
+
+.contact-email {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .card-footer {
   background-color: #f9fafb;
   padding: 0.25rem 1rem;

--- a/src/pages/Tenants.tsx
+++ b/src/pages/Tenants.tsx
@@ -44,6 +44,7 @@ const Tenants = () => {
       data.content.map((tenant) => ({
         ...tenant?.info,
         id: tenant?.id,
+        contacts: tenant?.contacts,
       }))) ||
     []
 
@@ -185,6 +186,16 @@ const Tenants = () => {
                   <p className={styles['tenant-description']}>
                     {tenant.description}
                   </p>
+                  {tenant.contacts && tenant.contacts.length > 0 && (
+                    <div className={styles['contact-info']}>
+                      <p className={styles['contact-name']}>
+                        Contact: {tenant.contacts[0].name}
+                      </p>
+                      <p className={styles['contact-email']}>
+                        {tenant.contacts[0].email}
+                      </p>
+                    </div>
+                  )}
                 </div>
                 <div className={styles['card-footer']}>
                   <button
@@ -215,7 +226,7 @@ const Tenants = () => {
       )}
 
       {data?.content && data.content?.length > 0 && (
-        <div className="flex items-center justify-between px-4 py-1 border border-gray-200 rounded-lg mt-3">
+        <div className="flex items-center justify-between px-4 py-1 border border-gray-200 rounded-lg my-4">
           <div className="flex items-center gap-2">
             <span className="text-sm text-gray-700">
               Page {currentPage} of {data.total_pages}

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -213,7 +213,7 @@ const View = () => {
         )}
 
         {data?.content && data.content?.length > 0 && (
-          <div className="flex items-center justify-between px-4 py-1 border border-gray-200 rounded-lg mt-3">
+          <div className="flex items-center justify-between px-4 py-1 border border-gray-200 rounded-lg my-4">
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-700">
                 Page {currentPage} of {data.total_pages}

--- a/src/types/tenants.ts
+++ b/src/types/tenants.ts
@@ -1,3 +1,9 @@
+export type Contact = {
+  name: string
+  email: string
+  type?: string
+}
+
 export type TenantInfo = {
   name: string
   email: string
@@ -11,6 +17,7 @@ export type TenantInfo = {
 export type Tenant = {
   id?: string
   info: TenantInfo
+  contacts?: Contact[]
   updated_by?: string
 }
 


### PR DESCRIPTION
**⚠️ This PR should not be merged before [ARGO-5174](https://github.com/ARGOeu/argo-mon-status-api/pull/33) is merged.**

This PR adds a Contact Information section to the Tenant creation and edit forms, allowing administrators to add contact details for each tenant.

- Added Contact Information section in CreateTenant component with input fields for contact name, email and type
- Updated form submission to send contacts with tenant data in POST/PUT requests
- Implemented mutual requirement for contact name and email fields
- Changed Data Retention Policy field in CreateProject component from input to textarea with 3 rows