### PR TITLE
[ARGO-5231] - Implement User Role Indicator in Tenant View

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,0 +1,22 @@
+import type { UserProfile } from '@/types/profile'
+
+const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+export const fetchUserProfile = async (token: string): Promise<UserProfile> => {
+  const response = await fetch(`${BACKEND_API}/v1/users/profile`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+import { useAuth } from '@/auth/useAuth'
+import { fetchUserProfile } from '@/api/profile'
+import type { UserProfile } from '@/types/profile'
+
+export const useGetUserProfile = () => {
+  const { token } = useAuth()
+
+  return useQuery<UserProfile, Error>({
+    queryKey: ['user-profile'],
+    queryFn: () => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      return fetchUserProfile(token)
+    },
+    retry: false,
+    enabled: !!token,
+  })
+}

--- a/src/pages/AssignProjects.module.css
+++ b/src/pages/AssignProjects.module.css
@@ -92,12 +92,20 @@
   background-color: #fefefe;
   border-color: #d1d5db;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-  transform: translateY(-1px);
 }
 
 .project-item:active {
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.15);
   transform: scale(1.01);
+}
+
+.project-item.read-only {
+  cursor: default !important;
+}
+
+.project-item.read-only:active {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  transform: none;
 }
 
 .drag-handle {

--- a/src/pages/AssignProjects.tsx
+++ b/src/pages/AssignProjects.tsx
@@ -16,6 +16,8 @@ import { GripVertical } from 'lucide-react'
 import type { ProjectItem } from '@/types/projects'
 import styles from './AssignProjects.module.css'
 import { useAuth } from '@/auth/useAuth'
+import { useGetUserProfile } from '@/hooks/useProfile'
+import type { UserGroup } from '@/types/profile'
 
 const formatDate = (dateString: string) => {
   return new Date(dateString).toLocaleDateString('en-GB', {
@@ -27,15 +29,32 @@ const formatDate = (dateString: string) => {
 
 const AssignProjects = () => {
   const { profile } = useAuth()
+  const { id: tenantId } = useParams<{ id: string }>()
   const [allProjects, setAllProjects] = useState<ProjectItem[]>([])
   const [tenantProjectIds, setTenantProjectIds] = useState<string[]>([])
   const [availableProjects, setAvailableProjects] = useState<ProjectItem[]>([])
   const [assignedProjects, setAssignedProjects] = useState<ProjectItem[]>([])
   const [isInitialized, setIsInitialized] = useState(false)
+  const { data: adminTenantData } = useGetTenantById(tenantId || '')
+  const { data: userTenantData } = useGetUserTenantById(tenantId || '')
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
-  const isAdmin = profile?.roles?.includes('admin')
-  const isReadOnly = isAdmin
+  const { data: userProfileData } = useGetUserProfile()
+
+  const tenantData = isSuperAdmin ? adminTenantData : userTenantData
+
+  const isTenantAdmin = (tenantName: string) => {
+    if (!tenantName) return false
+    if (isSuperAdmin) return false
+    if (!userProfileData?.groups) return false
+
+    const group = userProfileData?.groups?.find(
+      (g: UserGroup) => g?.name === tenantName,
+    )
+    return group?.role === 'admin'
+  }
+
+  const isReadOnly = isTenantAdmin(tenantData?.info.name || '')
 
   const groupName = 'projects-assignment'
   const [availableRef, availableItems, setAvailableItems] = useDragAndDrop<
@@ -56,12 +75,7 @@ const AssignProjects = () => {
     disabled: isReadOnly,
   })
 
-  const { id: tenantId } = useParams<{ id: string }>()
   const navigate = useNavigate()
-
-  const { data: adminTenantData } = useGetTenantById(tenantId || '')
-  const { data: userTenantData } = useGetUserTenantById(tenantId || '')
-  const tenantData = isSuperAdmin ? adminTenantData : userTenantData
 
   const {
     data: adminProjectsData,
@@ -345,7 +359,7 @@ const AssignProjects = () => {
                   ? assignedItems.map((project) => (
                       <li
                         key={project.id}
-                        className={styles['project-item']}
+                        className={`${styles['project-item']} ${isReadOnly ? styles['read-only'] : ''}`}
                         style={isReadOnly ? { cursor: 'default' } : {}}
                       >
                         <div className="dnd-handle flex items-center gap-2 flex-grow-1">

--- a/src/pages/Tenants.module.css
+++ b/src/pages/Tenants.module.css
@@ -133,14 +133,46 @@
   min-width: 0;
 }
 
+.name-role-container {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.125rem;
+}
+
 .tenant-name {
   font-size: 1rem;
   font-weight: 600;
   color: #111827;
-  margin-bottom: 0.125rem;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
+  flex: 1;
+  min-width: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 9999px;
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.role-badge.admin {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.role-badge.viewer {
+  background-color: #f3f4f6;
+  color: #4b5563;
 }
 
 .tenant-email {

--- a/src/pages/Tenants.tsx
+++ b/src/pages/Tenants.tsx
@@ -4,6 +4,7 @@ import {
   useGetUserTenants,
   useDeleteTenantMutation,
 } from '@/hooks/useTenants'
+import { useGetUserProfile } from '@/hooks/useProfile'
 import { useAuth } from '@/auth/useAuth'
 import {
   ArrowPathIcon,
@@ -13,23 +14,38 @@ import {
   ChevronRightIcon,
   MagnifyingGlassIcon,
   PlusCircleIcon,
+  ListBulletIcon,
 } from '@heroicons/react/16/solid'
 import Button from '@/components/Button'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import { useNavigate } from 'react-router-dom'
 import { toast, Toaster } from 'sonner'
 import styles from './Tenants.module.css'
+import type { UserGroup } from '@/types/profile'
+
+const pageSize = 9
 
 const Tenants = () => {
-  const { profile } = useAuth()
   const [currentPage, setCurrentPage] = useState(1)
   const [searchInput, setSearchInput] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
-  const pageSize = 9
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [tenantToDelete, setTenantToDelete] = useState<{
+    id: string
+    name: string
+  } | null>(null)
+
+  const { profile } = useAuth()
+  const navigate = useNavigate()
+  const { data: userProfileData } = useGetUserProfile()
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
-  const isAdmin = profile?.roles?.includes('admin')
-  const isViewer = profile?.roles?.includes('viewer')
+
+  const hasTenantAccess =
+    (!isSuperAdmin &&
+      userProfileData?.groups &&
+      userProfileData.groups.length > 0) ||
+    false
 
   const { data: adminData, isLoading: adminLoading } = useGetTenants(
     currentPage,
@@ -41,19 +57,33 @@ const Tenants = () => {
     currentPage,
     pageSize,
     searchQuery,
-    isAdmin || isViewer,
+    hasTenantAccess,
   )
 
   const data = isSuperAdmin ? adminData : userData
   const isLoading = isSuperAdmin ? adminLoading : userLoading
 
   const deleteMutation = useDeleteTenantMutation()
-  const navigate = useNavigate()
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [tenantToDelete, setTenantToDelete] = useState<{
-    id: string
-    name: string
-  } | null>(null)
+
+  const getRoleForTenant = (tenantName: string): string | null => {
+    if (isSuperAdmin || !userProfileData?.groups) return null
+
+    const group = userProfileData?.groups?.find(
+      (g: UserGroup) => g?.name === tenantName,
+    )
+    return group?.role || null
+  }
+
+  const isTenantAdmin = (tenantName: string) => {
+    if (!tenantName) return false
+    if (isSuperAdmin) return false
+    if (!userProfileData?.groups) return false
+
+    const group = userProfileData?.groups?.find(
+      (g: UserGroup) => g?.name === tenantName,
+    )
+    return group?.role === 'admin'
+  }
 
   // Debounced search effect
   useEffect(() => {
@@ -143,11 +173,9 @@ const Tenants = () => {
           <p className="page-subtitle">
             {isSuperAdmin
               ? 'Manage and create new tenants for the monitoring service'
-              : isAdmin
-                ? 'View and manage your tenants'
-                : isViewer
-                  ? 'View your tenants'
-                  : 'View tenants'}
+              : hasTenantAccess
+                ? 'View your tenants'
+                : null}
           </p>
         </div>
         {isSuperAdmin && (
@@ -210,9 +238,37 @@ const Tenants = () => {
                       )}
                     </div>
                     <div className={styles['info-container']}>
-                      <h3 className={styles['tenant-name']} title={tenant.name}>
-                        {tenant.name}
-                      </h3>
+                      <div className={styles['name-role-container']}>
+                        <h3
+                          className={styles['tenant-name']}
+                          title={tenant.name}
+                        >
+                          {tenant.name}
+                        </h3>
+                        {(() => {
+                          if (isSuperAdmin) {
+                            return (
+                              <span
+                                className={`${styles['role-badge']} ${styles['admin']}`}
+                              >
+                                Admin
+                              </span>
+                            )
+                          }
+                          const role = getRoleForTenant(tenant.name)
+                          return role ? (
+                            <span
+                              className={`${styles['role-badge']} ${styles[role.toLowerCase()]}`}
+                            >
+                              {role.toLowerCase() === 'admin'
+                                ? 'Admin'
+                                : role.toLowerCase() === 'viewer'
+                                  ? 'Member'
+                                  : null}
+                            </span>
+                          ) : null
+                        })()}
+                      </div>
                       <p
                         className={styles['tenant-email']}
                         title={tenant.email}
@@ -225,50 +281,52 @@ const Tenants = () => {
                     {tenant.description}
                   </p>
                 </div>
-                <div className={styles['card-footer']}>
-                  {(isSuperAdmin || isAdmin) && (
-                    <button
-                      aria-label="Edit Tenant"
-                      className={`${styles['action-button']} ${styles.edit} tooltip`}
-                      data-tip="Edit"
-                      onClick={() => handleEdit(tenant.id!)}
-                    >
-                      <PencilSquareIcon className={styles['action-icon']} />
-                    </button>
-                  )}
-                  {isAdmin && (
-                    <button
-                      aria-label="View Projects"
-                      className={`${styles['action-button']} ${styles.assign} tooltip`}
-                      data-tip="View Projects"
-                      onClick={() => handleAssignProjects(tenant.id!)}
-                    >
-                      <PlusCircleIcon className={styles['action-icon']} />
-                    </button>
-                  )}
-                  {isSuperAdmin && (
-                    <>
+                {(isSuperAdmin || isTenantAdmin(tenant.name)) && (
+                  <div className={styles['card-footer']}>
+                    {(isSuperAdmin || isTenantAdmin(tenant.name)) && (
                       <button
-                        aria-label="Assign Projects"
+                        aria-label="Edit Tenant"
+                        className={`${styles['action-button']} ${styles.edit} tooltip`}
+                        data-tip="Edit"
+                        onClick={() => handleEdit(tenant.id!)}
+                      >
+                        <PencilSquareIcon className={styles['action-icon']} />
+                      </button>
+                    )}
+                    {isTenantAdmin(tenant.name) && (
+                      <button
+                        aria-label="View Assigned Projects"
                         className={`${styles['action-button']} ${styles.assign} tooltip`}
-                        data-tip="Assign Projects"
+                        data-tip="View Assigned Projects"
                         onClick={() => handleAssignProjects(tenant.id!)}
                       >
-                        <PlusCircleIcon className={styles['action-icon']} />
+                        <ListBulletIcon className={styles['action-icon']} />
                       </button>
-                      <button
-                        aria-label="Delete Tenant"
-                        className={`${styles['action-button']} ${styles.delete} tooltip`}
-                        data-tip="Delete"
-                        onClick={() =>
-                          handleDeleteClick(tenant.id!, tenant.name)
-                        }
-                      >
-                        <TrashIcon className={styles['action-icon']} />
-                      </button>
-                    </>
-                  )}
-                </div>
+                    )}
+                    {isSuperAdmin && (
+                      <>
+                        <button
+                          aria-label="Assign Projects"
+                          className={`${styles['action-button']} ${styles.assign} tooltip`}
+                          data-tip="Assign Projects"
+                          onClick={() => handleAssignProjects(tenant.id!)}
+                        >
+                          <PlusCircleIcon className={styles['action-icon']} />
+                        </button>
+                        <button
+                          aria-label="Delete Tenant"
+                          className={`${styles['action-button']} ${styles.delete} tooltip`}
+                          data-tip="Delete"
+                          onClick={() =>
+                            handleDeleteClick(tenant.id!, tenant.name)
+                          }
+                        >
+                          <TrashIcon className={styles['action-icon']} />
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
             ))
           ) : (

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,12 @@
+export interface UserGroup {
+  name: string
+  role: string
+}
+
+export interface UserProfile {
+  sub: string
+  username: string
+  email: string
+  roles: string[]
+  groups?: UserGroup[] | null
+}


### PR DESCRIPTION
**⚠️ This PR should not be merged before [ARGO-5229](https://github.com/ARGOeu/argo-mon-status-api/pull/44) is merged.**

This PR implements tenant-specific role-based access control with visual role indicators, enabling users to have different roles across multiple tenants.

- Added profile API endpoint and corresponding hook to fetch user profile with tenant-specific role groups
- Implemented role indicator badges on tenants list displaying Admin or Member based on per-tenant roles
- Refactored role checking from global roles to tenant-specific groups
- Updated action button visibility only for tenant admins