### PR TITLE
[ARGO-5325] - Implement Revoke Pending Invitation Functionality for Admins

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+VITE_KEYCLOAK_URL=http://localhost:58080
+VITE_KEYCLOAK_REALM=quarkus
+VITE_KEYCLOAK_CLIENT_ID=frontend-service
+VITE_KEYCLOAK_SCOPE="openid voperson_id email profile entitlements"
+VITE_REDIRECT_URI=http://localhost:5173
+VITE_BACKEND_URI=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules
 dist
 build
 npm-debug.log
-.env
 .DS_Store

--- a/src/App.css
+++ b/src/App.css
@@ -108,7 +108,7 @@ select:focus {
   padding: 0.4rem 1rem;
   border: 1px solid #e5e7eb;
   border-radius: 0.5rem;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   background-color: white;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ function App() {
                 element={
                   <ProtectedRoute
                     requiredRoles={['super_admin', 'admin', 'viewer']}
+                    checkTenantAccess
                   >
                     <TenantDetails />
                   </ProtectedRoute>
@@ -95,7 +96,10 @@ function App() {
               <Route
                 path="tenants/edit/:id"
                 element={
-                  <ProtectedRoute requiredRoles={['super_admin', 'admin']}>
+                  <ProtectedRoute
+                    requiredRoles={['super_admin', 'admin']}
+                    checkTenantAccess
+                  >
                     <CreateTenant />
                   </ProtectedRoute>
                 }
@@ -103,7 +107,10 @@ function App() {
               <Route
                 path="tenants/:id/projects/assign"
                 element={
-                  <ProtectedRoute requiredRoles={['super_admin', 'admin']}>
+                  <ProtectedRoute
+                    requiredRoles={['super_admin', 'admin']}
+                    checkTenantAccess
+                  >
                     <AssignProjects />
                   </ProtectedRoute>
                 }
@@ -111,7 +118,10 @@ function App() {
               <Route
                 path="tenants/:id/members"
                 element={
-                  <ProtectedRoute requiredRoles={['super_admin', 'admin']}>
+                  <ProtectedRoute
+                    requiredRoles={['super_admin', 'admin']}
+                    checkTenantAccess
+                  >
                     <ManageTenantMembers />
                   </ProtectedRoute>
                 }

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,7 +1,5 @@
 import { Link, NavLink, Outlet } from 'react-router'
 import { useAuth } from './auth/useAuth'
-import { useRegisterUserMutation } from './hooks/useUsers'
-import { useEffect, useRef } from 'react'
 import {
   ArrowLeftStartOnRectangleIcon,
   ServerStackIcon,
@@ -43,25 +41,15 @@ function SidebarNavItem({
 
 export default function Layout() {
   const { authenticated, profile, login, logout } = useAuth()
-  const registerMutation = useRegisterUserMutation()
-  const hasRegistered = useRef(false)
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
   const isAdmin = profile?.roles?.includes('admin')
   const isViewer = profile?.roles?.includes('viewer')
   const hasTenantsAccess = isSuperAdmin || isAdmin || isViewer
 
-  // Register user once when authenticated
-  useEffect(() => {
-    if (authenticated && !hasRegistered.current) {
-      hasRegistered.current = true
-      registerMutation.mutate()
-    }
-  }, [authenticated, registerMutation])
-
   return (
-    <div className="min-h-screen flex">
-      <aside className="w-64 bg-gray-50 border-r border-gray-200 flex flex-col">
+    <div className="h-screen flex overflow-hidden">
+      <aside className="w-64 bg-gray-50 border-r border-gray-200 flex flex-col overflow-y-auto overflow-x-hidden">
         <div className="px-3 border-b border-gray-200">
           <div
             className="flex items-center gap-2 cursor-pointer"
@@ -115,7 +103,7 @@ export default function Layout() {
             <div className="p-4">
               <div className="flex items-center justify-between gap-1 text-sm text-gray-700">
                 <Link to="/profile">
-                  <div className="flex items-center gap-2 min-w-0 flex-1 hover:opacity-90 w-50">
+                  <div className="flex items-center gap-2 min-w-0 flex-1 hover:opacity-90 w-48">
                     <div className="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0">
                       {(profile.name || 'U').charAt(0).toUpperCase()}
                     </div>
@@ -125,10 +113,10 @@ export default function Layout() {
                   </div>
                 </Link>
                 <button
-                  type="button"
-                  className="p-2 hover:bg-gray-100 rounded transition-colors flex-shrink-0 cursor-pointer"
+                  className="me-2 p-1 hover:bg-gray-100 rounded transition-colors flex-shrink-0 cursor-pointer tooltip"
+                  data-tip="Logout"
                   onClick={logout}
-                  title="Logout"
+                  type="button"
                 >
                   <ArrowLeftStartOnRectangleIcon className="size-5 text-gray-600" />
                 </button>

--- a/src/api/invitations.ts
+++ b/src/api/invitations.ts
@@ -79,17 +79,27 @@ export const createTenantInvitation = async (
 export const fetchTenantInvitations = async (
   tenantId: string,
   token: string,
+  params?: {
+    page?: number
+    size?: number
+  },
 ): Promise<PaginatedInvitationsResponse> => {
-  const response = await fetch(
-    `${BACKEND_API}/v1/tenants/${tenantId}/invitations`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
+  const queryParams = new URLSearchParams()
+
+  if (params?.page) queryParams.append('page', params.page.toString())
+  if (params?.size) queryParams.append('size', params.size.toString())
+
+  const url = `${BACKEND_API}/v1/tenants/${tenantId}/invitations${
+    queryParams.toString() ? `?${queryParams.toString()}` : ''
+  }`
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
     },
-  )
+  })
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}))

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -460,3 +460,27 @@ export const removeMemberFromTenant = async (
     )
   }
 }
+
+export const revokeInvitation = async (
+  tenantId: string,
+  invitationId: string,
+  token: string,
+): Promise<void> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/invitations/${invitationId}`,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+}

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -2,6 +2,7 @@
 import { AuthContext, type AuthContextType } from './context'
 import { keycloak, initKeycloak } from './keycloak'
 import { useEffect, useRef, useState } from 'react'
+import { registerUser } from '@/api/users'
 import { fetchUserProfile } from '@/api/profile'
 
 export const AuthProvider: React.FC<React.PropsWithChildren> = ({
@@ -9,11 +10,13 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
 }) => {
   const [initialized, setInitialized] = useState(false)
   const [authenticated, setAuthenticated] = useState(false)
+  const [registered, setRegistered] = useState(false)
   const [token, setToken] = useState<string | undefined>(undefined)
   const [profile, setProfile] = useState<AuthContextType['profile']>(undefined)
 
   const startedRef = useRef(false)
   const refreshTimerRef = useRef<number | null>(null)
+  const hasRegistered = useRef(false)
 
   // Fetch profile data when token becomes available
   useEffect(() => {
@@ -59,6 +62,21 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
 
         if (auth) {
           setToken(keycloak.token)
+
+          // Register user once when authenticated
+          if (!hasRegistered.current && keycloak.token) {
+            hasRegistered.current = true
+            try {
+              await registerUser(keycloak.token)
+              setRegistered(true)
+            } catch (error) {
+              console.error('User registration error:', error)
+              // Set registered to true even if registration fails to not block the app
+              setRegistered(true)
+            }
+          } else {
+            setRegistered(true)
+          }
         }
 
         setInitialized(true)
@@ -92,7 +110,15 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
 
   return (
     <AuthContext.Provider
-      value={{ initialized, authenticated, token, profile, login, logout }}
+      value={{
+        initialized,
+        authenticated,
+        registered,
+        token,
+        profile,
+        login,
+        logout,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/auth/context.ts
+++ b/src/auth/context.ts
@@ -3,6 +3,7 @@ import { createContext } from 'react'
 export type AuthContextType = {
   initialized: boolean
   authenticated: boolean
+  registered: boolean
   token?: string
   profile?: {
     id?: string
@@ -23,6 +24,7 @@ export type AuthContextType = {
 export const AuthContext = createContext<AuthContextType>({
   initialized: false,
   authenticated: false,
+  registered: false,
   login: () => {},
   logout: () => {},
 })

--- a/src/hooks/useInvitations.ts
+++ b/src/hooks/useInvitations.ts
@@ -70,17 +70,19 @@ export const useCreateTenantInvitation = () => {
 
 export const useGetTenantInvitations = (
   tenantId: string,
+  page: number,
+  size: number,
   enabled: boolean = true,
 ) => {
   const { token } = useAuth()
 
   return useQuery<PaginatedInvitationsResponse, Error>({
-    queryKey: ['tenant-invitations', tenantId],
+    queryKey: ['tenant-invitations', tenantId, page, size],
     queryFn: () => {
       if (!token) {
         throw new Error('No authentication token available')
       }
-      return fetchTenantInvitations(tenantId, token)
+      return fetchTenantInvitations(tenantId, token, { page, size })
     },
     retry: false,
     enabled: enabled && !!token && !!tenantId,

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -24,6 +24,7 @@ import {
   fetchTenantMembers,
   addMemberDirectly,
   removeMemberFromTenant,
+  revokeInvitation,
 } from '@/api/tenants'
 import type {
   Job,
@@ -454,6 +455,28 @@ export const useGetTenantByName = () => {
     },
     onError: (error) => {
       console.error('Fetch tenant by name error:', error)
+    },
+  })
+}
+
+export const useRevokeInvitation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<void, Error, { tenantId: string; invitationId: string }>({
+    mutationFn: ({ tenantId, invitationId }) => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      return revokeInvitation(tenantId, invitationId, token)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tenant-invitations'] })
+      queryClient.invalidateQueries({ queryKey: ['admin-invitations'] })
+      queryClient.invalidateQueries({ queryKey: ['user-invitations'] })
+    },
+    onError: (error) => {
+      console.error('Revoke invitation error:', error)
     },
   })
 }

--- a/src/pages/AdminInvitations.module.css
+++ b/src/pages/AdminInvitations.module.css
@@ -35,11 +35,11 @@
 }
 
 .th-tenant-name {
-  width: 25%;
+  width: 22%;
 }
 
 .th-email {
-  width: 27%;
+  width: 22%;
 }
 
 .th-role {
@@ -51,7 +51,11 @@
 }
 
 .th-created {
-  width: 20%;
+  width: 15%;
+}
+
+.th-actions {
+  width: 12%;
 }
 
 .table-body {
@@ -137,8 +141,42 @@
   font-size: 0.875rem;
 }
 
+.actions-container {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.7rem;
+}
+
+.empty-actions {
+  margin-left: 0.9rem;
+  display: block;
+  color: #6b7280;
+  font-size: 0.875rem;
+}
+
+.remove-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.375rem;
+  background: none;
+  border-radius: 0.375rem;
+  color: #ef4444;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.remove-button:hover {
+  background-color: #fef2f2;
+}
+
+.remove-button:active {
+  transform: scale(0.95);
+}
+
 .search-container {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .search-input-wrapper {

--- a/src/pages/AdminInvitations.tsx
+++ b/src/pages/AdminInvitations.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useGetAdminInvitations } from '@/hooks/useInvitations'
+import { useRevokeInvitation } from '@/hooks/useTenants'
 import { ArrowPathIcon, MagnifyingGlassIcon } from '@heroicons/react/16/solid'
 import {
   ChevronUpIcon,
@@ -7,6 +8,9 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
 } from '@heroicons/react/24/outline'
+import { XCircleIcon } from '@heroicons/react/24/solid'
+import { toast } from 'sonner'
+import ConfirmDialog from '@/components/ConfirmDialog'
 import styles from './AdminInvitations.module.css'
 import adminStyles from './Administration.module.css'
 
@@ -24,6 +28,13 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
   const [sortOrder, setSortOrder] = useState<SortOrder>('ASC')
   const [currentPage, setCurrentPage] = useState(1)
   const pageSize = 10
+  const [revokeDialogOpen, setRevokeDialogOpen] = useState(false)
+  const [invitationToRevoke, setInvitationToRevoke] = useState<{
+    tenantId: string
+    invitationId: string
+    tenantName: string
+    email: string
+  } | null>(null)
 
   // Debounce search input
   useEffect(() => {
@@ -43,6 +54,44 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
       page: currentPage,
       size: pageSize,
     })
+
+  const revokeInvitationMutation = useRevokeInvitation()
+
+  const handleRevokeClick = (
+    tenantId: string,
+    invitationId: string,
+    tenantName: string,
+    email: string,
+  ) => {
+    setInvitationToRevoke({ tenantId, invitationId, tenantName, email })
+    setRevokeDialogOpen(true)
+  }
+
+  const handleRevokeConfirm = () => {
+    if (!invitationToRevoke) return
+
+    revokeInvitationMutation.mutate(
+      {
+        tenantId: invitationToRevoke.tenantId,
+        invitationId: invitationToRevoke.invitationId,
+      },
+      {
+        onSuccess: () => {
+          toast.success('Invitation revoked successfully!')
+          setRevokeDialogOpen(false)
+          setInvitationToRevoke(null)
+        },
+        onError: (error) => {
+          toast.error(`Failed to revoke invitation: ${error.message}`)
+        },
+      },
+    )
+  }
+
+  const handleRevokeCancel = () => {
+    setRevokeDialogOpen(false)
+    setInvitationToRevoke(null)
+  }
 
   const handleClearSearch = () => {
     setSearchInput('')
@@ -149,6 +198,7 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
                       {renderSortIcon('created_at')}
                     </button>
                   </th>
+                  <th className={styles['th-actions']}>Actions</th>
                 </tr>
               </thead>
               <tbody className={styles['table-body']}>
@@ -191,7 +241,9 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
                             ? 'Accepted'
                             : invitation.status === 'REJECTED'
                               ? 'Rejected'
-                              : invitation.status}
+                              : invitation.status === 'REVOKED'
+                                ? 'Revoked'
+                                : invitation.status}
                       </span>
                     </td>
                     <td className={styles['td-created']}>
@@ -205,6 +257,34 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
                           },
                         )}
                       </span>
+                    </td>
+                    <td>
+                      <div className={styles['actions-container']}>
+                        {invitation.status === 'PENDING' ? (
+                          <button
+                            onClick={() =>
+                              handleRevokeClick(
+                                invitation.tenant_id,
+                                invitation.id,
+                                invitation.tenant_name,
+                                invitation.email,
+                              )
+                            }
+                            className={`${styles['remove-button']} tooltip`}
+                            data-tip="Revoke invitation"
+                            disabled={revokeInvitationMutation.isPending}
+                          >
+                            <XCircleIcon
+                              style={{
+                                width: '1.6rem',
+                                height: '1.6rem',
+                              }}
+                            />
+                          </button>
+                        ) : (
+                          <span className={styles['empty-actions']}>-</span>
+                        )}
+                      </div>
                     </td>
                   </tr>
                 ))}
@@ -275,6 +355,30 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
         </div>
       </div>
       {renderContent()}
+
+      <ConfirmDialog
+        isOpen={revokeDialogOpen}
+        title="Revoke Invitation"
+        message={
+          invitationToRevoke ? (
+            <>
+              Are you sure you want to revoke the invitation for{' '}
+              <strong>{invitationToRevoke.email}</strong> to join tenant{' '}
+              <strong>{invitationToRevoke.tenantName}</strong>?
+              <br />
+              <span className="text-amber-600 font-medium">
+                This action cannot be undone.
+              </span>
+            </>
+          ) : (
+            ''
+          )
+        }
+        confirmLabel="Revoke"
+        cancelLabel="Cancel"
+        onConfirm={handleRevokeConfirm}
+        onCancel={handleRevokeCancel}
+      />
     </>
   )
 }

--- a/src/pages/Administration.module.css
+++ b/src/pages/Administration.module.css
@@ -6,7 +6,7 @@
   display: flex;
   gap: 0.5rem;
   border-bottom: 2px solid #e5e7eb;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .tab {
@@ -43,7 +43,7 @@
 }
 
 .search-container {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .search-input-wrapper {
@@ -309,6 +309,7 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  margin-left: 0.6rem;
 }
 
 .action-button {

--- a/src/pages/Administration.tsx
+++ b/src/pages/Administration.tsx
@@ -227,7 +227,7 @@ const Administration = () => {
                                 className={styles['username-text']}
                                 title={user.username}
                               >
-                                {squishEmail(user.username, 6, 6)}
+                                {squishEmail(user.username, 8, 8)}
                               </span>
                             </td>
                             <td className={styles['td-name']}>

--- a/src/pages/InvitationReview.tsx
+++ b/src/pages/InvitationReview.tsx
@@ -17,7 +17,7 @@ import styles from './InvitationReview.module.css'
 export const InvitationReview = () => {
   const { id: invitationId } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { authenticated, initialized, login } = useAuth()
+  const { authenticated, initialized, registered, login } = useAuth()
   const [isProcessing, setIsProcessing] = useState(false)
 
   const {
@@ -26,7 +26,7 @@ export const InvitationReview = () => {
     error,
   } = useGetUserInvitationById(
     invitationId || '',
-    authenticated && !!invitationId,
+    authenticated && registered && !!invitationId,
   )
 
   const respondMutation = useRespondToInvitation()
@@ -85,7 +85,7 @@ export const InvitationReview = () => {
     )
   }
 
-  if (!initialized || !authenticated || isLoading) {
+  if (!initialized || !authenticated || !registered || isLoading) {
     return (
       <div className={styles.container}>
         <div className={styles.loading}>

--- a/src/pages/ManageTenantMembers.module.css
+++ b/src/pages/ManageTenantMembers.module.css
@@ -10,7 +10,7 @@
   display: flex;
   gap: 0.5rem;
   border-bottom: 2px solid #e5e7eb;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 }
 
 .tab {
@@ -59,14 +59,14 @@
 
 .members-section,
 .invitations-section {
-  margin-bottom: 2rem;
+  margin-bottom: 2.5rem;
 }
 
 .section-title {
   font-size: 1.125rem;
   font-weight: 600;
   color: #1f2937;
-  margin-bottom: 1rem;
+  margin-bottom: 0.6rem;
 }
 
 .section-description {
@@ -223,6 +223,7 @@
 }
 
 .remove-button {
+  margin-left: 0.5rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/ManageTenantMembers.tsx
+++ b/src/pages/ManageTenantMembers.tsx
@@ -1,9 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import {
-  useGetTenantInvitations,
-  useCreateTenantInvitation,
-} from '@/hooks/useInvitations'
+import { useCreateTenantInvitation } from '@/hooks/useInvitations'
 import {
   useGetTenantMembers,
   useGetUserTenantById,
@@ -23,6 +20,7 @@ import {
 import { toast, Toaster } from 'sonner'
 import Button from '@/components/Button'
 import ConfirmDialog from '@/components/ConfirmDialog'
+import TenantInvitations from './TenantInvitations'
 import styles from './ManageTenantMembers.module.css'
 import type { InvitationRole } from '@/types/invitations'
 
@@ -40,7 +38,7 @@ const ManageTenantMembers = () => {
   const isSuperAdmin = profile?.roles?.includes('super_admin')
 
   const [activeTab, setActiveTab] = useState<
-    'members' | 'invite' | 'add-direct'
+    'members' | 'invite' | 'add-direct' | 'invitations'
   >('members')
   const [currentMembersPage, setCurrentMembersPage] = useState(1)
   const membersPageSize = 10
@@ -67,7 +65,6 @@ const ManageTenantMembers = () => {
   const [searchInput, setSearchInput] = useState('')
   const [showSearchResults, setShowSearchResults] = useState(false)
   const [selectedUser, setSelectedUser] = useState<{
-    username: string
     email: string
     firstName: string
     lastName: string
@@ -75,7 +72,7 @@ const ManageTenantMembers = () => {
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false)
   const [memberToRemove, setMemberToRemove] = useState<{
     id: string
-    name: string
+    email: string
   } | null>(null)
 
   const { data: membersData, isLoading: membersLoading } = useGetTenantMembers(
@@ -84,8 +81,6 @@ const ManageTenantMembers = () => {
     membersPageSize,
     !!tenantId,
   )
-  const { data: invitationsData, isLoading: invitationsLoading } =
-    useGetTenantInvitations(tenantId || '', !!tenantId)
 
   const { data: searchResults, isLoading: searchLoading } = useGetMembers(
     1,
@@ -255,8 +250,8 @@ const ManageTenantMembers = () => {
     )
   }
 
-  const handleRemoveClick = (memberId: string, memberName: string) => {
-    setMemberToRemove({ id: memberId, name: memberName })
+  const handleRemoveClick = (memberId: string, memberEmail: string) => {
+    setMemberToRemove({ id: memberId, email: memberEmail })
     setRemoveDialogOpen(true)
   }
 
@@ -290,7 +285,7 @@ const ManageTenantMembers = () => {
     navigate('/tenants/view')
   }
 
-  const isLoading = membersLoading || invitationsLoading
+  const isLoading = membersLoading
 
   return (
     <>
@@ -333,6 +328,12 @@ const ManageTenantMembers = () => {
               Add Member
             </button>
           )}
+          <button
+            className={`${styles.tab} ${activeTab === 'invitations' ? styles['tab-active'] : ''}`}
+            onClick={() => setActiveTab('invitations')}
+          >
+            Invitations
+          </button>
         </div>
 
         {isLoading ? (
@@ -380,15 +381,17 @@ const ManageTenantMembers = () => {
                                 <td>
                                   <button
                                     onClick={() =>
-                                      handleRemoveClick(
-                                        member.id,
-                                        member.username,
-                                      )
+                                      handleRemoveClick(member.id, member.email)
                                     }
-                                    className={styles['remove-button']}
-                                    title="Remove member"
+                                    className={`${styles['remove-button']} tooltip`}
+                                    data-tip="Remove member"
                                   >
-                                    <UserMinusIcon className="size-4" />
+                                    <UserMinusIcon
+                                      style={{
+                                        width: '1.2rem',
+                                        height: '1.2rem',
+                                      }}
+                                    />
                                   </button>
                                 </td>
                               </tr>
@@ -445,65 +448,6 @@ const ManageTenantMembers = () => {
                       </div>
                     </div>
                   )}
-                </div>
-
-                <div className={styles['invitations-section']}>
-                  <h2 className={styles['section-title']}>
-                    Pending Invitations
-                  </h2>
-                  <div className={styles['table-wrapper']}>
-                    <table className={styles.table}>
-                      <thead className={styles['table-head']}>
-                        <tr>
-                          <th>Email</th>
-                          <th>Role</th>
-                          <th>Status</th>
-                          <th>Created At</th>
-                        </tr>
-                      </thead>
-                      <tbody className={styles['table-body']}>
-                        {invitationsData &&
-                        invitationsData.content.length > 0 ? (
-                          invitationsData.content.map((invitation) => (
-                            <tr key={invitation.id}>
-                              <td>{invitation.email}</td>
-                              <td>
-                                <span
-                                  className={`${styles['role-badge']} ${styles[`role-${invitation.role}`]}`}
-                                >
-                                  {invitation.role === 'admin'
-                                    ? 'Tenant Admin'
-                                    : 'Member'}
-                                </span>
-                              </td>
-                              <td>
-                                <span
-                                  className={`${styles['status-badge']} ${styles[`status-${invitation.status.toLowerCase()}`]}`}
-                                >
-                                  {invitation.status}
-                                </span>
-                              </td>
-                              <td>
-                                {new Date(
-                                  invitation.created_at,
-                                ).toLocaleDateString('en-US', {
-                                  year: 'numeric',
-                                  month: 'short',
-                                  day: 'numeric',
-                                })}
-                              </td>
-                            </tr>
-                          ))
-                        ) : (
-                          <tr>
-                            <td colSpan={4} className={styles['empty-state']}>
-                              No pending invitations
-                            </td>
-                          </tr>
-                        )}
-                      </tbody>
-                    </table>
-                  </div>
                 </div>
               </div>
             )}
@@ -592,7 +536,7 @@ const ManageTenantMembers = () => {
                     <p className={styles['section-description']}>
                       Add a new member directly to this tenant without sending
                       an invitation. Search for a registered user by email or
-                      username.
+                      name.
                     </p>
 
                     <div className={styles['form-fields']}>
@@ -607,7 +551,7 @@ const ManageTenantMembers = () => {
                               name="search"
                               value={searchInput}
                               onChange={handleAddDirectFormChange}
-                              placeholder="Search by email or username..."
+                              placeholder="Search by email or name..."
                               className={
                                 addDirectErrors.search
                                   ? styles['input-error']
@@ -644,7 +588,7 @@ const ManageTenantMembers = () => {
                                           <span
                                             className={styles['user-details']}
                                           >
-                                            {user.username} • {user.email}
+                                            {user.email}
                                           </span>
                                         </div>
                                       </li>
@@ -668,7 +612,7 @@ const ManageTenantMembers = () => {
                                 {selectedUser.firstName} {selectedUser.lastName}
                               </span>
                               <span className={styles['selected-user-details']}>
-                                {selectedUser.username} • {selectedUser.email}
+                                {selectedUser.email}
                               </span>
                             </div>
                             <button
@@ -717,6 +661,15 @@ const ManageTenantMembers = () => {
                 </form>
               </div>
             )}
+
+            {activeTab === 'invitations' && (
+              <div className={styles['tab-content']}>
+                <TenantInvitations
+                  tenantId={tenantId || ''}
+                  tenantName={tenantData?.info.name || ''}
+                />
+              </div>
+            )}
           </>
         )}
       </div>
@@ -727,8 +680,9 @@ const ManageTenantMembers = () => {
         message={
           memberToRemove ? (
             <>
-              Are you sure you want to remove this user from the tenant "
-              {tenantData?.info.name}"?
+              Are you sure you want to remove user with email{' '}
+              <strong>{memberToRemove.email}</strong> from tenant{' '}
+              <strong>{tenantData?.info.name}</strong>?
               <br />
               <span className="text-amber-600 font-medium">
                 The user will lose access to this tenant.

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -168,14 +168,18 @@ export const Profile = () => {
         isOpen={removeDialogOpen}
         title="Remove from Tenant"
         message={
-          <>
-            Are you sure you want to remove this user from the tenant "
-            {tenantToRemove?.name}"?
-            <br />
-            <span className="text-amber-600 font-medium">
-              The user will lose access to this tenant.
-            </span>
-          </>
+          tenantToRemove ? (
+            <>
+              Are you sure you want to remove this user from tenant{' '}
+              <strong>{tenantToRemove.name}</strong> ?
+              <br />
+              <span className="text-amber-600 font-medium">
+                The user will lose access to this tenant.
+              </span>
+            </>
+          ) : (
+            ''
+          )
         }
         confirmLabel="Remove"
         cancelLabel="Cancel"
@@ -211,8 +215,11 @@ export const Profile = () => {
                 </div>
                 <div>
                   <label className={styles['username-label']}>Username</label>
-                  <h2 className={styles['username-value']}>
-                    {squishEmail(currentUsername, 10, 10)}
+                  <h2
+                    className={styles['username-value']}
+                    title={currentUsername}
+                  >
+                    {squishEmail(currentUsername, 12, 12)}
                   </h2>
                 </div>
               </div>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -94,7 +94,20 @@ const Projects = () => {
       <ConfirmDialog
         isOpen={deleteDialogOpen}
         title="Delete Project"
-        message={`Are you sure you want to delete the project "${projectToDelete?.name}"? This action cannot be undone.`}
+        message={
+          projectToDelete ? (
+            <>
+              Are you sure you want to delete project{' '}
+              <strong>{projectToDelete.name}</strong> ?
+              <br />
+              <span className="text-amber-600 font-medium">
+                This action cannot be undone.
+              </span>
+            </>
+          ) : (
+            ''
+          )
+        }
         confirmLabel="Delete"
         cancelLabel="Cancel"
         onConfirm={handleDeleteConfirm}

--- a/src/pages/TenantInvitations.module.css
+++ b/src/pages/TenantInvitations.module.css
@@ -1,0 +1,130 @@
+.section-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 0.6rem;
+}
+
+.table-wrapper {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table-head {
+  background-color: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.table-head th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  white-space: nowrap;
+}
+
+.table-body td {
+  padding: 0.875rem 1rem;
+  font-size: 0.875rem;
+  color: #1f2937;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.table-body tr:last-child td {
+  border-bottom: none;
+}
+
+.table-body tr:hover {
+  background-color: #f9fafb;
+}
+
+.empty-state {
+  text-align: center;
+  color: #9ca3af !important;
+  font-style: italic;
+  padding: 2rem !important;
+}
+
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
+.role-badge.role-admin {
+  background-color: #fef3c7;
+  color: #b45309;
+}
+
+.role-badge.role-viewer {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
+.status-badge.status-pending {
+  background-color: #fef3c7;
+  color: #b45309;
+}
+
+.status-badge.status-accepted {
+  background-color: #ecfdf5;
+  color: #10b981;
+}
+
+.status-badge.status-rejected {
+  background-color: #fef2f2;
+  color: #ef4444;
+}
+
+.remove-button {
+  margin-left: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.375rem;
+  background: none;
+  border-radius: 0.375rem;
+  color: #ef4444;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.remove-button:hover {
+  background-color: #fef2f2;
+}
+
+.remove-button:active {
+  transform: scale(0.95);
+}
+
+@media (max-width: 768px) {
+  .table-wrapper {
+    overflow-x: auto;
+  }
+
+  .table {
+    min-width: 700px;
+  }
+}

--- a/src/pages/TenantInvitations.tsx
+++ b/src/pages/TenantInvitations.tsx
@@ -1,0 +1,229 @@
+import { useState } from 'react'
+import { useGetTenantInvitations } from '@/hooks/useInvitations'
+import { useRevokeInvitation } from '@/hooks/useTenants'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/solid'
+import { toast } from 'sonner'
+import ConfirmDialog from '@/components/ConfirmDialog'
+import styles from './TenantInvitations.module.css'
+
+interface TenantInvitationsProps {
+  tenantId: string
+  tenantName: string
+}
+
+const TenantInvitations = ({
+  tenantId,
+  tenantName,
+}: TenantInvitationsProps) => {
+  const [currentPage, setCurrentPage] = useState(1)
+  const pageSize = 10
+  const [revokeDialogOpen, setRevokeDialogOpen] = useState(false)
+  const [invitationToRevoke, setInvitationToRevoke] = useState<{
+    invitationId: string
+    email: string
+  } | null>(null)
+
+  const { data: invitationsData } = useGetTenantInvitations(
+    tenantId,
+    currentPage,
+    pageSize,
+    !!tenantId,
+  )
+
+  const revokeInvitationMutation = useRevokeInvitation()
+
+  const handleRevokeClick = (invitationId: string, invitationEmail: string) => {
+    setInvitationToRevoke({ invitationId, email: invitationEmail })
+    setRevokeDialogOpen(true)
+  }
+
+  const handleRevokeConfirm = () => {
+    if (!tenantId || !invitationToRevoke) return
+
+    revokeInvitationMutation.mutate(
+      { tenantId, invitationId: invitationToRevoke.invitationId },
+      {
+        onSuccess: () => {
+          toast.success('Invitation revoked successfully!')
+          setRevokeDialogOpen(false)
+          setInvitationToRevoke(null)
+        },
+        onError: (error) => {
+          toast.error(`Failed to revoke invitation: ${error.message}`)
+        },
+      },
+    )
+  }
+
+  const handleRevokeCancel = () => {
+    setRevokeDialogOpen(false)
+    setInvitationToRevoke(null)
+  }
+
+  return (
+    <>
+      <h2 className={styles['section-title']}>Tenant Invitations</h2>
+      <div className={styles['table-wrapper']}>
+        <table className={styles.table}>
+          <thead className={styles['table-head']}>
+            <tr>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Status</th>
+              <th>Created At</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody className={styles['table-body']}>
+            {invitationsData && invitationsData.content.length > 0 ? (
+              invitationsData.content.map((invitation) => (
+                <tr key={invitation.id}>
+                  <td>{invitation.email}</td>
+                  <td>
+                    <span
+                      className={`${styles['role-badge']} ${styles[`role-${invitation.role}`]}`}
+                    >
+                      {invitation.role === 'admin' ? 'Tenant Admin' : 'Member'}
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      className={`${styles['status-badge']} ${
+                        invitation.status === 'PENDING'
+                          ? styles['status-pending']
+                          : invitation.status === 'ACCEPTED'
+                            ? styles['status-accepted']
+                            : styles['status-rejected']
+                      }`}
+                    >
+                      {invitation.status === 'PENDING'
+                        ? 'Pending'
+                        : invitation.status === 'ACCEPTED'
+                          ? 'Accepted'
+                          : invitation.status === 'REJECTED'
+                            ? 'Rejected'
+                            : invitation.status === 'REVOKED'
+                              ? 'Revoked'
+                              : invitation.status}
+                    </span>
+                  </td>
+                  <td>
+                    {new Date(invitation.created_at).toLocaleDateString(
+                      'en-US',
+                      {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                      },
+                    )}
+                  </td>
+                  <td>
+                    {invitation.status === 'PENDING' ? (
+                      <button
+                        onClick={() =>
+                          handleRevokeClick(invitation.id, invitation.email)
+                        }
+                        className={`${styles['remove-button']} tooltip`}
+                        data-tip="Revoke invitation"
+                        disabled={revokeInvitationMutation.isPending}
+                      >
+                        <XCircleIcon
+                          style={{
+                            width: '1.6rem',
+                            height: '1.6rem',
+                          }}
+                        />
+                      </button>
+                    ) : (
+                      <span
+                        style={{
+                          color: '#9ca3af',
+                          fontSize: '0.875rem',
+                          display: 'inline-block',
+                          marginLeft: '1.4rem',
+                        }}
+                      >
+                        -
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={5} className={styles['empty-state']}>
+                  No invitations
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {invitationsData?.content && invitationsData.content.length > 0 && (
+        <div className="pagination-container">
+          <div className="pagination-info">
+            <span className="pagination-text">
+              Page {currentPage} of {invitationsData.total_pages}
+            </span>
+            <span className="pagination-count">
+              ({invitationsData.total_elements} total invitations)
+            </span>
+          </div>
+          <div className="pagination-buttons">
+            <button
+              onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+              disabled={currentPage === 1}
+              className="pagination-button"
+              aria-label="Previous page"
+            >
+              <ChevronLeftIcon className="pagination-icon" />
+            </button>
+            <button
+              onClick={() =>
+                setCurrentPage((prev) =>
+                  Math.min(invitationsData.total_pages, prev + 1),
+                )
+              }
+              disabled={currentPage >= invitationsData.total_pages}
+              className="pagination-button"
+              aria-label="Next page"
+            >
+              <ChevronRightIcon className="pagination-icon" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={revokeDialogOpen}
+        title="Revoke Invitation"
+        message={
+          invitationToRevoke ? (
+            <>
+              Are you sure you want to revoke the invitation for{' '}
+              <strong>{invitationToRevoke.email}</strong> to join tenant{' '}
+              <strong>{tenantName}</strong>?
+              <br />
+              <span className="text-amber-600 font-medium">
+                This action cannot be undone.
+              </span>
+            </>
+          ) : (
+            ''
+          )
+        }
+        confirmLabel="Revoke"
+        cancelLabel="Cancel"
+        onConfirm={handleRevokeConfirm}
+        onCancel={handleRevokeCancel}
+      />
+    </>
+  )
+}
+
+export default TenantInvitations

--- a/src/pages/Tenants.tsx
+++ b/src/pages/Tenants.tsx
@@ -194,14 +194,18 @@ const Tenants = () => {
         isOpen={deleteDialogOpen}
         title="Delete Tenant"
         message={
-          <>
-            Are you sure you want to delete the tenant "{tenantToDelete?.name}
-            "?
-            <br />
-            <span className="text-red-600 font-medium">
-              This action cannot be undone.
-            </span>
-          </>
+          tenantToDelete ? (
+            <>
+              Are you sure you want to delete tenant{' '}
+              <strong>{tenantToDelete.name}</strong> ?
+              <br />
+              <span className="text-amber-600 font-medium">
+                This action cannot be undone.
+              </span>
+            </>
+          ) : (
+            ''
+          )
         }
         confirmLabel="Delete"
         cancelLabel="Cancel"

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -72,14 +72,18 @@ const View = () => {
         isOpen={deleteDialogOpen}
         title="Delete Status Page"
         message={
-          <>
-            Are you sure you want to delete the status page "
-            {pageToDelete?.name}"?
-            <br />
-            <span className="text-red-600 font-medium">
-              This action cannot be undone.
-            </span>
-          </>
+          pageToDelete ? (
+            <>
+              Are you sure you want to delete status page{' '}
+              <strong>{pageToDelete.name}</strong> ?
+              <br />
+              <span className="text-amber-600 font-medium">
+                This action cannot be undone.
+              </span>
+            </>
+          ) : (
+            ''
+          )
         }
         confirmLabel="Delete"
         cancelLabel="Cancel"

--- a/src/routing/ProtectedRoute.tsx
+++ b/src/routing/ProtectedRoute.tsx
@@ -1,20 +1,31 @@
 import type { JSX } from 'react'
-import { Navigate, useLocation } from 'react-router-dom'
+import { Navigate, useLocation, useParams } from 'react-router-dom'
 import { useAuth } from '@/auth/useAuth'
+import { useGetTenantById } from '@/hooks/useTenants'
+import { ArrowPathIcon } from '@heroicons/react/24/outline'
+import type { UserGroup } from '@/types/profile'
 
 type RoleProtectedProps = {
   children: JSX.Element
   requiredRoles: string[]
   redirectTo?: string
+  checkTenantAccess?: boolean
 }
 
 function ProtectedRoute({
   children,
   requiredRoles,
   redirectTo = '/',
+  checkTenantAccess = false,
 }: RoleProtectedProps) {
   const { initialized, authenticated, profile } = useAuth()
   const location = useLocation()
+  const { id: tenantId } = useParams<{ id: string }>() || {}
+
+  const { data: tenantData, isLoading: tenantLoading } = useGetTenantById(
+    tenantId || '',
+    checkTenantAccess && !!tenantId && authenticated,
+  )
 
   if (!initialized) return null
 
@@ -22,9 +33,48 @@ function ProtectedRoute({
     return <Navigate to="/" state={{ from: location }} replace />
   }
 
-  const hasRequiredRole = requiredRoles.some((role) =>
-    profile?.roles?.includes(role),
-  )
+  if (checkTenantAccess && tenantId && tenantLoading) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: '400px',
+        }}
+      >
+        <ArrowPathIcon
+          style={{ width: '2.5rem', height: '2.5rem', color: '#1d4ed8' }}
+          className="animate-spin"
+        />
+      </div>
+    )
+  }
+
+  const isSuperAdmin = profile?.roles?.includes('super_admin')
+
+  const hasTenantAccess = (tenantName: string) => {
+    if (!tenantName || !profile?.groups) return false
+
+    const group = profile?.groups?.find(
+      (g: UserGroup) => g?.name === tenantName,
+    )
+    return group?.role === 'admin' || group?.role === 'viewer'
+  }
+
+  let hasRequiredRole = false
+
+  if (isSuperAdmin) {
+    hasRequiredRole = true
+  } else if (checkTenantAccess && tenantData) {
+    // For tenant-specific routes, check if user is admin or member of this specific tenant
+    hasRequiredRole = hasTenantAccess(tenantData.info.name)
+  } else if (!checkTenantAccess) {
+    // For non-tenant routes, check if user has any of the required roles
+    hasRequiredRole = requiredRoles.some((role) =>
+      profile?.roles?.includes(role),
+    )
+  }
 
   if (!hasRequiredRole) {
     return <Navigate to={redirectTo} state={{ from: location }} replace />


### PR DESCRIPTION
This PR implements the ability for super admins and tenant admins to revoke pending invitations. Super admins can revoke any pending invitation across all tenants through the Admin Invitations page, while tenant admins can revoke pending invitations for their own tenant through the Tenant Invitations tab.

- Integrated useRevokeInvitation mutation for tenant-invitations and admin-invitations
- Implemented revokeInvitation API function endpoint /v1/tenants/{tenantId}/invitations/{invitationId}
- Created TenantInvitations component with dedicated tab in ManageTenantMembers for tenant admin access
- Implemented confirmation dialog component for revoke invitation actions

