### PR TITLE
[ARGO-5339] - Refactor Add Member Directly to Support User Search

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 .page-container {
-  max-width: 1280px;
+  max-width: 1480px;
   margin: 0 auto;
   width: 100%;
 }
@@ -164,6 +164,6 @@ select:focus {
 
 @media (min-width: 1921px) {
   .page-container {
-    max-width: 1440px;
+    max-width: 1800px;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,11 +69,9 @@ function App() {
               <Route
                 path="tenants/view"
                 element={
-                  <ProtectedRoute
-                    requiredRoles={['super_admin', 'admin', 'viewer']}
-                  >
+                  <AuthProtected>
                     <Tenants />
-                  </ProtectedRoute>
+                  </AuthProtected>
                 }
               />
               <Route

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -11,7 +11,6 @@ import {
   UserGroupIcon,
   EnvelopeIcon,
 } from '@heroicons/react/16/solid'
-import { squishEmail } from './utils/profile'
 import Button from './components/Button'
 import LoginPrompt from './components/LoginPrompt'
 
@@ -112,21 +111,16 @@ export default function Layout() {
         </nav>
 
         <div className="border-t border-gray-200">
-          {authenticated && (profile?.username || profile?.sub) ? (
+          {authenticated && profile?.name ? (
             <div className="p-4">
               <div className="flex items-center justify-between gap-1 text-sm text-gray-700">
                 <Link to="/profile">
                   <div className="flex items-center gap-2 min-w-0 flex-1 hover:opacity-90 w-50">
                     <div className="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0">
-                      {(profile.username || profile.sub || 'U')
-                        .charAt(0)
-                        .toUpperCase()}
+                      {(profile.name || 'U').charAt(0).toUpperCase()}
                     </div>
-                    <div
-                      className="truncate font-medium"
-                      title={profile.username || squishEmail(profile.sub || '')}
-                    >
-                      {profile.username || squishEmail(profile.sub || '')}
+                    <div className="truncate font-medium" title={profile.name}>
+                      {profile.name || 'User'}
                     </div>
                   </div>
                 </Link>

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -414,7 +414,7 @@ export const fetchTenantMembers = async (
 
 export const addMemberDirectly = async (
   tenantId: string,
-  data: { email: string; role: string },
+  data: { username: string; email: string; role: string },
   token: string,
 ): Promise<void> => {
   const response = await fetch(

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -2,16 +2,7 @@
 import { AuthContext, type AuthContextType } from './context'
 import { keycloak, initKeycloak } from './keycloak'
 import { useEffect, useRef, useState } from 'react'
-
-type KeycloakUserInfo = {
-  preferred_username: string
-  email: string
-  name: string
-  given_name: string
-  family_name: string
-  sub: string
-  entitlements: string[]
-}
+import { fetchUserProfile } from '@/api/profile'
 
 export const AuthProvider: React.FC<React.PropsWithChildren> = ({
   children,
@@ -23,6 +14,32 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
 
   const startedRef = useRef(false)
   const refreshTimerRef = useRef<number | null>(null)
+
+  // Fetch profile data when token becomes available
+  useEffect(() => {
+    if (token && authenticated) {
+      fetchUserProfile(token)
+        .then((profileData) => {
+          // Extract unique roles from groups array
+          const roles = profileData.groups
+            ? Array.from(new Set(profileData.groups.map((group) => group.role)))
+            : []
+
+          setProfile({
+            id: profileData.id,
+            username: profileData.username,
+            email: profileData.email,
+            name: profileData.name,
+            surname: profileData.surname,
+            groups: profileData.groups || [],
+            roles: roles,
+          })
+        })
+        .catch((error) => {
+          console.error('Failed to fetch user profile:', error)
+        })
+    }
+  }, [token, authenticated])
 
   useEffect(() => {
     if (startedRef.current) return
@@ -42,43 +59,6 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
 
         if (auth) {
           setToken(keycloak.token)
-
-          // Load minimal profile
-          const userInfo = (await keycloak.loadUserInfo()) as KeycloakUserInfo
-
-          // Extract roles from entitlements
-          const roles =
-            userInfo.entitlements
-              ?.filter((entitlement) =>
-                entitlement.includes('group:status-pages'),
-              )
-              .map((entitlement) => {
-                const rolePart = entitlement.split('role=')[1]
-                return rolePart || null
-              })
-              .filter((role): role is string => role !== null) || []
-
-          setProfile({
-            username: userInfo.preferred_username,
-            name: userInfo.name,
-            given_name: userInfo.given_name,
-            family_name: userInfo.family_name,
-            email: userInfo.email,
-            sub: userInfo.sub,
-            entitlements: userInfo.entitlements,
-            roles: roles,
-          })
-
-          // // Refresh token every 30s; keep at least 60s of validity.
-          // refreshTimerRef.current = window.setInterval(async () => {
-          //   try {
-          //     const refreshed = await keycloak.updateToken(60);
-          //     if (refreshed) setToken(keycloak.token);
-          //   } catch {
-          //     setAuthenticated(false);
-          //     setToken(undefined);
-          //   }
-          // }, 30_000);
         }
 
         setInitialized(true)

--- a/src/auth/context.ts
+++ b/src/auth/context.ts
@@ -5,14 +5,16 @@ export type AuthContextType = {
   authenticated: boolean
   token?: string
   profile?: {
-    sub?: string
+    id?: string
     username?: string
     email?: string
     name?: string
-    given_name?: string
-    family_name?: string
-    entitlements: string[]
-    roles: string[]
+    surname?: string
+    roles?: string[]
+    groups?: Array<{
+      name: string
+      role: string
+    }>
   }
   login: (redirectUri?: string) => void
   logout: () => void

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -391,7 +391,10 @@ export const useAddMemberDirectly = () => {
   return useMutation<
     void,
     Error,
-    { tenantId: string; data: { email: string; role: string } }
+    {
+      tenantId: string
+      data: { username: string; email: string; role: string }
+    }
   >({
     mutationFn: ({ tenantId, data }) => {
       if (!token) {

--- a/src/pages/AdminInvitations.module.css
+++ b/src/pages/AdminInvitations.module.css
@@ -73,6 +73,7 @@
 
 .table-row td {
   padding: 0.75rem 1rem;
+  word-break: break-word;
 }
 
 .tenant-name-text {

--- a/src/pages/Administration.module.css
+++ b/src/pages/Administration.module.css
@@ -242,6 +242,7 @@
 
 .table-row td {
   padding: 0.75rem 1rem;
+  word-break: break-word;
 }
 
 .td-username,

--- a/src/pages/Administration.tsx
+++ b/src/pages/Administration.tsx
@@ -15,6 +15,7 @@ import {
 import styles from './Administration.module.css'
 import AdminInvitations from './AdminInvitations'
 import { useNavigate } from 'react-router-dom'
+import { squishEmail } from '@/utils/profile'
 
 type SortColumn = 'username' | 'firstName' | 'lastName' | 'email' | 'tenants'
 type SortDirection = 'asc' | 'desc'
@@ -222,8 +223,11 @@ const Administration = () => {
                         {filteredUsers.map((user) => (
                           <tr key={user.id} className={styles['table-row']}>
                             <td className={styles['td-username']}>
-                              <span className={styles['username-text']}>
-                                {user.username}
+                              <span
+                                className={styles['username-text']}
+                                title={user.username}
+                              >
+                                {squishEmail(user.username, 6, 6)}
                               </span>
                             </td>
                             <td className={styles['td-name']}>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,11 +8,11 @@ export function Home() {
     <div className="page-container">
       <h1 className="text-2xl font-semibold text-gray-900 mb-3">
         Welcome to Status Pages
-        {profile?.username && (
+        {profile?.name && (
           <span>
             ,{' '}
             <span className="text-amber-700">
-              <Link to="/profile">{profile.username}</Link>
+              <Link to="/profile">{profile.name}</Link>
             </span>
             !
           </span>

--- a/src/pages/ManageTenantMembers.module.css
+++ b/src/pages/ManageTenantMembers.module.css
@@ -107,6 +107,7 @@
   font-size: 0.875rem;
   color: #1f2937;
   border-bottom: 1px solid #f3f4f6;
+  word-break: break-word;
 }
 
 .table-body tr:last-child td {
@@ -170,7 +171,7 @@
 }
 
 .invite-form {
-  max-width: 600px;
+  max-width: 640px;
 }
 
 .form-section {
@@ -181,6 +182,7 @@
 }
 
 .form-fields {
+  max-width: 400px;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -190,6 +192,7 @@
 .field {
   display: flex;
   flex-direction: column;
+  max-width: 100%;
 }
 
 .label {
@@ -237,6 +240,130 @@
 
 .remove-button:active {
   transform: scale(0.95);
+}
+
+.search-wrapper {
+  position: relative;
+}
+
+.search-wrapper input {
+  width: 100%;
+}
+
+.search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  margin-top: 0.25rem;
+  max-height: 300px;
+  overflow-y: auto;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+}
+
+.search-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  color: #6b7280;
+  font-size: 0.875rem;
+}
+
+.results-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.result-item {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.result-item:last-child {
+  border-bottom: none;
+}
+
+.result-item:hover {
+  background-color: #f9fafb;
+}
+
+.user-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.user-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.user-details {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.no-results {
+  padding: 1rem;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 0.875rem;
+  font-style: italic;
+}
+
+.selected-user-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+}
+
+.selected-user-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.selected-user-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.selected-user-details {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.clear-user-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  background: none;
+  border: none;
+  border-radius: 0.375rem;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.clear-user-button:hover {
+  background-color: #e5e7eb;
+  color: #374151;
 }
 
 @media (max-width: 768px) {

--- a/src/pages/ManageTenantMembers.tsx
+++ b/src/pages/ManageTenantMembers.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
   useGetTenantInvitations,
@@ -9,6 +9,7 @@ import {
   useGetUserTenantById,
   useAddMemberDirectly,
   useRemoveMemberFromTenant,
+  useGetMembers,
 } from '@/hooks/useTenants'
 import { useAuth } from '@/auth/useAuth'
 import {
@@ -17,6 +18,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   UserMinusIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/solid'
 import { toast, Toaster } from 'sonner'
 import Button from '@/components/Button'
@@ -46,7 +48,12 @@ const ManageTenantMembers = () => {
     email: '',
     role: 'viewer' as InvitationRole,
   })
-  const [addDirectForm, setAddDirectForm] = useState({
+  const [addDirectForm, setAddDirectForm] = useState<{
+    username: string
+    email: string
+    role: InvitationRole
+  }>({
+    username: '',
     email: '',
     role: 'viewer' as InvitationRole,
   })
@@ -54,8 +61,17 @@ const ManageTenantMembers = () => {
     email: '',
   })
   const [addDirectErrors, setAddDirectErrors] = useState({
-    email: '',
+    search: '',
   })
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchInput, setSearchInput] = useState('')
+  const [showSearchResults, setShowSearchResults] = useState(false)
+  const [selectedUser, setSelectedUser] = useState<{
+    username: string
+    email: string
+    firstName: string
+    lastName: string
+  } | null>(null)
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false)
   const [memberToRemove, setMemberToRemove] = useState<{
     id: string
@@ -71,9 +87,24 @@ const ManageTenantMembers = () => {
   const { data: invitationsData, isLoading: invitationsLoading } =
     useGetTenantInvitations(tenantId || '', !!tenantId)
 
+  const { data: searchResults, isLoading: searchLoading } = useGetMembers(
+    1,
+    5,
+    searchQuery,
+    !!searchQuery && showSearchResults,
+  )
+
   const createInvitationMutation = useCreateTenantInvitation()
   const addMemberDirectlyMutation = useAddMemberDirectly()
   const removeMemberMutation = useRemoveMemberFromTenant()
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchQuery(searchInput)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [searchInput])
 
   const validateEmail = (email: string): boolean => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -145,35 +176,53 @@ const ManageTenantMembers = () => {
   ) => {
     const { name, value } = e.target
 
-    setAddDirectForm((prev) => ({
-      ...prev,
-      [name]: value,
-    }))
-
-    if (name === 'email') {
+    if (name === 'search') {
+      setSearchInput(value)
+      setShowSearchResults(true)
       if (!value.trim()) {
-        setAddDirectErrors((prev) => ({ ...prev, email: 'Email is required' }))
-      } else if (!validateEmail(value)) {
-        setAddDirectErrors((prev) => ({
-          ...prev,
-          email: 'Invalid email format',
-        }))
-      } else {
-        setAddDirectErrors((prev) => ({ ...prev, email: '' }))
+        setShowSearchResults(false)
+        setAddDirectErrors((prev) => ({ ...prev, search: '' }))
       }
+    } else if (name === 'role') {
+      setAddDirectForm((prev) => ({
+        ...prev,
+        role: value as InvitationRole,
+      }))
     }
+  }
+
+  const handleUserSelect = (user: {
+    username: string
+    email: string
+    firstName: string
+    lastName: string
+  }) => {
+    setSelectedUser(user)
+    setAddDirectForm({
+      username: user.username,
+      email: user.email,
+      role: addDirectForm.role,
+    })
+    setSearchInput('')
+    setShowSearchResults(false)
+    setAddDirectErrors({ search: '' })
+  }
+
+  const handleClearSelectedUser = () => {
+    setSelectedUser(null)
+    setAddDirectForm({
+      username: '',
+      email: '',
+      role: addDirectForm.role,
+    })
+    setSearchInput('')
   }
 
   const handleAddDirectSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (!addDirectForm.email.trim()) {
-      setAddDirectErrors({ email: 'Email is required' })
-      return
-    }
-
-    if (!validateEmail(addDirectForm.email)) {
-      setAddDirectErrors({ email: 'Invalid email format' })
+    if (!selectedUser) {
+      setAddDirectErrors({ search: 'Please select a user' })
       return
     }
 
@@ -186,6 +235,7 @@ const ManageTenantMembers = () => {
       {
         tenantId,
         data: {
+          username: addDirectForm.username,
           email: addDirectForm.email,
           role: addDirectForm.role,
         },
@@ -193,8 +243,10 @@ const ManageTenantMembers = () => {
       {
         onSuccess: () => {
           toast.success('Member added successfully!')
-          setAddDirectForm({ email: '', role: 'viewer' })
-          setAddDirectErrors({ email: '' })
+          setAddDirectForm({ username: '', email: '', role: 'viewer' })
+          setSelectedUser(null)
+          setSearchInput('')
+          setAddDirectErrors({ search: '' })
         },
         onError: (error) => {
           toast.error(`Failed to add member: ${error.message}`)
@@ -297,7 +349,6 @@ const ManageTenantMembers = () => {
                     <table className={styles.table}>
                       <thead className={styles['table-head']}>
                         <tr>
-                          <th>Username</th>
                           <th>First Name</th>
                           <th>Last Name</th>
                           <th>Email</th>
@@ -314,7 +365,6 @@ const ManageTenantMembers = () => {
                             )
                             return (
                               <tr key={member.id}>
-                                <td>{member.username}</td>
                                 <td>{member.firstName || '-'}</td>
                                 <td>{member.lastName || '-'}</td>
                                 <td>{member.email}</td>
@@ -484,7 +534,7 @@ const ManageTenantMembers = () => {
                           name="email"
                           value={inviteForm.email}
                           onChange={handleInviteFormChange}
-                          placeholder="Enter email address to invite"
+                          placeholder="Enter email address to invite..."
                           className={errors.email ? styles['input-error'] : ''}
                         />
                         {errors.email && (
@@ -541,31 +591,97 @@ const ManageTenantMembers = () => {
                     </h2>
                     <p className={styles['section-description']}>
                       Add a new member directly to this tenant without sending
-                      an invitation. The user must already have an account in
-                      the system.
+                      an invitation. Search for a registered user by email or
+                      username.
                     </p>
 
                     <div className={styles['form-fields']}>
-                      <div className={styles.field}>
-                        <label className={styles.label}>
-                          Email Address <span className="required">*</span>
-                        </label>
-                        <input
-                          type="email"
-                          name="email"
-                          value={addDirectForm.email}
-                          onChange={handleAddDirectFormChange}
-                          placeholder="Enter registered user's email address"
-                          className={
-                            addDirectErrors.email ? styles['input-error'] : ''
-                          }
-                        />
-                        {addDirectErrors.email && (
-                          <span className={styles.error}>
-                            {addDirectErrors.email}
-                          </span>
-                        )}
-                      </div>
+                      {!selectedUser ? (
+                        <div className={styles.field}>
+                          <label className={styles.label}>
+                            Search User <span className="required">*</span>
+                          </label>
+                          <div className={styles['search-wrapper']}>
+                            <input
+                              type="text"
+                              name="search"
+                              value={searchInput}
+                              onChange={handleAddDirectFormChange}
+                              placeholder="Search by email or username..."
+                              className={
+                                addDirectErrors.search
+                                  ? styles['input-error']
+                                  : ''
+                              }
+                              autoComplete="off"
+                            />
+                            {addDirectErrors.search && (
+                              <span className={styles.error}>
+                                {addDirectErrors.search}
+                              </span>
+                            )}
+
+                            {showSearchResults && (
+                              <div className={styles['search-results']}>
+                                {searchLoading ? (
+                                  <div className={styles['search-loading']}>
+                                    <ArrowPathIcon className="animate-spin size-5 text-blue-400" />
+                                    <span>Searching...</span>
+                                  </div>
+                                ) : searchResults &&
+                                  searchResults.content.length > 0 ? (
+                                  <ul className={styles['results-list']}>
+                                    {searchResults.content.map((user) => (
+                                      <li
+                                        key={user.id}
+                                        className={styles['result-item']}
+                                        onClick={() => handleUserSelect(user)}
+                                      >
+                                        <div className={styles['user-info']}>
+                                          <span className={styles['user-name']}>
+                                            {user.firstName} {user.lastName}
+                                          </span>
+                                          <span
+                                            className={styles['user-details']}
+                                          >
+                                            {user.username} • {user.email}
+                                          </span>
+                                        </div>
+                                      </li>
+                                    ))}
+                                  </ul>
+                                ) : (
+                                  <div className={styles['no-results']}>
+                                    No users found
+                                  </div>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      ) : (
+                        <div className={styles.field}>
+                          <label className={styles.label}>Selected User</label>
+                          <div className={styles['selected-user-card']}>
+                            <div className={styles['selected-user-info']}>
+                              <span className={styles['selected-user-name']}>
+                                {selectedUser.firstName} {selectedUser.lastName}
+                              </span>
+                              <span className={styles['selected-user-details']}>
+                                {selectedUser.username} • {selectedUser.email}
+                              </span>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={handleClearSelectedUser}
+                              className={styles['clear-user-button']}
+                              aria-label="Clear selected user"
+                            >
+                              <XMarkIcon className="size-5" />
+                            </button>
+                          </div>
+                        </div>
+                      )}
 
                       <div className={styles.field}>
                         <label className={styles.label}>
@@ -591,9 +707,7 @@ const ManageTenantMembers = () => {
                         size="md"
                         type="submit"
                         disabled={
-                          !addDirectForm.email.trim() ||
-                          !!addDirectErrors.email ||
-                          addMemberDirectlyMutation.isPending
+                          !selectedUser || addMemberDirectlyMutation.isPending
                         }
                       >
                         Add Member

--- a/src/pages/MyInvitations.module.css
+++ b/src/pages/MyInvitations.module.css
@@ -81,6 +81,7 @@
 
 .table-row td {
   padding: 0.75rem 1rem;
+  word-break: break-word;
 }
 
 .tenant-name-text {

--- a/src/pages/Profile.module.css
+++ b/src/pages/Profile.module.css
@@ -13,7 +13,7 @@
 }
 
 .wrapper {
-  max-width: 64rem;
+  max-width: 72rem;
   width: 100%;
 }
 
@@ -62,9 +62,10 @@
 }
 
 .username-value {
-  font-size: 1.5rem;
+  font-size: 1rem;
   font-weight: 700;
   color: #1f2937;
+  word-break: break-word;
 }
 
 .profile-body {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -139,19 +139,27 @@ export const Profile = () => {
   // Use displayProfile for viewing other users, profile for own profile
   const currentUsername = isViewingOtherUser
     ? displayProfile?.username || 'N/A'
-    : profile?.username || squishEmail(profile?.sub || '') || 'N/A'
+    : profile?.username || 'N/A'
   const currentFirstName = isViewingOtherUser
     ? displayProfile?.firstName || 'Not available'
-    : profile?.given_name || 'Not available'
+    : profile?.name || 'Not available'
   const currentLastName = isViewingOtherUser
     ? displayProfile?.lastName || 'Not available'
-    : profile?.family_name || 'Not available'
+    : profile?.surname || 'Not available'
   const currentEmail = isViewingOtherUser
     ? displayProfile?.email || 'Not available'
     : profile?.email || 'Not available'
-  const currentUserId = isViewingOtherUser
-    ? displayProfile?.id || 'Not available'
-    : profile?.sub || 'Not available'
+
+  const currentGroups = isViewingOtherUser
+    ? displayProfile?.tenants || []
+    : profile?.groups || []
+
+  // Remove a specific record if the name is equal to "members"
+  currentGroups.forEach((group, index) => {
+    if (group.name === 'members') {
+      currentGroups.splice(index, 1)
+    }
+  })
 
   return (
     <div className={styles.container}>
@@ -204,7 +212,7 @@ export const Profile = () => {
                 <div>
                   <label className={styles['username-label']}>Username</label>
                   <h2 className={styles['username-value']}>
-                    {currentUsername}
+                    {squishEmail(currentUsername, 10, 10)}
                   </h2>
                 </div>
               </div>
@@ -254,19 +262,6 @@ export const Profile = () => {
                       {currentEmail}
                     </p>
                   </div>
-
-                  <div className={styles['field-container']}>
-                    <label className={styles['field-label']}>User ID</label>
-                    <p
-                      className={
-                        currentUserId !== 'Not available'
-                          ? styles['field-value-break']
-                          : styles['field-value-break-unavailable']
-                      }
-                    >
-                      {currentUserId}
-                    </p>
-                  </div>
                 </div>
               </div>
 
@@ -283,61 +278,48 @@ export const Profile = () => {
                     <label className={`${styles['field-label']} mb-4`}>
                       Tenants
                     </label>
-                    {isViewingOtherUser ? (
-                      <div className={styles['tenants-section']}>
-                        {displayProfile?.tenants &&
-                        displayProfile.tenants.length > 0 ? (
-                          <div className={styles['tenants-list']}>
-                            {displayProfile.tenants.map((tenant, index) => (
-                              <div
-                                key={index}
-                                className={styles['tenant-item']}
-                              >
-                                <div className={styles['tenant-info']}>
-                                  <span className={styles['tenant-name']}>
-                                    {tenant.name}
-                                  </span>
-                                  <span
-                                    className={`${styles['role-badge']} ${
-                                      tenant.role === 'admin'
-                                        ? styles['role-admin']
-                                        : styles['role-viewer']
-                                    }`}
-                                  >
-                                    {tenant.role}
-                                  </span>
-                                </div>
-                                {isSuperAdmin && (
-                                  <button
-                                    aria-label="Remove from tenant"
-                                    className={`${styles['action-button']} ${styles.delete}`}
-                                    onClick={() =>
-                                      handleRemoveClick(
-                                        tenant.name,
-                                        tenant.role,
-                                      )
-                                    }
-                                    title="Remove user from this tenant"
-                                  >
-                                    <UserMinusIcon
-                                      className={styles['action-icon']}
-                                    />
-                                  </button>
-                                )}
+                    <div className={styles['tenants-section']}>
+                      {currentGroups && currentGroups.length > 0 ? (
+                        <div className={styles['tenants-list']}>
+                          {currentGroups.map((tenant, index) => (
+                            <div key={index} className={styles['tenant-item']}>
+                              <div className={styles['tenant-info']}>
+                                <span className={styles['tenant-name']}>
+                                  {tenant.name}
+                                </span>
+                                <span
+                                  className={`${styles['role-badge']} ${
+                                    tenant.role === 'admin'
+                                      ? styles['role-admin']
+                                      : styles['role-viewer']
+                                  }`}
+                                >
+                                  {tenant.role}
+                                </span>
                               </div>
-                            ))}
-                          </div>
-                        ) : (
-                          <p className={styles['field-value-unavailable']}>
-                            Not a member of any tenant
-                          </p>
-                        )}
-                      </div>
-                    ) : (
-                      <p className={styles['field-value-unavailable']}>
-                        View tenant memberships information
-                      </p>
-                    )}
+                              {isSuperAdmin && isViewingOtherUser && (
+                                <button
+                                  aria-label="Remove from tenant"
+                                  className={`${styles['action-button']} ${styles.delete}`}
+                                  onClick={() =>
+                                    handleRemoveClick(tenant.name, tenant.role)
+                                  }
+                                  title="Remove user from this tenant"
+                                >
+                                  <UserMinusIcon
+                                    className={styles['action-icon']}
+                                  />
+                                </button>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className={styles['field-value-unavailable']}>
+                          Not a member of any tenant
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/pages/TenantDetails.tsx
+++ b/src/pages/TenantDetails.tsx
@@ -53,6 +53,9 @@ const TenantDetails = () => {
           <h1 className="page-title">Tenant Details</h1>
           <p className="page-subtitle">
             View detailed information about the tenant
+            <strong style={{ wordBreak: 'break-all' }}>
+              {tenantData?.info.name ? ` ${tenantData.info.name}` : '...'}
+            </strong>
           </p>
         </div>
         <Button

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -4,9 +4,11 @@ export interface UserGroup {
 }
 
 export interface UserProfile {
-  sub: string
+  id: string
   username: string
   email: string
+  name: string
+  surname: string
   roles: string[]
   groups?: UserGroup[] | null
 }

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -3,8 +3,11 @@ export const squishEmail = (
   start: number = 3,
   end: number = 3,
 ): string => {
-  const [local, domain] = email.split('@')
-  return local.length > start + end
+  const parts = email?.split('@')
+  if (!parts) return email
+  const [local, domain] = parts
+
+  return local?.length > start + end
     ? `${local.slice(0, start)}...${local.slice(-end)}@${domain}`
     : email
 }


### PR DESCRIPTION
This PR refactors the Add Member Directly functionality to include a searchable user selection interface instead of requiring manual email entry

- Implemented debounced search allowing super admins to search users by email or username
- Added dropdown with user selection and profile card display
- Updated API request body to include complete user identification data
- Refactored Auth Provider to fetch profile data from /v1/users/profile endpoint instead of keycloak token introspection