### PR TITLE
[ARGO-5359] - Implement Reports Page for Tenant Details with ARGO Monitoring Information

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ function App() {
             <Route element={<Layout />}>
               <Route index element={<Home />} />
               <Route
-                path="tenants/view"
+                path="tenants"
                 element={
                   <AuthProtected>
                     <Tenants />
@@ -135,7 +135,7 @@ function App() {
                 }
               />
               <Route
-                path="projects/view"
+                path="projects"
                 element={
                   <ProtectedRoute requiredRoles={['super_admin']}>
                     <Projects />

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -77,13 +77,13 @@ export default function Layout() {
             </SidebarNavItem>
           )}
           {hasTenantsAccess && (
-            <SidebarNavItem to="/tenants/view">
+            <SidebarNavItem to="/tenants">
               <ServerStackIcon className="size-5" aria-hidden />
               Tenants
             </SidebarNavItem>
           )}
           {isSuperAdmin && (
-            <SidebarNavItem to="/projects/view">
+            <SidebarNavItem to="/projects">
               <FolderIcon className="size-5" aria-hidden />
               Projects
             </SidebarNavItem>

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -3,6 +3,9 @@ import type {
   Tenant,
   TenantList,
   PaginatedMembersResponse,
+  ReportListItem,
+  ReportDetail,
+  MetricProfileResponse,
 } from '@/types/tenants'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
@@ -483,4 +486,83 @@ export const revokeInvitation = async (
       errorData.message || `HTTP error! status: ${response.status}`,
     )
   }
+}
+
+export const fetchTenantReports = async (
+  tenantId: string,
+  token: string,
+  search?: string,
+): Promise<ReportListItem[]> => {
+  const searchParam = search ? `?search=${encodeURIComponent(search)}` : ''
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/reports${searchParam}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchTenantReportById = async (
+  tenantId: string,
+  reportId: string,
+  token: string,
+): Promise<ReportDetail> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/reports/${reportId}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchTenantMetricProfile = async (
+  tenantId: string,
+  profileId: string,
+  token: string,
+): Promise<MetricProfileResponse> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/metric-profiles/${profileId}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
 }

--- a/src/auth/context.ts
+++ b/src/auth/context.ts
@@ -6,13 +6,13 @@ export type AuthContextType = {
   registered: boolean
   token?: string
   profile?: {
-    id?: string
+    id: string
     username?: string
     email?: string
     name?: string
     surname?: string
-    roles?: string[]
-    groups?: Array<{
+    roles: string[]
+    groups: Array<{
       name: string
       role: string
     }>

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,28 @@
+import { ArrowPathIcon } from '@heroicons/react/24/outline'
+
+type LoadingSpinnerProps = {
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  className?: string
+  inline?: boolean
+}
+
+const sizeClasses = {
+  xs: 'size-6',
+  sm: 'size-8',
+  md: 'size-10',
+  lg: 'size-12',
+  xl: 'size-14',
+}
+
+export default function LoadingSpinner({
+  size = 'md',
+  className = '',
+  inline = false,
+}: LoadingSpinnerProps) {
+  const sizeClass = sizeClasses[size]
+  const inlineClass = inline ? 'inline-block' : ''
+  const combinedClassName =
+    `animate-spin ${sizeClass} text-blue-400 ${inlineClass} ${className}`.trim()
+
+  return <ArrowPathIcon className={combinedClassName} />
+}

--- a/src/components/MetricProfileItem.module.css
+++ b/src/components/MetricProfileItem.module.css
@@ -1,0 +1,124 @@
+.metric-profile-card {
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.metric-profile-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.metric-profile-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.expand-all-button {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #3b82f6;
+  background-color: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.expand-all-button:hover {
+  background-color: #dbeafe;
+  border-color: #93c5fd;
+}
+
+.metric-profile-loading {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 0;
+}
+
+.services-list {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+  align-items: start;
+}
+
+.service-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+.service-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  background-color: #fafafa;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.2s;
+}
+
+.service-header:hover {
+  background-color: #f3f4f6;
+}
+
+.expand-icon {
+  font-size: 0.625rem;
+  color: #6b7280;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.service-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  flex: 1;
+}
+
+.metrics-count {
+  font-size: 0.75rem;
+  color: #6b7280;
+  font-weight: 400;
+}
+
+.metrics-list {
+  background-color: white;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.metric-item {
+  padding: 0.375rem 0.625rem;
+  font-size: 0.8125rem;
+  color: #4b5563;
+  background-color: #f9fafb;
+  border-radius: 0.25rem;
+  border-left: 3px solid #d1d5db;
+}
+
+.no-data {
+  color: #9ca3af;
+  font-style: italic;
+  text-align: center;
+}
+
+@media (max-width: 1024px) {
+  .services-list {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/MetricProfileItem.tsx
+++ b/src/components/MetricProfileItem.tsx
@@ -1,0 +1,95 @@
+import { useGetTenantMetricProfile } from '@/hooks/useTenants'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import styles from './MetricProfileItem.module.css'
+
+interface MetricProfileItemProps {
+  tenantId: string
+  profile: { id: string; name: string; type: string }
+  expandedServices: Set<string>
+  onToggleService: (serviceName: string) => void
+  onToggleAll: (allServices: string[], expand: boolean) => void
+}
+
+const MetricProfileItem = ({
+  tenantId,
+  profile,
+  expandedServices,
+  onToggleService,
+  onToggleAll,
+}: MetricProfileItemProps) => {
+  const { data: metricProfileData, isLoading } = useGetTenantMetricProfile(
+    tenantId,
+    profile.id,
+    true,
+  )
+
+  const allServices =
+    metricProfileData?.data?.[0]?.services?.map(
+      (s: { service: string; metrics: string[] }) => s.service,
+    ) || []
+  const allExpanded =
+    allServices.length > 0 &&
+    allServices.every((s: string) => expandedServices.has(s))
+
+  return (
+    <div className={styles['metric-profile-card']}>
+      <div className={styles['metric-profile-header']}>
+        <h3 className={styles['metric-profile-name']}>{profile.name}</h3>
+        {allServices.length > 0 && (
+          <button
+            className={styles['expand-all-button']}
+            onClick={() => onToggleAll(allServices, !allExpanded)}
+          >
+            {allExpanded ? 'Collapse All' : 'Expand All'}
+          </button>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className={styles['metric-profile-loading']}>
+          <LoadingSpinner size="sm" />
+        </div>
+      ) : metricProfileData?.data?.[0]?.services ? (
+        <div className={styles['services-list']}>
+          {metricProfileData.data[0].services.map(
+            (service: { service: string; metrics: string[] }) => {
+              const isExpanded = expandedServices.has(service.service)
+              return (
+                <div key={service.service} className={styles['service-item']}>
+                  <button
+                    className={styles['service-header']}
+                    onClick={() => onToggleService(service.service)}
+                  >
+                    <span className={styles['expand-icon']}>
+                      {isExpanded ? '▼' : '▶'}
+                    </span>
+                    <span className={styles['service-name']}>
+                      {service.service}
+                    </span>
+                    <span className={styles['metrics-count']}>
+                      ({service.metrics.length}{' '}
+                      {service.metrics.length === 1 ? 'metric' : 'metrics'})
+                    </span>
+                  </button>
+                  {isExpanded && (
+                    <div className={styles['metrics-list']}>
+                      {service.metrics.map((metric: string) => (
+                        <div key={metric} className={styles['metric-item']}>
+                          {metric}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            },
+          )}
+        </div>
+      ) : (
+        <p className={styles['no-data']}>No services available</p>
+      )}
+    </div>
+  )
+}
+
+export default MetricProfileItem

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -25,6 +25,9 @@ import {
   addMemberDirectly,
   removeMemberFromTenant,
   revokeInvitation,
+  fetchTenantReports,
+  fetchTenantReportById,
+  fetchTenantMetricProfile,
 } from '@/api/tenants'
 import type {
   Job,
@@ -33,6 +36,9 @@ import type {
   TenantProjectAssignment,
   Member,
   PaginatedMembersResponse,
+  ReportListItem,
+  ReportDetail,
+  MetricProfileResponse,
 } from '@/types/tenants'
 
 export const useGetTenants = (
@@ -478,5 +484,74 @@ export const useRevokeInvitation = () => {
     onError: (error) => {
       console.error('Revoke invitation error:', error)
     },
+  })
+}
+
+export const useGetTenantReports = (
+  tenantId: string,
+  search?: string,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+
+  return useQuery<ReportListItem[], Error>({
+    queryKey: ['tenant-reports', tenantId, search],
+    queryFn: () => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      if (!tenantId) {
+        throw new Error('Tenant ID is required')
+      }
+      return fetchTenantReports(tenantId, token, search)
+    },
+    retry: false,
+    enabled: enabled && !!token && !!tenantId,
+  })
+}
+
+export const useGetTenantReportById = (
+  tenantId: string,
+  reportId: string,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+
+  return useQuery<ReportDetail, Error>({
+    queryKey: ['tenant-report', tenantId, reportId],
+    queryFn: () => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      if (!tenantId || !reportId) {
+        throw new Error('Tenant ID and Report ID are required')
+      }
+      return fetchTenantReportById(tenantId, reportId, token)
+    },
+    retry: false,
+    enabled: enabled && !!token && !!tenantId && !!reportId,
+  })
+}
+
+export const useGetTenantMetricProfile = (
+  tenantId: string,
+  profileId: string,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+
+  return useQuery<MetricProfileResponse, Error>({
+    queryKey: ['tenant-metric-profile', tenantId, profileId],
+    queryFn: () => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      if (!tenantId || !profileId) {
+        throw new Error('Tenant ID and Profile ID are required')
+      }
+      return fetchTenantMetricProfile(tenantId, profileId, token)
+    },
+    retry: false,
+    enabled: enabled && !!token && !!tenantId && !!profileId,
   })
 }

--- a/src/pages/AdminInvitations.tsx
+++ b/src/pages/AdminInvitations.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useGetAdminInvitations } from '@/hooks/useInvitations'
 import { useRevokeInvitation } from '@/hooks/useTenants'
-import { ArrowPathIcon, MagnifyingGlassIcon } from '@heroicons/react/16/solid'
+import { MagnifyingGlassIcon } from '@heroicons/react/16/solid'
 import {
   ChevronUpIcon,
   ChevronDownIcon,
@@ -10,6 +10,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { XCircleIcon } from '@heroicons/react/24/solid'
 import { toast } from 'sonner'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import styles from './AdminInvitations.module.css'
 import adminStyles from './Administration.module.css'
@@ -129,7 +130,7 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
     if (invitationsLoading) {
       return (
         <div className="loading-container">
-          <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+          <LoadingSpinner />
         </div>
       )
     }

--- a/src/pages/Administration.tsx
+++ b/src/pages/Administration.tsx
@@ -1,17 +1,14 @@
 import { useState, useMemo, useEffect } from 'react'
 import { useAuth } from '@/auth/useAuth'
 import { useGetMembers } from '@/hooks/useTenants'
-import {
-  ArrowPathIcon,
-  MagnifyingGlassIcon,
-  UserCircleIcon,
-} from '@heroicons/react/16/solid'
+import { MagnifyingGlassIcon, UserCircleIcon } from '@heroicons/react/16/solid'
 import {
   ChevronUpIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
 } from '@heroicons/react/24/outline'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import styles from './Administration.module.css'
 import AdminInvitations from './AdminInvitations'
 import { useNavigate } from 'react-router-dom'
@@ -161,7 +158,7 @@ const Administration = () => {
 
           {isLoading ? (
             <div className="loading-container">
-              <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+              <LoadingSpinner />
             </div>
           ) : (
             <>

--- a/src/pages/AssignProjects.tsx
+++ b/src/pages/AssignProjects.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useDragAndDrop } from '@formkit/drag-and-drop/react'
-import { ArrowPathIcon } from '@heroicons/react/16/solid'
 import { toast, Toaster } from 'sonner'
 import Button from '@/components/Button'
 import {
@@ -18,6 +17,7 @@ import styles from './AssignProjects.module.css'
 import { useAuth } from '@/auth/useAuth'
 import { useGetUserProfile } from '@/hooks/useProfile'
 import type { UserGroup } from '@/types/profile'
+import LoadingSpinner from '@/components/LoadingSpinner'
 
 const formatDate = (dateString: string) => {
   return new Date(dateString).toLocaleDateString('en-GB', {
@@ -210,7 +210,7 @@ const AssignProjects = () => {
         onSuccess: () => {
           toast.success('Projects assigned successfully!')
           setTimeout(() => {
-            navigate('/tenants/view')
+            navigate('/tenants')
           }, 2000)
         },
         onError: (error: Error & { errors?: string[] }) => {
@@ -231,13 +231,13 @@ const AssignProjects = () => {
   }
 
   const handleCancel = () => {
-    navigate('/tenants/view')
+    navigate('/tenants')
   }
 
   if (!isInitialized) {
     return (
       <div className="loading-container">
-        <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+        <LoadingSpinner />
       </div>
     )
   }

--- a/src/pages/Build.tsx
+++ b/src/pages/Build.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowPathIcon,
   ArrowTopRightOnSquareIcon,
   CheckCircleIcon,
   Cog6ToothIcon,
@@ -34,6 +33,7 @@ import { toast, Toaster } from 'sonner'
 import SelectGroup from '@/components/SelectGroup'
 import { BanIcon, Columns2Icon, SquareIcon } from 'lucide-react'
 import { useDropzone } from 'react-dropzone'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import Button from '@/components/Button'
 import styles from './Build.module.css'
 
@@ -75,6 +75,9 @@ const Build = () => {
   const [filterItems, setFilterItems] = useState('')
   const reportsMutation = useReportsMutation()
 
+  // Track next group ID to avoid duplicate names when groups are deleted
+  const nextGroupIdRef = useRef(1)
+
   // Load existing page data in edit mode
   useEffect(() => {
     if (isEditMode && getPageQuery.data) {
@@ -90,6 +93,21 @@ const Build = () => {
       })
       setReport(pageData.report || '')
       setStatusGroups(pageData.config?.groups || [])
+
+      // Calculate the next group ID based on existing groups
+      const existingGroups = pageData.config?.groups || []
+      if (existingGroups.length > 0) {
+        const maxId = existingGroups.reduce((max, group) => {
+          const match = group.name.match(/^group-(\d+)$/)
+          if (match) {
+            const id = parseInt(match[1], 10)
+            return id > max ? id : max
+          }
+          return max
+        }, 0)
+        nextGroupIdRef.current = maxId + 1
+      }
+
       setSaved(true) // Already saved since we're editing
       setSelectIcon(pageData.config?.theming?.status.icon || 'led')
       setSelectText(pageData.config?.theming?.status.text || 'none')
@@ -116,14 +134,16 @@ const Build = () => {
   }, [isEditMode, JSON.stringify(getPageQuery.data)])
 
   const handleAddStatusGroup = () => {
+    const newGroupId = nextGroupIdRef.current
     setStatusGroups((prev) => [
       ...prev,
       {
-        name: `group-${prev.length + 1}`,
-        alias: `group-${prev.length + 1}`,
+        name: `group-${newGroupId}`,
+        alias: `group-${newGroupId}`,
         list: [],
       },
     ])
+    nextGroupIdRef.current = newGroupId + 1
   }
 
   const handleReportChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -418,7 +438,7 @@ const Build = () => {
   if (isEditMode && getPageQuery.isLoading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <ArrowPathIcon className="animate-spin size-8 text-blue-400" />
+        <LoadingSpinner size="md" />
         <span className="ml-2">Loading page data...</span>
       </div>
     )
@@ -607,7 +627,7 @@ const Build = () => {
                       >
                         {reportsMutation.isPending ? (
                           <>
-                            <ArrowPathIcon className="animate-spin size-4 text-blue-400" />
+                            <LoadingSpinner size="xs" />
                             <span>Connecting ...</span>
                           </>
                         ) : reportsMutation.data ? (
@@ -676,8 +696,7 @@ const Build = () => {
 
                           {groupsMutation.isPending && (
                             <div className="p-2 text-base mt-2 mx-auto">
-                              <ArrowPathIcon className="size-4 animate-spin inline-block me-2 text-blue-400" />{' '}
-                              Loading items...
+                              <LoadingSpinner size="xs" inline />
                             </div>
                           )}
 

--- a/src/pages/CreateProject.tsx
+++ b/src/pages/CreateProject.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { ArrowPathIcon } from '@heroicons/react/16/solid'
 import {
   useCreateProjectMutation,
   useUpdateProjectMutation,
   useGetProjectById,
 } from '@/hooks/useProjects'
 import { toast, Toaster } from 'sonner'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import Button from '../components/Button'
 import styles from './CreateTenant.module.css'
 
@@ -135,7 +135,7 @@ const CreateProject = () => {
           onSuccess: () => {
             toast.success('Project updated successfully!')
             setTimeout(() => {
-              navigate(`/projects/view`)
+              navigate(`/projects`)
             }, 2000)
           },
           onError: (error: Error & { errors?: string[] }) => {
@@ -159,7 +159,7 @@ const CreateProject = () => {
         onSuccess: () => {
           toast.success('Project created successfully!')
           setTimeout(() => {
-            navigate(`/projects/view`)
+            navigate(`/projects`)
           }, 2000)
         },
         onError: (error: Error & { errors?: string[] }) => {
@@ -203,7 +203,7 @@ const CreateProject = () => {
       <div className="page-container">
         {isEditMode && isProjectLoading ? (
           <div className="loading-container">
-            <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+            <LoadingSpinner />
           </div>
         ) : (
           <>

--- a/src/pages/CreateTenant.tsx
+++ b/src/pages/CreateTenant.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useDropzone } from 'react-dropzone'
-import { ArrowPathIcon, PhotoIcon, XMarkIcon } from '@heroicons/react/16/solid'
+import { PhotoIcon, XMarkIcon } from '@heroicons/react/16/solid'
 import {
   useCreateTenantMutation,
   useUpdateTenantMutation,
@@ -15,6 +15,7 @@ import { toast, Toaster } from 'sonner'
 import Button from '../components/Button'
 import ContactInformation from '../components/ContactInformation'
 import InfrastructureMetadata from '../components/InfrastructureMetadata'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import styles from './CreateTenant.module.css'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
@@ -286,7 +287,7 @@ const CreateTenant = () => {
           onSuccess: () => {
             toast.success('Tenant updated successfully!')
             setTimeout(() => {
-              navigate(`/tenants/view`)
+              navigate(`/tenants`)
             }, 2000)
           },
           onError: (error: Error & { errors?: string[] }) => {
@@ -312,7 +313,7 @@ const CreateTenant = () => {
           onSuccess: () => {
             toast.success('Tenant created successfully!')
             setTimeout(() => {
-              navigate(`/tenants/view`)
+              navigate(`/tenants`)
             }, 2000)
           },
           onError: (error: Error & { errors?: string[] }) => {
@@ -436,7 +437,7 @@ const CreateTenant = () => {
       <div className="page-container">
         {isEditMode && isTenantLoading ? (
           <div className="loading-container">
-            <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+            <LoadingSpinner />
           </div>
         ) : (
           <>

--- a/src/pages/InvitationReview.tsx
+++ b/src/pages/InvitationReview.tsx
@@ -1,16 +1,13 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import {
-  ArrowPathIcon,
-  CheckCircleIcon,
-  XCircleIcon,
-} from '@heroicons/react/24/outline'
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline'
 import { useAuth } from '@/auth/useAuth'
 import {
   useGetUserInvitationById,
   useRespondToInvitation,
 } from '@/hooks/useInvitations'
 import Button from '@/components/Button'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import { Toaster, toast } from 'sonner'
 import styles from './InvitationReview.module.css'
 
@@ -50,7 +47,7 @@ export const InvitationReview = () => {
         onSuccess: () => {
           toast.success('Invitation accepted successfully!')
           setTimeout(() => {
-            navigate('/tenants/view')
+            navigate('/tenants')
           }, 2000)
         },
         onError: (error) => {
@@ -89,7 +86,7 @@ export const InvitationReview = () => {
     return (
       <div className={styles.container}>
         <div className={styles.loading}>
-          <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+          <LoadingSpinner />
           <p>Loading invitation...</p>
         </div>
       </div>
@@ -148,7 +145,7 @@ export const InvitationReview = () => {
                 <Button
                   variant="primary"
                   size="md"
-                  onClick={() => navigate('/tenants/view')}
+                  onClick={() => navigate('/tenants')}
                 >
                   View Tenants
                 </Button>
@@ -204,7 +201,7 @@ export const InvitationReview = () => {
                 <label className={styles.label}>Invited On</label>
                 <div className={styles.value}>
                   {invitation?.created_at
-                    ? new Date(invitation.created_at).toLocaleString('en-US', {
+                    ? new Date(invitation.created_at).toLocaleString('en-GB', {
                         year: 'numeric',
                         month: 'long',
                         day: 'numeric',
@@ -241,7 +238,7 @@ export const InvitationReview = () => {
               {isProcessing &&
               respondMutation.variables?.data.action === 'REJECT' ? (
                 <>
-                  <ArrowPathIcon className="animate-spin size-5" />
+                  <LoadingSpinner size="sm" />
                   Rejecting...
                 </>
               ) : (
@@ -260,7 +257,7 @@ export const InvitationReview = () => {
               {isProcessing &&
               respondMutation.variables?.data.action === 'ACCEPT' ? (
                 <>
-                  <ArrowPathIcon className="animate-spin size-5" />
+                  <LoadingSpinner size="sm" />
                   Accepting...
                 </>
               ) : (

--- a/src/pages/ManageTenantMembers.tsx
+++ b/src/pages/ManageTenantMembers.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/hooks/useTenants'
 import { useAuth } from '@/auth/useAuth'
 import {
-  ArrowPathIcon,
   ArrowLeftIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -23,6 +22,7 @@ import ConfirmDialog from '@/components/ConfirmDialog'
 import TenantInvitations from './TenantInvitations'
 import styles from './ManageTenantMembers.module.css'
 import type { InvitationRole } from '@/types/invitations'
+import LoadingSpinner from '@/components/LoadingSpinner'
 
 const roleOptions = [
   { label: 'Tenant Admin', value: 'admin' as InvitationRole },
@@ -282,7 +282,7 @@ const ManageTenantMembers = () => {
   }
 
   const handleBack = () => {
-    navigate('/tenants/view')
+    navigate('/tenants')
   }
 
   const isLoading = membersLoading
@@ -338,7 +338,7 @@ const ManageTenantMembers = () => {
 
         {isLoading ? (
           <div className="loading-container">
-            <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+            <LoadingSpinner />
           </div>
         ) : (
           <>
@@ -569,7 +569,7 @@ const ManageTenantMembers = () => {
                               <div className={styles['search-results']}>
                                 {searchLoading ? (
                                   <div className={styles['search-loading']}>
-                                    <ArrowPathIcon className="animate-spin size-5 text-blue-400" />
+                                    <LoadingSpinner size="sm" />
                                     <span>Searching...</span>
                                   </div>
                                 ) : searchResults &&

--- a/src/pages/MyInvitations.tsx
+++ b/src/pages/MyInvitations.tsx
@@ -4,13 +4,13 @@ import {
   useRespondToInvitation,
 } from '@/hooks/useInvitations'
 import {
-  ArrowPathIcon,
   CheckCircleIcon,
   XCircleIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
 } from '@heroicons/react/24/solid'
 import { toast, Toaster } from 'sonner'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import styles from './MyInvitations.module.css'
 
 const pageSize = 10
@@ -55,7 +55,7 @@ const MyInvitations = () => {
 
         {isLoading ? (
           <div className="loading-container">
-            <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+            <LoadingSpinner />
           </div>
         ) : (
           <>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { UserCircleIcon, ArrowPathIcon } from '@heroicons/react/16/solid'
+import { UserCircleIcon } from '@heroicons/react/16/solid'
 import { ArrowLeftIcon, UserMinusIcon } from '@heroicons/react/24/solid'
 import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import { useState } from 'react'
@@ -9,6 +9,7 @@ import {
   useRemoveMemberFromTenant,
 } from '@/hooks/useTenants'
 import { squishEmail } from '@/utils/profile'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import Button from '@/components/Button'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import { toast, Toaster } from 'sonner'
@@ -103,7 +104,7 @@ export const Profile = () => {
   if (isLoading) {
     return (
       <div className="loading-container">
-        <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+        <LoadingSpinner />
       </div>
     )
   }

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useGetProjects, useDeleteProjectMutation } from '@/hooks/useProjects'
 import {
-  ArrowPathIcon,
   PencilSquareIcon,
   TrashIcon,
   ChevronLeftIcon,
@@ -9,6 +8,7 @@ import {
   MagnifyingGlassIcon,
 } from '@heroicons/react/16/solid'
 import Button from '@/components/Button'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import { useNavigate } from 'react-router-dom'
 import { toast, Toaster } from 'sonner'
@@ -154,7 +154,7 @@ const Projects = () => {
 
       {isLoading ? (
         <div className="loading-container">
-          <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+          <LoadingSpinner />
         </div>
       ) : (
         <div className={styles.grid}>

--- a/src/pages/Status.tsx
+++ b/src/pages/Status.tsx
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router-dom'
 import {
-  ArrowPathIcon,
   ArrowDownCircleIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -10,6 +9,7 @@ import {
 } from '@heroicons/react/16/solid'
 import { useGetStatusQuery } from '@/hooks/useStatus'
 import ViewGroup from '@/components/ViewGroup'
+import LoadingSpinner from '@/components/LoadingSpinner'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 
@@ -23,7 +23,7 @@ export const Status = () => {
       <div className="container mx-auto max-w-5xl">
         {isLoading ? (
           <div className="flex flex-col items-center justify-center mt-32">
-            <ArrowPathIcon className="size-10 animate-spin text-blue-400 mb-4" />
+            <LoadingSpinner />
             <div className="text-lg text-gray-600">Loading status page...</div>
           </div>
         ) : statusData ? (

--- a/src/pages/TenantDetails.module.css
+++ b/src/pages/TenantDetails.module.css
@@ -21,7 +21,7 @@
 }
 
 .card {
-  background-color: white;
+  background-color: #f9fafb;
   border: 1px solid #e5e7eb;
   border-radius: 0.5rem;
   padding: 1rem 1.5rem;
@@ -37,13 +37,13 @@
 .card-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 .info-group {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.1rem;
 }
 
 .label {
@@ -85,7 +85,7 @@
   border-radius: 0.5rem;
   border: 1px solid #e5e7eb;
   padding: 0.5rem;
-  background-color: #f9fafb;
+  background-color: white;
 }
 
 .contacts-grid {
@@ -127,6 +127,7 @@
 
 .metadata-subsection {
   padding-top: 0.5rem;
+  padding-bottom: 0.1rem;
   border-top: 1px solid #e5e7eb;
 }
 
@@ -169,6 +170,42 @@
   color: #dc2626;
   font-size: 1rem;
   font-weight: 500;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 2px solid #e5e7eb;
+  margin-bottom: 1.5rem;
+}
+
+.tab {
+  padding: 0.75rem 1.5rem 0.5rem 1.5rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: #6b7280;
+  background: none;
+  border: none;
+  border-radius: 0.375rem 0.375rem 0 0;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-bottom: -2px;
+}
+
+.tab:hover {
+  color: #374151;
+  background: #f9fafb;
+  border-bottom-color: #d1d5db;
+}
+
+.tab-active {
+  color: #3b82f6;
+  border-bottom-color: #3b82f6;
+}
+
+.tab-active:hover {
+  border-bottom-color: #3b82f6;
 }
 
 @media (max-width: 768px) {

--- a/src/pages/TenantDetails.tsx
+++ b/src/pages/TenantDetails.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowPathIcon, ArrowLeftIcon } from '@heroicons/react/24/outline'
+import { ArrowLeftIcon } from '@heroicons/react/24/outline'
 import { useAuth } from '../auth/useAuth'
 import { useGetTenantById, useGetUserTenantById } from '../hooks/useTenants'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import TenantReports from './TenantReports'
 import styles from './TenantDetails.module.css'
 import Button from '@/components/Button'
 
@@ -9,6 +12,7 @@ const TenantDetails = () => {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { profile } = useAuth()
+  const [activeTab, setActiveTab] = useState<'details' | 'reports'>('details')
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
 
@@ -28,7 +32,7 @@ const TenantDetails = () => {
     return (
       <div className="page-container">
         <div className="loading-container">
-          <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+          <LoadingSpinner />
         </div>
       </div>
     )
@@ -59,7 +63,7 @@ const TenantDetails = () => {
           </p>
         </div>
         <Button
-          onClick={() => navigate('/tenants/view')}
+          onClick={() => navigate('/tenants')}
           size="sm"
           variant="secondary"
         >
@@ -68,183 +72,164 @@ const TenantDetails = () => {
         </Button>
       </div>
 
-      {/* Tenant Information */}
-      <div className={styles.section}>
-        <div className={styles['section-header']}>
-          <h2 className={styles['section-title']}>Tenant Information</h2>
-        </div>
-        <div className={styles.card}>
-          <div className={styles['card-row']}>
-            <div className={styles['info-group']}>
-              <label className={styles.label}>Name</label>
-              <p className={styles.value}>{info.name}</p>
-            </div>
-            <div className={styles['info-group']}>
-              <label className={styles.label}>Email</label>
-              <p className={styles.value}>{info.email}</p>
-            </div>
-          </div>
-
-          <div className={styles['card-row']}>
-            <div className={styles['info-group']}>
-              <label className={styles.label}>Description</label>
-              <p className={styles.value}>
-                {info.description || (
-                  <span className={styles['no-data']}>No description</span>
-                )}
-              </p>
-            </div>
-          </div>
-
-          {(info.created_at || info.updated_at) && (
-            <div className={styles['card-row']}>
-              {info.created_at && (
-                <div className={styles['info-group']}>
-                  <label className={styles.label}>Created At</label>
-                  <p className={styles.value}>
-                    {new Date(info.created_at).toLocaleString()}
-                  </p>
-                </div>
-              )}
-              {info.updated_at && (
-                <div className={styles['info-group']}>
-                  <label className={styles.label}>Last Updated</label>
-                  <p className={styles.value}>
-                    {new Date(info.updated_at).toLocaleString()}
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
-
-          <div className={styles['card-row']}>
-            <div className={styles['info-group']}>
-              <label className={styles.label}>Website</label>
-              <p className={styles.value}>
-                {info.website ? (
-                  <a
-                    href={info.website}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={styles.link}
-                  >
-                    {info.website}
-                  </a>
-                ) : (
-                  <span className={styles['no-data']}>Not provided</span>
-                )}
-              </p>
-            </div>
-            <div className={styles['info-group']}>
-              <label className={styles.label}>Logo</label>
-              {info.image ? (
-                <img
-                  src={info.image}
-                  alt={`${info.name} logo`}
-                  className={styles.logo}
-                />
-              ) : (
-                <span className={styles['no-data']}>No logo</span>
-              )}
-            </div>
-          </div>
-        </div>
+      <div className={styles.tabs}>
+        <button
+          className={`${styles.tab} ${activeTab === 'details' ? styles['tab-active'] : ''}`}
+          onClick={() => setActiveTab('details')}
+        >
+          Tenant Details
+        </button>
+        <button
+          className={`${styles.tab} ${activeTab === 'reports' ? styles['tab-active'] : ''}`}
+          onClick={() => setActiveTab('reports')}
+        >
+          Reports
+        </button>
       </div>
 
-      {/* Contacts */}
-      <div className={styles.section}>
-        <div className={styles['section-header']}>
-          <h2 className={styles['section-title']}>Contacts</h2>
-        </div>
-        {contacts && contacts.length > 0 ? (
-          <div className={styles['contacts-grid']}>
-            {contacts.map((contact, index) => (
-              <div key={index} className={styles['card']}>
-                <div className={styles['contact-info']}>
-                  <p className={styles['contact-name']}>{contact.name}</p>
-                  <p className={styles['contact-email']}>{contact.email}</p>
-                  {contact.type && (
-                    <span className={styles['contact-type']}>
-                      {contact.type}
-                    </span>
+      {activeTab === 'details' && (
+        <>
+          {/* Tenant Information */}
+          <div className={styles.section}>
+            <div className={styles['section-header']}>
+              <h2 className={styles['section-title']}>Tenant Information</h2>
+            </div>
+            <div className={styles.card}>
+              <div className={styles['card-row']}>
+                <div className={styles['info-group']}>
+                  <label className={styles.label}>Name</label>
+                  <p className={styles.value}>{info.name}</p>
+                </div>
+                <div className={styles['info-group']}>
+                  <label className={styles.label}>Email</label>
+                  <p className={styles.value}>{info.email}</p>
+                </div>
+              </div>
+
+              <div className={styles['card-row']}>
+                <div className={styles['info-group']}>
+                  <label className={styles.label}>Description</label>
+                  <p className={styles.value}>
+                    {info.description || (
+                      <span className={styles['no-data']}>Not provided</span>
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              {(info.created_at || info.updated_at) && (
+                <div className={styles['card-row']}>
+                  {info.created_at && (
+                    <div className={styles['info-group']}>
+                      <label className={styles.label}>Created At</label>
+                      <p className={styles.value}>
+                        {new Date(info.created_at).toLocaleString()}
+                      </p>
+                    </div>
+                  )}
+                  {info.updated_at && (
+                    <div className={styles['info-group']}>
+                      <label className={styles.label}>Last Updated</label>
+                      <p className={styles.value}>
+                        {new Date(info.updated_at).toLocaleString()}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <div className={styles['card-row']}>
+                <div className={styles['info-group']}>
+                  <label className={styles.label}>Website</label>
+                  <p className={styles.value}>
+                    {info.website ? (
+                      <a
+                        href={info.website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={styles.link}
+                      >
+                        {info.website}
+                      </a>
+                    ) : (
+                      <span className={styles['no-data']}>Not provided</span>
+                    )}
+                  </p>
+                </div>
+                <div className={styles['info-group']}>
+                  <label className={styles.label}>Logo</label>
+                  {info.image ? (
+                    <img className={styles.logo} src={info.image} />
+                  ) : (
+                    <span className={styles['no-data']}>Not provided</span>
                   )}
                 </div>
               </div>
-            ))}
+            </div>
           </div>
-        ) : (
-          <div className={styles.card}>
-            <p className={styles['no-data']}>No contacts available</p>
+
+          {/* Contacts */}
+          <div className={styles.section}>
+            <div className={styles['section-header']}>
+              <h2 className={styles['section-title']}>Contacts</h2>
+            </div>
+            {contacts && contacts.length > 0 ? (
+              <div className={styles['contacts-grid']}>
+                {contacts.map((contact, index) => (
+                  <div key={index} className={styles['card']}>
+                    <div className={styles['contact-info']}>
+                      <p className={styles['contact-name']}>{contact.name}</p>
+                      <p className={styles['contact-email']}>{contact.email}</p>
+                      {contact.type && (
+                        <span className={styles['contact-type']}>
+                          {contact.type}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className={styles.card}>
+                <p className={styles['no-data']}>No contacts available</p>
+              </div>
+            )}
           </div>
-        )}
-      </div>
 
-      {/* Infrastructure Metadata */}
-      <div className={styles.section}>
-        <div className={styles['section-header']}>
-          <h2 className={styles['section-title']}>Infrastructure Metadata</h2>
-        </div>
-        {metadata &&
-        (metadata.instance ||
-          metadata.internalLists ||
-          metadata.auth_metadata) ? (
-          <div
-            className={`${styles.card} ${styles['infrastructure-metadata']}`}
-          >
-            {/* Instance Information */}
-            {metadata.instance && (
-              <>
-                <div className={styles['metadata-subsection']}>
-                  <h3 className={styles['subsection-title']}>Instance</h3>
-                </div>
-                <div className={styles['card-row']}>
-                  <div className={styles['info-group']}>
-                    <label className={styles.label}>UI URL</label>
-                    <p className={styles.value}>
-                      {metadata.instance.ui_url ? (
-                        <a
-                          href={metadata.instance.ui_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={styles.link}
-                        >
-                          {metadata.instance.ui_url}
-                        </a>
-                      ) : (
-                        <span className={styles['no-data']}>Not provided</span>
-                      )}
-                    </p>
-                  </div>
-                  <div className={styles['info-group']}>
-                    <label className={styles.label}>POEM URL</label>
-                    <p className={styles.value}>
-                      {metadata.instance.poem_url ? (
-                        <a
-                          href={metadata.instance.poem_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={styles.link}
-                        >
-                          {metadata.instance.poem_url}
-                        </a>
-                      ) : (
-                        <span className={styles['no-data']}>Not provided</span>
-                      )}
-                    </p>
-                  </div>
-                </div>
-
-                {/* Topology */}
-                {metadata.instance.topology && (
+          {/* Infrastructure Metadata */}
+          <div className={styles.section}>
+            <div className={styles['section-header']}>
+              <h2 className={styles['section-title']}>
+                Infrastructure Metadata
+              </h2>
+            </div>
+            {metadata &&
+            (metadata.instance ||
+              metadata.internalLists ||
+              metadata.auth_metadata) ? (
+              <div
+                className={`${styles.card} ${styles['infrastructure-metadata']}`}
+              >
+                {/* Instance Information */}
+                {metadata.instance && (
                   <>
                     <div className={styles['metadata-subsection']}>
-                      <h3 className={styles['subsection-title']}>Topology</h3>
+                      <h3 className={styles['subsection-title']}>Instance</h3>
                     </div>
                     <div className={styles['card-row']}>
                       <div className={styles['info-group']}>
-                        <label className={styles.label}>Type</label>
+                        <label className={styles.label}>UI URL</label>
                         <p className={styles.value}>
-                          {metadata.instance.topology.type || (
+                          {metadata.instance.ui_url ? (
+                            <a
+                              href={metadata.instance.ui_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={styles.link}
+                            >
+                              {metadata.instance.ui_url}
+                            </a>
+                          ) : (
                             <span className={styles['no-data']}>
                               Not provided
                             </span>
@@ -252,16 +237,16 @@ const TenantDetails = () => {
                         </p>
                       </div>
                       <div className={styles['info-group']}>
-                        <label className={styles.label}>URL</label>
+                        <label className={styles.label}>POEM URL</label>
                         <p className={styles.value}>
-                          {metadata.instance.topology.url ? (
+                          {metadata.instance.poem_url ? (
                             <a
-                              href={metadata.instance.topology.url}
+                              href={metadata.instance.poem_url}
                               target="_blank"
                               rel="noopener noreferrer"
                               className={styles.link}
                             >
-                              {metadata.instance.topology.url}
+                              {metadata.instance.poem_url}
                             </a>
                           ) : (
                             <span className={styles['no-data']}>
@@ -271,11 +256,124 @@ const TenantDetails = () => {
                         </p>
                       </div>
                     </div>
+
+                    {/* Topology */}
+                    {metadata.instance.topology && (
+                      <>
+                        <div className={styles['metadata-subsection']}>
+                          <h3 className={styles['subsection-title']}>
+                            Topology
+                          </h3>
+                        </div>
+                        <div className={styles['card-row']}>
+                          <div className={styles['info-group']}>
+                            <label className={styles.label}>Type</label>
+                            <p className={styles.value}>
+                              {metadata.instance.topology.type || (
+                                <span className={styles['no-data']}>
+                                  Not provided
+                                </span>
+                              )}
+                            </p>
+                          </div>
+                          <div className={styles['info-group']}>
+                            <label className={styles.label}>URL</label>
+                            <p className={styles.value}>
+                              {metadata.instance.topology.url ? (
+                                <a
+                                  href={metadata.instance.topology.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className={styles.link}
+                                >
+                                  {metadata.instance.topology.url}
+                                </a>
+                              ) : (
+                                <span className={styles['no-data']}>
+                                  Not provided
+                                </span>
+                              )}
+                            </p>
+                          </div>
+                        </div>
+                        <div className={styles['card-row']}>
+                          <div className={styles['info-group']}>
+                            <label className={styles.label}>Feed</label>
+                            <p className={styles.value}>
+                              {metadata.instance.topology.feed || (
+                                <span className={styles['no-data']}>
+                                  Not provided
+                                </span>
+                              )}
+                            </p>
+                          </div>
+                        </div>
+                      </>
+                    )}
+                  </>
+                )}
+
+                {/* Internal Lists */}
+                {metadata.internalLists &&
+                  metadata.internalLists.length > 0 && (
+                    <>
+                      <div className={styles['metadata-subsection']}>
+                        <h3 className={styles['subsection-title']}>
+                          Internal Lists
+                        </h3>
+                      </div>
+                      <div className={styles['internal-lists']}>
+                        {metadata.internalLists.map((list, index) => (
+                          <div
+                            key={index}
+                            className={styles['internal-list-item']}
+                          >
+                            <div className={styles['info-group']}>
+                              <label className={styles.label}>Email</label>
+                              <p className={styles.value}>{list.email}</p>
+                            </div>
+                            <div className={styles['info-group']}>
+                              <label className={styles.label}>Type</label>
+                              <p className={styles.value}>{list.type}</p>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  )}
+
+                {/* Authentication Metadata */}
+                {metadata.auth_metadata && (
+                  <>
+                    <div className={styles['metadata-subsection']}>
+                      <h3 className={styles['subsection-title']}>
+                        Authentication
+                      </h3>
+                    </div>
                     <div className={styles['card-row']}>
                       <div className={styles['info-group']}>
-                        <label className={styles.label}>Feed</label>
+                        <label className={styles.label}>Auth Name</label>
                         <p className={styles.value}>
-                          {metadata.instance.topology.feed || (
+                          {metadata.auth_metadata.auth_name || (
+                            <span className={styles['no-data']}>
+                              Not provided
+                            </span>
+                          )}
+                        </p>
+                      </div>
+                      <div className={styles['info-group']}>
+                        <label className={styles.label}>Auth URL</label>
+                        <p className={styles.value}>
+                          {metadata.auth_metadata.auth_url ? (
+                            <a
+                              href={metadata.auth_metadata.auth_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={styles.link}
+                            >
+                              {metadata.auth_metadata.auth_url}
+                            </a>
+                          ) : (
                             <span className={styles['no-data']}>
                               Not provided
                             </span>
@@ -285,76 +383,19 @@ const TenantDetails = () => {
                     </div>
                   </>
                 )}
-              </>
-            )}
-
-            {/* Internal Lists */}
-            {metadata.internalLists && metadata.internalLists.length > 0 && (
-              <>
-                <div className={styles['metadata-subsection']}>
-                  <h3 className={styles['subsection-title']}>Internal Lists</h3>
-                </div>
-                <div className={styles['internal-lists']}>
-                  {metadata.internalLists.map((list, index) => (
-                    <div key={index} className={styles['internal-list-item']}>
-                      <div className={styles['info-group']}>
-                        <label className={styles.label}>Email</label>
-                        <p className={styles.value}>{list.email}</p>
-                      </div>
-                      <div className={styles['info-group']}>
-                        <label className={styles.label}>Type</label>
-                        <p className={styles.value}>{list.type}</p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </>
-            )}
-
-            {/* Authentication Metadata */}
-            {metadata.auth_metadata && (
-              <>
-                <div className={styles['metadata-subsection']}>
-                  <h3 className={styles['subsection-title']}>Authentication</h3>
-                </div>
-                <div className={styles['card-row']}>
-                  <div className={styles['info-group']}>
-                    <label className={styles.label}>Auth Name</label>
-                    <p className={styles.value}>
-                      {metadata.auth_metadata.auth_name || (
-                        <span className={styles['no-data']}>Not provided</span>
-                      )}
-                    </p>
-                  </div>
-                  <div className={styles['info-group']}>
-                    <label className={styles.label}>Auth URL</label>
-                    <p className={styles.value}>
-                      {metadata.auth_metadata.auth_url ? (
-                        <a
-                          href={metadata.auth_metadata.auth_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={styles.link}
-                        >
-                          {metadata.auth_metadata.auth_url}
-                        </a>
-                      ) : (
-                        <span className={styles['no-data']}>Not provided</span>
-                      )}
-                    </p>
-                  </div>
-                </div>
-              </>
+              </div>
+            ) : (
+              <div className={styles.card}>
+                <p className={styles['no-data']}>
+                  No infrastructure metadata available
+                </p>
+              </div>
             )}
           </div>
-        ) : (
-          <div className={styles.card}>
-            <p className={styles['no-data']}>
-              No infrastructure metadata available
-            </p>
-          </div>
-        )}
-      </div>
+        </>
+      )}
+
+      {activeTab === 'reports' && <TenantReports tenantId={id || ''} />}
     </div>
   )
 }

--- a/src/pages/TenantReports.module.css
+++ b/src/pages/TenantReports.module.css
@@ -1,0 +1,497 @@
+.reports-container {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 2.5rem;
+  min-height: 500px;
+}
+
+.reports-sidebar {
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  height: fit-content;
+  max-height: calc(100vh - 300px);
+  overflow-y: auto;
+}
+
+.sidebar-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 0.75rem;
+}
+
+.sidebar-loading {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 0;
+}
+
+.reports-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.report-item {
+  padding: 0.75rem;
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.report-item:not(.report-item-active):hover {
+  border-color: #d1d5db;
+  background-color: #fafafa;
+}
+
+.report-item-active {
+  border-color: #3b82f6;
+  background-color: #eff6ff;
+}
+
+.report-item-active:hover {
+  opacity: 0.85;
+}
+
+.report-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.report-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #111827;
+  word-break: break-word;
+}
+
+.report-item-description {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin: 0.5rem 0 0 0;
+  line-height: 1.4;
+}
+
+.reports-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.section {
+  margin-bottom: 0.5rem;
+}
+
+.section-header {
+  margin-bottom: 0.25rem;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.card {
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.report-info-header {
+  margin-bottom: 0.3rem;
+  padding-bottom: 0.3rem;
+}
+
+.report-main-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.report-subtitle {
+  font-size: 0.9375rem;
+  color: #6b7280;
+  margin: 0 0 0.6rem 0;
+  line-height: 1.5;
+}
+
+.report-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: 0.5rem;
+  column-gap: 1rem;
+  align-items: center;
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.meta-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.meta-value {
+  font-size: 0.8125rem;
+  color: #111827;
+}
+
+.no-data {
+  color: #9ca3af;
+  font-style: italic;
+  text-align: center;
+}
+
+.status-enabled {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 9999px;
+  background-color: #d1fae5;
+  color: #065f46;
+  border: 1px solid #6ee7b7;
+}
+
+.status-disabled {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 9999px;
+  background-color: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+.profiles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 0.5rem;
+}
+
+.computations-card {
+  background-color: white;
+}
+
+.computations-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.computation-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: #fafafa;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  gap: 0.5rem;
+}
+
+.computation-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  line-height: 1.4;
+  flex: 1;
+  word-wrap: break-word;
+}
+
+.thresholds-card {
+  background-color: white;
+}
+
+.thresholds-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.threshold-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: #fafafa;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  gap: 0.5rem;
+}
+
+.threshold-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  line-height: 1.4;
+  flex: 1;
+  word-wrap: break-word;
+}
+
+.threshold-value {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  border-radius: 9999px;
+  background-color: #dcfce7;
+  color: #15803d;
+  border: 1px solid #86efac;
+  white-space: nowrap;
+}
+
+.topology-card {
+  background-color: white;
+}
+
+.topology-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.topology-node {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.topology-node-icon {
+  font-size: 1rem;
+  color: #3b82f6;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.topology-node-content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.topology-node-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.topology-node-value {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  border-radius: 0.375rem;
+  background-color: #dbeafe;
+  color: #1e40af;
+  border: 1px solid #93c5fd;
+}
+
+.topology-node-child {
+  display: flex;
+  align-items: center;
+  margin-left: 0.5rem;
+}
+
+.topology-connector {
+  width: 1.5rem;
+  height: 2rem;
+  border-left: 2px solid #d1d5db;
+  border-bottom: 2px solid #d1d5db;
+  border-bottom-left-radius: 0.5rem;
+  margin-right: -0.75rem;
+  flex-shrink: 0;
+}
+
+.profile-card {
+  position: relative;
+  padding: 1.25rem 1rem;
+  border-width: 1px;
+  transition: all 0.2s;
+}
+
+.profile-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.profile-type-badge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  border-radius: 0.25rem;
+  letter-spacing: 0.025em;
+}
+
+.profile-name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #111827;
+  word-break: break-word;
+}
+
+.profile-metric {
+  background-color: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.profile-metric .profile-type-badge {
+  background-color: #dbeafe;
+  color: #1e40af;
+  border: 1px solid #93c5fd;
+}
+
+.profile-aggregation {
+  background-color: #faf5ff;
+  border-color: #e9d5ff;
+}
+
+.profile-aggregation .profile-type-badge {
+  background-color: #f3e8ff;
+  color: #7e22ce;
+  border: 1px solid #d8b4fe;
+}
+
+.profile-operations {
+  background-color: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
+.profile-operations .profile-type-badge {
+  background-color: #dcfce7;
+  color: #15803d;
+  border: 1px solid #86efac;
+}
+
+.metric-profiles-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profiles-two-column {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.profiles-card {
+  background-color: white;
+}
+
+.profile-section-subtitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 0.75rem 0;
+}
+
+.profiles-grid-simple {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.profile-simple-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: #fafafa;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  gap: 0.5rem;
+}
+
+.profile-simple-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  line-height: 1.4;
+  flex: 1;
+  word-wrap: break-word;
+}
+
+.profile-type-badge-simple {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
+.badge-aggregation {
+  background-color: #dbeafe;
+  color: #1e40af;
+  border: 1px solid #93c5fd;
+}
+
+.badge-operations {
+  background-color: #dbeafe;
+  color: #1e40af;
+  border: 1px solid #93c5fd;
+}
+
+@media (max-width: 1024px) {
+  .reports-container {
+    grid-template-columns: 1fr;
+  }
+
+  .reports-sidebar {
+    max-height: 400px;
+  }
+
+  .card-row {
+    grid-template-columns: 1fr;
+  }
+
+  .profiles-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .computations-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .thresholds-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .profiles-grid-simple {
+    grid-template-columns: 1fr;
+  }
+
+  .profiles-two-column {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}

--- a/src/pages/TenantReports.tsx
+++ b/src/pages/TenantReports.tsx
@@ -1,0 +1,403 @@
+import { useState, useEffect } from 'react'
+import { useGetTenantReports, useGetTenantReportById } from '@/hooks/useTenants'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import MetricProfileItem from '@/components/MetricProfileItem'
+import styles from './TenantReports.module.css'
+
+const TenantReports = ({ tenantId }: { tenantId: string }) => {
+  const [selectedReportId, setSelectedReportId] = useState<string | null>(null)
+  const [expandedServices, setExpandedServices] = useState<
+    Record<string, Set<string>>
+  >({})
+
+  const { data: reportsData, isLoading: reportsLoading } = useGetTenantReports(
+    tenantId,
+    undefined,
+    true,
+  )
+
+  const { data: reportDetail, isLoading: reportDetailLoading } =
+    useGetTenantReportById(tenantId, selectedReportId || '', !!selectedReportId)
+
+  // Auto-select first report when reports data loads
+  useEffect(() => {
+    if (reportsData && reportsData.length > 0 && !selectedReportId) {
+      setSelectedReportId(reportsData[0].id)
+    }
+  }, [reportsData, selectedReportId])
+
+  const toggleService = (profileId: string, serviceName: string) => {
+    setExpandedServices((prev) => {
+      const profileServices = prev[profileId] || new Set()
+      const newServices = new Set(profileServices)
+      if (newServices.has(serviceName)) {
+        newServices.delete(serviceName)
+      } else {
+        newServices.add(serviceName)
+      }
+      return { ...prev, [profileId]: newServices }
+    })
+  }
+
+  const toggleAllServices = (
+    profileId: string,
+    allServices: string[],
+    expand: boolean,
+  ) => {
+    setExpandedServices((prev) => ({
+      ...prev,
+      [profileId]: expand ? new Set(allServices) : new Set(),
+    }))
+  }
+
+  return (
+    <div className={styles['reports-container']}>
+      <div className={styles['reports-sidebar']}>
+        <h3 className={styles['sidebar-title']}>Available Reports</h3>
+        {reportsLoading ? (
+          <div className={styles['sidebar-loading']}>
+            <LoadingSpinner size="sm" />
+          </div>
+        ) : reportsData && reportsData.length > 0 ? (
+          <ul className={styles['reports-list']}>
+            {reportsData.map((report) => (
+              <li
+                key={report.id}
+                className={`${styles['report-item']} ${selectedReportId === report.id ? styles['report-item-active'] : ''}`}
+                onClick={() => setSelectedReportId(report.id)}
+              >
+                <div className={styles['report-item-header']}>
+                  <span className={styles['report-name']}>{report.name}</span>
+                </div>
+                {report.description && (
+                  <p className={styles['report-item-description']}>
+                    {report.description}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className={styles['no-data']}>No reports available</p>
+        )}
+      </div>
+
+      <div className={styles['reports-content']}>
+        {reportDetailLoading ? (
+          <div className="loading-container">
+            <LoadingSpinner />
+          </div>
+        ) : reportDetail ? (
+          <>
+            {/* Info Header */}
+            <div className={styles['report-info-header']}>
+              <h1 className={styles['report-main-title']}>
+                {reportDetail.info.name}
+              </h1>
+              <p className={styles['report-subtitle']}>
+                {reportDetail.info.description || (
+                  <span className={styles['no-data']}>
+                    No description available
+                  </span>
+                )}
+              </p>
+              <div className={styles['report-meta-row']}>
+                <div className={styles['meta-item']}>
+                  <span className={styles['meta-label']}>Status:</span>
+                  {reportDetail.disabled ? (
+                    <span className={styles['status-disabled']}>Disabled</span>
+                  ) : (
+                    <span className={styles['status-enabled']}>Active</span>
+                  )}
+                </div>
+                <div className={styles['meta-item']}>
+                  <span className={styles['meta-label']}>Report ID:</span>
+                  <span className={styles['meta-value']}>
+                    {reportDetail.id}
+                  </span>
+                </div>
+                <div className={styles['meta-item']}>
+                  <span className={styles['meta-label']}>Created:</span>
+                  <span className={styles['meta-value']}>
+                    {new Date(reportDetail.info.created).toLocaleString(
+                      'en-GB',
+                      {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      },
+                    )}
+                  </span>
+                </div>
+                <div className={styles['meta-item']}>
+                  <span className={styles['meta-label']}>Last Updated:</span>
+                  <span className={styles['meta-value']}>
+                    {new Date(reportDetail.info.updated).toLocaleString(
+                      'en-GB',
+                      {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      },
+                    )}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Metric Profile */}
+            {reportDetail.profiles &&
+              reportDetail.profiles.filter((p) => p.type === 'metric').length >
+                0 && (
+                <div className={styles.section}>
+                  <div className={styles['section-header']}>
+                    <h2 className={styles['section-title']}>Metric Profile</h2>
+                  </div>
+                  <div className={styles['metric-profiles-container']}>
+                    {reportDetail.profiles
+                      .filter((p) => p.type === 'metric')
+                      .map((profile) => (
+                        <MetricProfileItem
+                          key={profile.id}
+                          tenantId={tenantId}
+                          profile={profile}
+                          expandedServices={
+                            expandedServices[profile.id] || new Set()
+                          }
+                          onToggleService={(serviceName) =>
+                            toggleService(profile.id, serviceName)
+                          }
+                          onToggleAll={(allServices, expand) =>
+                            toggleAllServices(profile.id, allServices, expand)
+                          }
+                        />
+                      ))}
+                  </div>
+                </div>
+              )}
+
+            {/* Profiles - Aggregation & Operations */}
+            {reportDetail.profiles &&
+              (reportDetail.profiles.filter((p) => p.type === 'aggregation')
+                .length > 0 ||
+                reportDetail.profiles.filter((p) => p.type === 'operations')
+                  .length > 0) && (
+                <div className={styles.section}>
+                  <div className={styles['section-header']}>
+                    <h2 className={styles['section-title']}>Profiles</h2>
+                  </div>
+                  <div className={`${styles.card} ${styles['profiles-card']}`}>
+                    <div className={styles['profiles-two-column']}>
+                      {/* Aggregation Profiles */}
+                      {reportDetail.profiles.filter(
+                        (p) => p.type === 'aggregation',
+                      ).length > 0 && (
+                        <div>
+                          <div className={styles['profiles-grid-simple']}>
+                            {reportDetail.profiles
+                              .filter((p) => p.type === 'aggregation')
+                              .map((profile) => (
+                                <div
+                                  key={profile.id}
+                                  className={styles['profile-simple-item']}
+                                >
+                                  <span
+                                    className={styles['profile-simple-name']}
+                                  >
+                                    {profile.name}
+                                  </span>
+                                  <span
+                                    className={`${styles['profile-type-badge-simple']} ${styles['badge-aggregation']}`}
+                                  >
+                                    Aggregation
+                                  </span>
+                                </div>
+                              ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Operations Profiles */}
+                      {reportDetail.profiles.filter(
+                        (p) => p.type === 'operations',
+                      ).length > 0 && (
+                        <div>
+                          <div className={styles['profiles-grid-simple']}>
+                            {reportDetail.profiles
+                              .filter((p) => p.type === 'operations')
+                              .map((profile) => (
+                                <div
+                                  key={profile.id}
+                                  className={styles['profile-simple-item']}
+                                >
+                                  <span
+                                    className={styles['profile-simple-name']}
+                                  >
+                                    {profile.name}
+                                  </span>
+                                  <span
+                                    className={`${styles['profile-type-badge-simple']} ${styles['badge-operations']}`}
+                                  >
+                                    Operations
+                                  </span>
+                                </div>
+                              ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+            {/* Topology Schema */}
+            <div className={styles.section}>
+              <div className={styles['section-header']}>
+                <h2 className={styles['section-title']}>Topology Schema</h2>
+              </div>
+              <div className={`${styles.card} ${styles['topology-card']}`}>
+                <div className={styles['topology-tree']}>
+                  <div className={styles['topology-node']}>
+                    <div className={styles['topology-node-icon']}>●</div>
+                    <div className={styles['topology-node-content']}>
+                      <span className={styles['topology-node-label']}>
+                        Group
+                      </span>
+                      <span className={styles['topology-node-value']}>
+                        {reportDetail.topology_schema.group.type}
+                      </span>
+                    </div>
+                  </div>
+                  {reportDetail.topology_schema.group.group && (
+                    <div className={styles['topology-node-child']}>
+                      <div className={styles['topology-connector']}></div>
+                      <div className={styles['topology-node']}>
+                        <div className={styles['topology-node-icon']}>●</div>
+                        <div className={styles['topology-node-content']}>
+                          <span className={styles['topology-node-label']}>
+                            Subgroup
+                          </span>
+                          <span className={styles['topology-node-value']}>
+                            {reportDetail.topology_schema.group.group.type}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Computations */}
+            <div className={styles.section}>
+              <div className={styles['section-header']}>
+                <h2 className={styles['section-title']}>Computations</h2>
+              </div>
+              <div className={`${styles.card} ${styles['computations-card']}`}>
+                <div className={styles['computations-grid']}>
+                  {/* AR Computation */}
+                  <div className={styles['computation-item']}>
+                    <span className={styles['computation-title']}>
+                      Availability & Reliability
+                    </span>
+                    {reportDetail.computations.ar ? (
+                      <span className={styles['status-enabled']}>Enabled</span>
+                    ) : (
+                      <span className={styles['status-disabled']}>
+                        Disabled
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Status Computation */}
+                  <div className={styles['computation-item']}>
+                    <span className={styles['computation-title']}>Status</span>
+                    {reportDetail.computations.status ? (
+                      <span className={styles['status-enabled']}>Enabled</span>
+                    ) : (
+                      <span className={styles['status-disabled']}>
+                        Disabled
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Trends */}
+                  {reportDetail.computations.trends &&
+                    reportDetail.computations.trends.map((trend) => (
+                      <div key={trend} className={styles['computation-item']}>
+                        <span className={styles['computation-title']}>
+                          {trend.charAt(0).toUpperCase() + trend.slice(1)}
+                        </span>
+                        <span className={styles['status-enabled']}>
+                          Enabled
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Thresholds */}
+            <div className={styles.section}>
+              <div className={styles['section-header']}>
+                <h2 className={styles['section-title']}>Thresholds</h2>
+              </div>
+              <div className={`${styles.card} ${styles['thresholds-card']}`}>
+                <div className={styles['thresholds-grid']}>
+                  <div className={styles['threshold-item']}>
+                    <span className={styles['threshold-title']}>
+                      Availability
+                    </span>
+                    <span className={styles['threshold-value']}>
+                      {reportDetail.thresholds.availability}%
+                    </span>
+                  </div>
+                  <div className={styles['threshold-item']}>
+                    <span className={styles['threshold-title']}>
+                      Reliability
+                    </span>
+                    <span className={styles['threshold-value']}>
+                      {reportDetail.thresholds.reliability}%
+                    </span>
+                  </div>
+                  <div className={styles['threshold-item']}>
+                    <span className={styles['threshold-title']}>Uptime</span>
+                    <span className={styles['threshold-value']}>
+                      {reportDetail.thresholds.uptime}
+                    </span>
+                  </div>
+                  <div className={styles['threshold-item']}>
+                    <span className={styles['threshold-title']}>Unknown</span>
+                    <span className={styles['threshold-value']}>
+                      {reportDetail.thresholds.unknown}
+                    </span>
+                  </div>
+                  <div className={styles['threshold-item']}>
+                    <span className={styles['threshold-title']}>Downtime</span>
+                    <span className={styles['threshold-value']}>
+                      {reportDetail.thresholds.downtime}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className={styles.card}>
+            <p className={styles['no-data']}>
+              {selectedReportId
+                ? 'Select a report from the list'
+                : 'No report selected'}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default TenantReports

--- a/src/pages/TenantStatus.tsx
+++ b/src/pages/TenantStatus.tsx
@@ -7,7 +7,6 @@ import {
 import { useAuth } from '@/auth/useAuth'
 import { useState } from 'react'
 import {
-  ArrowPathIcon,
   ArrowLeftIcon,
   CheckCircleIcon,
   XCircleIcon,
@@ -17,6 +16,7 @@ import {
   ChevronUpIcon,
 } from '@heroicons/react/16/solid'
 import { toast, Toaster } from 'sonner'
+import LoadingSpinner from '@/components/LoadingSpinner'
 import Button from '@/components/Button'
 import type { Job, JobStatus } from '@/types/tenants'
 import styles from './TenantStatus.module.css'
@@ -119,7 +119,7 @@ const TenantStatus = () => {
   if (tenantLoading) {
     return (
       <div className="loading-container">
-        <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+        <LoadingSpinner />
       </div>
     )
   }
@@ -268,7 +268,7 @@ const TenantStatus = () => {
           </div>
           <div>
             <Button
-              onClick={() => navigate('/tenants/view')}
+              onClick={() => navigate('/tenants')}
               size="sm"
               variant="secondary"
             >

--- a/src/pages/Tenants.tsx
+++ b/src/pages/Tenants.tsx
@@ -7,7 +7,6 @@ import {
 import { useGetUserProfile } from '@/hooks/useProfile'
 import { useAuth } from '@/auth/useAuth'
 import {
-  ArrowPathIcon,
   PencilSquareIcon,
   TrashIcon,
   ChevronLeftIcon,
@@ -25,6 +24,7 @@ import { toast, Toaster } from 'sonner'
 import styles from './Tenants.module.css'
 import type { UserGroup } from '@/types/profile'
 import type { Job, JobStatus } from '@/types/tenants'
+import LoadingSpinner from '@/components/LoadingSpinner'
 
 const pageSize = 9
 
@@ -259,7 +259,7 @@ const Tenants = () => {
 
       {isLoading ? (
         <div className="loading-container">
-          <ArrowPathIcon className="animate-spin size-10 text-blue-400" />
+          <LoadingSpinner />
         </div>
       ) : (
         <div className={styles.grid}>

--- a/src/routing/ProtectedRoute.tsx
+++ b/src/routing/ProtectedRoute.tsx
@@ -1,9 +1,10 @@
+import { useEffect, useState } from 'react'
 import type { JSX } from 'react'
 import { Navigate, useLocation, useParams } from 'react-router-dom'
 import { useAuth } from '@/auth/useAuth'
 import { useGetTenantById } from '@/hooks/useTenants'
-import { ArrowPathIcon } from '@heroicons/react/24/outline'
 import type { UserGroup } from '@/types/profile'
+import LoadingSpinner from '@/components/LoadingSpinner'
 
 type RoleProtectedProps = {
   children: JSX.Element
@@ -21,11 +22,23 @@ function ProtectedRoute({
   const { initialized, authenticated, profile } = useAuth()
   const location = useLocation()
   const { id: tenantId } = useParams<{ id: string }>() || {}
+  const [profileTimeout, setProfileTimeout] = useState(false)
 
   const { data: tenantData, isLoading: tenantLoading } = useGetTenantById(
     tenantId || '',
     checkTenantAccess && !!tenantId && authenticated,
   )
+
+  // Set a timeout for profile loading (10 seconds)
+  useEffect(() => {
+    if (authenticated && !profile && !profileTimeout) {
+      const timer = setTimeout(() => {
+        setProfileTimeout(true)
+      }, 10000)
+
+      return () => clearTimeout(timer)
+    }
+  }, [authenticated, profile, profileTimeout])
 
   if (!initialized) return null
 
@@ -33,7 +46,10 @@ function ProtectedRoute({
     return <Navigate to="/" state={{ from: location }} replace />
   }
 
-  if (checkTenantAccess && tenantId && tenantLoading) {
+  if (
+    (checkTenantAccess && tenantId && tenantLoading) ||
+    (!profile && profileTimeout)
+  ) {
     return (
       <div
         style={{
@@ -43,10 +59,7 @@ function ProtectedRoute({
           minHeight: '400px',
         }}
       >
-        <ArrowPathIcon
-          style={{ width: '2.5rem', height: '2.5rem', color: '#1d4ed8' }}
-          className="animate-spin"
-        />
+        <LoadingSpinner />
       </div>
     )
   }

--- a/src/types/tenants.ts
+++ b/src/types/tenants.ts
@@ -108,3 +108,87 @@ export type PaginatedMembersResponse = {
   total_pages: number
   content: Member[]
 }
+
+export type ReportListItem = {
+  id: string
+  name: string
+  description: string
+  tenant_name: string
+  disabled: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type ReportProfile = {
+  id: string
+  name: string
+  type: string
+}
+
+export type MetricProfileService = {
+  service: string
+  metrics: string[]
+}
+
+export type MetricProfileData = {
+  id: string
+  services: MetricProfileService[]
+}
+
+export type MetricProfileResponse = {
+  status: {
+    message: string
+    code: string
+  }
+  data: MetricProfileData[]
+}
+
+export type ReportTopologySchema = {
+  group: {
+    type: string
+    group?: {
+      type: string
+    }
+  }
+}
+
+export type ReportComputations = {
+  ar: boolean
+  status: boolean
+  trends: string[]
+}
+
+export type ReportThresholds = {
+  availability: number
+  reliability: number
+  uptime: number
+  unknown: number
+  downtime: number
+}
+
+export type ReportInfo = {
+  name: string
+  description: string
+  created: string
+  updated: string
+}
+
+export type ReportDetail = {
+  id: string
+  tenant: string
+  disabled: boolean
+  info: ReportInfo
+  computations: ReportComputations
+  thresholds: ReportThresholds
+  topology_schema: ReportTopologySchema
+  profiles: ReportProfile[]
+  filter_tags: string[]
+}
+
+export type ReportListResponse = {
+  size_of_page: number
+  number_of_page: number
+  total_elements: number
+  total_pages: number
+  content: ReportListItem[]
+}


### PR DESCRIPTION
**⚠️ This PR requires the endpoint `/v1/tenants/{id}/reports` and should not be merged before [ARGO-5344](https://github.com/ARGOeu/argo-mon-status-api/pull/82) is merged.**

This PR implements a Reports page within the Tenant Details section to display ARGO monitoring reports for each tenant, featuring a sidebar navigation for report selection and a detailed read-only view of report configurations.

- Added TenantReports component with sidebar navigation and main content area
- Created MetricProfileItem component with collapsible service/metrics display
- Implemented the sections: Metric Profile, Profiles, Topology Schema, Computations, and Thresholds
- Created LoadingSpinner component to replace custom loading code across multiple components
- Integrated API endpoints for reports list, report details, and metric profiles