### PR TITLE
[ARGO-5357] - Implement check readiness for a tenant page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -162,6 +162,39 @@ select:focus {
   color: #6b7280;
 }
 
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 2rem;
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 0.5rem;
+  margin: 2rem 0;
+  text-align: center;
+}
+
+.error-icon {
+  width: 2rem;
+  height: 2rem;
+  color: #dc2626;
+}
+
+.error-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #991b1b;
+}
+
+.error-message {
+  font-size: 0.9rem;
+  color: #7f1d1d;
+  max-width: 600px;
+  line-height: 1.6;
+}
+
 @media (min-width: 1921px) {
   .page-container {
     max-width: 1800px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import View from './pages/View'
 import Tenants from './pages/Tenants'
 import CreateTenant from './pages/CreateTenant'
 import TenantStatus from './pages/TenantStatus'
+import TenantReadiness from './pages/TenantReadiness'
 import TenantDetails from './pages/TenantDetails'
 import AssignProjects from './pages/AssignProjects'
 import Projects from './pages/Projects'
@@ -77,12 +78,9 @@ function App() {
               <Route
                 path="tenants/:id/details"
                 element={
-                  <ProtectedRoute
-                    requiredRoles={['super_admin', 'admin', 'viewer']}
-                    checkTenantAccess
-                  >
+                  <AuthProtected>
                     <TenantDetails />
-                  </ProtectedRoute>
+                  </AuthProtected>
                 }
               />
               <Route
@@ -96,34 +94,25 @@ function App() {
               <Route
                 path="tenants/edit/:id"
                 element={
-                  <ProtectedRoute
-                    requiredRoles={['super_admin', 'admin']}
-                    checkTenantAccess
-                  >
+                  <AuthProtected>
                     <CreateTenant />
-                  </ProtectedRoute>
+                  </AuthProtected>
                 }
               />
               <Route
                 path="tenants/:id/projects/assign"
                 element={
-                  <ProtectedRoute
-                    requiredRoles={['super_admin', 'admin']}
-                    checkTenantAccess
-                  >
+                  <AuthProtected>
                     <AssignProjects />
-                  </ProtectedRoute>
+                  </AuthProtected>
                 }
               />
               <Route
                 path="tenants/:id/members"
                 element={
-                  <ProtectedRoute
-                    requiredRoles={['super_admin', 'admin']}
-                    checkTenantAccess
-                  >
+                  <AuthProtected>
                     <ManageTenantMembers />
-                  </ProtectedRoute>
+                  </AuthProtected>
                 }
               />
               <Route
@@ -132,6 +121,14 @@ function App() {
                   <ProtectedRoute requiredRoles={['super_admin']}>
                     <TenantStatus />
                   </ProtectedRoute>
+                }
+              />
+              <Route
+                path="tenants/:id/readiness"
+                element={
+                  <AuthProtected>
+                    <TenantReadiness />
+                  </AuthProtected>
                 }
               />
               <Route

--- a/src/api/status.ts
+++ b/src/api/status.ts
@@ -3,15 +3,12 @@ import type { PageConfig } from '@/types/pages'
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 
 export const fetchStatus = async (slug: string): Promise<PageConfig> => {
-  const response = await fetch(
-    `${BACKEND_API}/v1/public/pages/status/${slug}`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+  const response = await fetch(`${BACKEND_API}/v1/public/pages/${slug}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
     },
-  )
+  })
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}))

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -6,6 +6,7 @@ import type {
   ReportListItem,
   ReportDetail,
   MetricProfileResponse,
+  TenantReadinessResponse,
 } from '@/types/tenants'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
@@ -548,6 +549,31 @@ export const fetchTenantMetricProfile = async (
 ): Promise<MetricProfileResponse> => {
   const response = await fetch(
     `${BACKEND_API}/v1/tenants/${tenantId}/metric-profiles/${profileId}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchTenantReadiness = async (
+  tenantId: string,
+  token: string,
+): Promise<TenantReadinessResponse> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/check-readiness`,
     {
       method: 'GET',
       headers: {

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -135,48 +135,6 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
       redirectUri: import.meta.env.VITE_REDIRECT_URI || window.location.origin,
     })
 
-  const delay = (ms: number): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, ms))
-
-  const waitForTenantInProfile = async (
-    tenantName?: string,
-    maxRetries: number = 3,
-    retryDelayMs: number = 2000,
-  ): Promise<void> => {
-    if (!token) {
-      console.warn('Cannot refresh profile: no token available')
-      return
-    }
-
-    const initialProfile = await loadProfile(token)
-
-    if (!tenantName) {
-      return
-    }
-
-    if (initialProfile?.groups?.some((group) => group.name === tenantName)) {
-      return
-    }
-
-    // Retry with delays until tenant is found or max retries reached
-    let attempt = 0
-    while (attempt < maxRetries) {
-      attempt++
-      await delay(retryDelayMs)
-
-      try {
-        const updatedProfile = await loadProfile(token)
-        if (
-          updatedProfile?.groups?.some((group) => group.name === tenantName)
-        ) {
-          return
-        }
-      } catch (error) {
-        console.error('Error refreshing profile:', error)
-      }
-    }
-  }
-
   return (
     <AuthContext.Provider
       value={{
@@ -187,7 +145,6 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
         profile,
         login,
         logout,
-        waitForTenantInProfile,
       }}
     >
       {children}

--- a/src/auth/context.ts
+++ b/src/auth/context.ts
@@ -19,11 +19,6 @@ export type AuthContextType = {
   }
   login: (redirectUri?: string) => void
   logout: () => void
-  waitForTenantInProfile: (
-    tenantName?: string,
-    maxRetries?: number,
-    retryDelayMs?: number,
-  ) => Promise<void>
 }
 
 export const AuthContext = createContext<AuthContextType>({
@@ -32,5 +27,4 @@ export const AuthContext = createContext<AuthContextType>({
   registered: false,
   login: () => {},
   logout: () => {},
-  waitForTenantInProfile: async () => {},
 })

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -1,0 +1,54 @@
+import { ExclamationCircleIcon } from '@heroicons/react/16/solid'
+
+interface ErrorDisplayProps {
+  error: Error | { message: string } | string
+  context?: string
+}
+
+const MAX_MESSAGE_LENGTH = 300
+
+const ErrorDisplay = ({ error, context = 'data' }: ErrorDisplayProps) => {
+  const errorMessage =
+    typeof error === 'string' ? error : error?.message || 'An error occurred'
+
+  const isUnauthorized =
+    errorMessage.includes('401') ||
+    errorMessage.toLowerCase().includes('unauthorized')
+  const isForbidden =
+    errorMessage.includes('403') ||
+    errorMessage.toLowerCase().includes('forbidden')
+
+  const getTitle = () => {
+    if (isUnauthorized) return 'Authentication Required'
+    if (isForbidden) return 'Access Denied'
+    return `Error Loading ${context.charAt(0).toUpperCase() + context.slice(1)}`
+  }
+
+  const getMessage = () => {
+    if (isUnauthorized) {
+      return 'Your session has expired or you are not authenticated. Please log in again'
+    }
+    if (isForbidden) {
+      return `You do not have permission to view this ${context}`
+    }
+    return errorMessage
+  }
+
+  const message = getMessage()
+  const isTruncated = message.length > MAX_MESSAGE_LENGTH
+  const displayMessage = isTruncated
+    ? `${message.substring(0, MAX_MESSAGE_LENGTH)}...`
+    : message
+
+  return (
+    <div className="error-container">
+      <ExclamationCircleIcon className="error-icon" />
+      <h2 className="error-title">{getTitle()}</h2>
+      <p className="error-message" title={isTruncated ? message : undefined}>
+        {displayMessage}
+      </p>
+    </div>
+  )
+}
+
+export default ErrorDisplay

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -28,6 +28,7 @@ import {
   fetchTenantReports,
   fetchTenantReportById,
   fetchTenantMetricProfile,
+  fetchTenantReadiness,
 } from '@/api/tenants'
 import type {
   Job,
@@ -39,6 +40,7 @@ import type {
   ReportListItem,
   ReportDetail,
   MetricProfileResponse,
+  TenantReadinessResponse,
 } from '@/types/tenants'
 
 export const useGetTenants = (
@@ -550,5 +552,27 @@ export const useGetTenantMetricProfile = (
     },
     retry: false,
     enabled: enabled && !!token && !!tenantId && !!profileId,
+  })
+}
+
+export const useGetTenantReadiness = (
+  tenantId: string,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+
+  return useQuery<TenantReadinessResponse, Error>({
+    queryKey: ['tenant-readiness', tenantId],
+    queryFn: () => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      if (!tenantId) {
+        throw new Error('Tenant ID is required')
+      }
+      return fetchTenantReadiness(tenantId, token)
+    },
+    retry: false,
+    enabled: enabled && !!token && !!tenantId,
   })
 }

--- a/src/pages/AssignProjects.tsx
+++ b/src/pages/AssignProjects.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useDragAndDrop } from '@formkit/drag-and-drop/react'
 import { toast, Toaster } from 'sonner'
+import ErrorDisplay from '@/components/ErrorDisplay'
 import Button from '@/components/Button'
 import {
   useGetTenantById,
@@ -35,13 +36,18 @@ const AssignProjects = () => {
   const [availableProjects, setAvailableProjects] = useState<ProjectItem[]>([])
   const [assignedProjects, setAssignedProjects] = useState<ProjectItem[]>([])
   const [isInitialized, setIsInitialized] = useState(false)
-  const { data: adminTenantData } = useGetTenantById(tenantId || '')
-  const { data: userTenantData } = useGetUserTenantById(tenantId || '')
+  const { data: adminTenantData, error: adminTenantError } = useGetTenantById(
+    tenantId || '',
+  )
+  const { data: userTenantData, error: userTenantError } = useGetUserTenantById(
+    tenantId || '',
+  )
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
   const { data: userProfileData } = useGetUserProfile()
 
   const tenantData = isSuperAdmin ? adminTenantData : userTenantData
+  const tenantError = isSuperAdmin ? adminTenantError : userTenantError
 
   const isTenantAdmin = (tenantName: string) => {
     if (!tenantName) return false
@@ -239,6 +245,17 @@ const AssignProjects = () => {
       <div className="loading-container">
         <LoadingSpinner />
       </div>
+    )
+  }
+
+  if (tenantError) {
+    return (
+      <>
+        <Toaster richColors position="top-center" duration={2000} />
+        <div className="page-container">
+          <ErrorDisplay error={tenantError} context="tenant" />
+        </div>
+      </>
     )
   }
 

--- a/src/pages/Build.tsx
+++ b/src/pages/Build.tsx
@@ -138,7 +138,7 @@ const Build = () => {
       name: name,
       slug: slug,
       tenant_id: tenantId,
-      ['report-id']: report,
+      'report-id': report,
 
       config: {
         groups: statusGroups,

--- a/src/pages/CreateTenant.tsx
+++ b/src/pages/CreateTenant.tsx
@@ -12,6 +12,7 @@ import {
 import type { Metadata } from '@/types/tenants'
 import { useAuth } from '@/auth/useAuth'
 import { toast, Toaster } from 'sonner'
+import ErrorDisplay from '@/components/ErrorDisplay'
 import Button from '../components/Button'
 import ContactInformation from '../components/ContactInformation'
 import InfrastructureMetadata from '../components/InfrastructureMetadata'
@@ -74,16 +75,19 @@ const CreateTenant = () => {
   const userUpdateMutation = useUpdateUserTenantMutation()
   const updateMutation = isSuperAdmin ? adminUpdateMutation : userUpdateMutation
 
-  const { data: adminTenantData, isLoading: adminLoading } = useGetTenantById(
-    tenantId || '',
-    isSuperAdmin,
-  )
-  const { data: userTenantData, isLoading: userLoading } = useGetUserTenantById(
-    tenantId || '',
-    !isSuperAdmin,
-  )
+  const {
+    data: adminTenantData,
+    isLoading: adminLoading,
+    error: adminError,
+  } = useGetTenantById(tenantId || '', isSuperAdmin)
+  const {
+    data: userTenantData,
+    isLoading: userLoading,
+    error: userError,
+  } = useGetUserTenantById(tenantId || '', !isSuperAdmin)
   const tenantData = isSuperAdmin ? adminTenantData : userTenantData
   const isTenantLoading = isSuperAdmin ? adminLoading : userLoading
+  const tenantError = isSuperAdmin ? adminError : userError
 
   // Load tenant data in edit mode
   useEffect(() => {
@@ -441,6 +445,8 @@ const CreateTenant = () => {
           <div className="loading-container">
             <LoadingSpinner />
           </div>
+        ) : isEditMode && tenantError ? (
+          <ErrorDisplay error={tenantError} context="tenant" />
         ) : (
           <>
             <div className={styles.header}>

--- a/src/pages/InvitationReview.tsx
+++ b/src/pages/InvitationReview.tsx
@@ -14,13 +14,7 @@ import styles from './InvitationReview.module.css'
 export const InvitationReview = () => {
   const { id: invitationId } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const {
-    authenticated,
-    initialized,
-    registered,
-    login,
-    waitForTenantInProfile,
-  } = useAuth()
+  const { authenticated, initialized, registered, login } = useAuth()
   const [isProcessing, setIsProcessing] = useState(false)
 
   const {
@@ -56,13 +50,6 @@ export const InvitationReview = () => {
           setTimeout(() => {
             navigate('/tenants')
           }, 2000)
-
-          try {
-            // Refetch profile and wait until the new tenant appears in groups
-            await waitForTenantInProfile(invitation?.tenant_name, 5, 2000)
-          } catch (error) {
-            console.error('Failed to refetch profile:', error)
-          }
         },
         onError: (error) => {
           toast.error(`Failed to accept invitation: ${error.message}`)

--- a/src/pages/ManageTenantMembers.module.css
+++ b/src/pages/ManageTenantMembers.module.css
@@ -1,7 +1,7 @@
 .header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: flex-start;
   margin-bottom: 0.5rem;
   padding-bottom: 0.5rem;
 }

--- a/src/pages/ManageTenantMembers.tsx
+++ b/src/pages/ManageTenantMembers.tsx
@@ -9,13 +9,14 @@ import {
   useGetMembers,
 } from '@/hooks/useTenants'
 import { useAuth } from '@/auth/useAuth'
+import ErrorDisplay from '@/components/ErrorDisplay'
 import {
   ArrowLeftIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   UserMinusIcon,
   XMarkIcon,
-} from '@heroicons/react/24/solid'
+} from '@heroicons/react/16/solid'
 import { toast, Toaster } from 'sonner'
 import Button from '@/components/Button'
 import ConfirmDialog from '@/components/ConfirmDialog'
@@ -33,7 +34,9 @@ const ManageTenantMembers = () => {
   const { id: tenantId } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { profile } = useAuth()
-  const { data: tenantData } = useGetUserTenantById(tenantId || '')
+  const { data: tenantData, error: tenantError } = useGetUserTenantById(
+    tenantId || '',
+  )
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
 
@@ -286,6 +289,17 @@ const ManageTenantMembers = () => {
   }
 
   const isLoading = membersLoading
+
+  if (tenantError) {
+    return (
+      <>
+        <Toaster richColors position="top-center" duration={2000} />
+        <div className="page-container">
+          <ErrorDisplay error={tenantError} context="tenant" />
+        </div>
+      </>
+    )
+  }
 
   return (
     <>

--- a/src/pages/MyInvitations.module.css
+++ b/src/pages/MyInvitations.module.css
@@ -209,7 +209,7 @@
   background-color: #f9fafb;
   border: 1px solid #e5e7eb;
   border-radius: 0.5rem;
-  padding: 3rem;
+  padding: 2rem 3rem;
   text-align: center;
 }
 

--- a/src/pages/MyInvitations.tsx
+++ b/src/pages/MyInvitations.tsx
@@ -11,14 +11,12 @@ import {
 } from '@heroicons/react/24/solid'
 import { toast, Toaster } from 'sonner'
 import LoadingSpinner from '@/components/LoadingSpinner'
-import { useAuth } from '@/auth/useAuth'
 import styles from './MyInvitations.module.css'
 
 const pageSize = 10
 
 const MyInvitations = () => {
   const [currentPage, setCurrentPage] = useState(1)
-  const { waitForTenantInProfile } = useAuth()
 
   const { data: invitationsData, isLoading } = useGetUserInvitations(true, {
     page: currentPage,
@@ -26,11 +24,7 @@ const MyInvitations = () => {
   })
   const respondMutation = useRespondToInvitation()
 
-  const handleRespond = (
-    invitationId: string,
-    tenantName: string,
-    action: 'ACCEPT' | 'REJECT',
-  ) => {
+  const handleRespond = (invitationId: string, action: 'ACCEPT' | 'REJECT') => {
     respondMutation.mutate(
       { invitationId, data: { action } },
       {
@@ -38,14 +32,6 @@ const MyInvitations = () => {
           toast.success(
             `Invitation ${action === 'ACCEPT' ? 'accepted' : 'rejected'} successfully!`,
           )
-          if (action === 'ACCEPT') {
-            try {
-              // Refetch profile and wait until the new tenant appears in groups
-              await waitForTenantInProfile(tenantName, 5, 2000)
-            } catch (error) {
-              console.error('Failed to refetch profile:', error)
-            }
-          }
         },
         onError: (error) => {
           toast.error(`Failed to respond to invitation: ${error.message}`)
@@ -144,11 +130,7 @@ const MyInvitations = () => {
                                 <div className={styles['actions-container']}>
                                   <button
                                     onClick={() =>
-                                      handleRespond(
-                                        invitation.id,
-                                        invitation.tenant_name,
-                                        'ACCEPT',
-                                      )
+                                      handleRespond(invitation.id, 'ACCEPT')
                                     }
                                     className={`tooltip ${styles['action-button']} ${styles['accept-button']}`}
                                     data-tip="Accept invitation"
@@ -160,11 +142,7 @@ const MyInvitations = () => {
                                   </button>
                                   <button
                                     onClick={() =>
-                                      handleRespond(
-                                        invitation.id,
-                                        invitation.tenant_name,
-                                        'REJECT',
-                                      )
+                                      handleRespond(invitation.id, 'REJECT')
                                     }
                                     className={`tooltip ${styles['action-button']} ${styles['reject-button']}`}
                                     data-tip="Reject invitation"

--- a/src/pages/Status.tsx
+++ b/src/pages/Status.tsx
@@ -10,6 +10,7 @@ import {
 import { useGetStatusQuery } from '@/hooks/useStatus'
 import ViewGroup from '@/components/ViewGroup'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 
@@ -181,10 +182,11 @@ export const Status = () => {
             </footer>
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-center mt-32 bg-white rounded-xl shadow-lg p-12">
-            <div className="text-red-600 text-xl font-semibold mb-2">
-              Failed to load status page
-            </div>
+          <div className="page-container">
+            <ErrorDisplay
+              error="Failed to load status page"
+              context="status page"
+            />
           </div>
         )}
       </div>

--- a/src/pages/TenantDetails.tsx
+++ b/src/pages/TenantDetails.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeftIcon } from '@heroicons/react/24/outline'
+import { ArrowLeftIcon } from '@heroicons/react/16/solid'
 import { useAuth } from '../auth/useAuth'
 import { useGetTenantById, useGetUserTenantById } from '../hooks/useTenants'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
 import TenantReports from './TenantReports'
 import styles from './TenantDetails.module.css'
 import Button from '@/components/Button'
@@ -16,17 +17,20 @@ const TenantDetails = () => {
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
 
-  const { data: adminTenantData, isLoading: adminLoading } = useGetTenantById(
-    id || '',
-    isSuperAdmin,
-  )
-  const { data: userTenantData, isLoading: userLoading } = useGetUserTenantById(
-    id || '',
-    !isSuperAdmin,
-  )
+  const {
+    data: adminTenantData,
+    isLoading: adminLoading,
+    error: adminError,
+  } = useGetTenantById(id || '', isSuperAdmin)
+  const {
+    data: userTenantData,
+    isLoading: userLoading,
+    error: userError,
+  } = useGetUserTenantById(id || '', !isSuperAdmin)
 
   const tenantData = isSuperAdmin ? adminTenantData : userTenantData
   const isLoading = isSuperAdmin ? adminLoading : userLoading
+  const error = isSuperAdmin ? adminError : userError
 
   if (isLoading) {
     return (
@@ -38,12 +42,21 @@ const TenantDetails = () => {
     )
   }
 
+  if (error) {
+    return (
+      <div className="page-container">
+        <ErrorDisplay error={error} context="tenant" />
+      </div>
+    )
+  }
+
   if (!tenantData) {
     return (
       <div className="page-container">
-        <div className={styles.error}>
-          <p>Tenant not found</p>
-        </div>
+        <ErrorDisplay
+          error="The tenant you are looking for does not exist or has been removed."
+          context="tenant"
+        />
       </div>
     )
   }

--- a/src/pages/TenantReadiness.module.css
+++ b/src/pages/TenantReadiness.module.css
@@ -1,0 +1,199 @@
+.header {
+  max-width: 1240px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0 auto 1.5rem auto;
+}
+
+.title-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.action-section {
+  display: flex;
+  align-items: center;
+}
+
+.content {
+  max-width: 1240px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin: 0 auto;
+}
+
+.overall-status-card {
+  background-color: white;
+  border: 2px solid #e5e7eb;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+.overall-status-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid #f3f4f6;
+}
+
+.overall-status-title-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.overall-status-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.375rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-align: center;
+  border-radius: 100%;
+}
+
+.overall-status-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.info-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.info-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #6b7280;
+  min-width: 120px;
+}
+
+.info-value {
+  font-size: 0.875rem;
+  color: #111827;
+  font-weight: 500;
+}
+
+.checks-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.check-card {
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  transition: all 0.2s;
+}
+
+.check-card:hover {
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+.check-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.check-title-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.check-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.check-message {
+  font-size: 0.875rem;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.check-message-empty {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+.status-ready {
+  background-color: #ecfdf5;
+  color: #047857;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.status-not-ready {
+  background-color: #fef2f2;
+  color: #dc2626;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .checks-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .checks-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .title-section {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .overall-status-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .check-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .info-label {
+    min-width: 100px;
+  }
+}

--- a/src/pages/TenantReadiness.tsx
+++ b/src/pages/TenantReadiness.tsx
@@ -1,0 +1,178 @@
+import { useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeftIcon } from '@heroicons/react/16/solid'
+import { useGetTenantReadiness, useGetUserTenantById } from '@/hooks/useTenants'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import Button from '@/components/Button'
+import styles from './TenantReadiness.module.css'
+import type { ReadinessCheckDetail } from '@/types/tenants'
+
+const TenantReadiness = () => {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+
+  const { data: tenantData } = useGetUserTenantById(id || '')
+
+  const {
+    data: readinessData,
+    isLoading: readinessLoading,
+    error: readinessError,
+    refetch: refetchReadiness,
+    isFetching: isRefetching,
+  } = useGetTenantReadiness(id || '')
+
+  const handleBackClick = () => {
+    navigate('/tenants')
+  }
+
+  const handleCheckReadiness = () => {
+    refetchReadiness()
+  }
+
+  const readiness = readinessData?.data
+  const hasError = readinessError || !tenantData
+
+  const formatDateTime = (dateString?: string) => {
+    if (!dateString) return 'N/A'
+    return new Date(dateString).toLocaleString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  }
+
+  const getReadinessClass = (ready: boolean) => {
+    return ready ? styles['status-ready'] : styles['status-not-ready']
+  }
+
+  const renderCheckDetail = (
+    title: string,
+    detail: ReadinessCheckDetail | undefined,
+  ) => {
+    if (!detail) return null
+
+    const hasMessage = detail.message && detail.message.trim().length > 0
+    const displayMessage = hasMessage
+      ? detail.message
+      : 'No additional details provided'
+
+    return (
+      <div className={styles['check-card']}>
+        <div className={styles['check-header']}>
+          <div className={styles['check-title-wrapper']}>
+            <h3 className={styles['check-title']}>{title}</h3>
+          </div>
+          <span
+            className={`${styles['status-badge']} ${getReadinessClass(detail.ready)}`}
+          >
+            {detail.ready ? 'Ready' : 'Not Ready'}
+          </span>
+        </div>
+        <div
+          className={`${styles['check-message']} ${
+            !hasMessage ? styles['check-message-empty'] : ''
+          }`}
+        >
+          {displayMessage}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="page-container">
+      <div className={styles.header}>
+        <div className={styles['title-section']}>
+          <div>
+            <h1 className="page-title">Tenant Readiness</h1>
+            <p className="page-subtitle">
+              View readiness checks for tenant
+              <strong style={{ wordBreak: 'break-all' }}>
+                {tenantData?.info.name ? ` ${tenantData.info.name}` : '...'}
+              </strong>
+            </p>
+          </div>
+          <Button variant="secondary" size="sm" onClick={handleBackClick}>
+            <ArrowLeftIcon className="size-4" />
+            Back to Tenants
+          </Button>
+        </div>
+        <div className={styles['action-section']}>
+          <Button
+            variant="primary"
+            onClick={handleCheckReadiness}
+            disabled={isRefetching}
+          >
+            {isRefetching ? 'Checking...' : 'Check Readiness'}
+          </Button>
+        </div>
+      </div>
+
+      {readinessError && (
+        <ErrorDisplay error={readinessError} context="readiness data" />
+      )}
+
+      {!tenantData && !readinessError && (
+        <ErrorDisplay
+          error="The tenant you are looking for does not exist or has been removed."
+          context="tenant"
+        />
+      )}
+
+      {readinessLoading && (
+        <div className="loading-container">
+          <LoadingSpinner />
+        </div>
+      )}
+
+      {!hasError && readiness && (
+        <div className={styles.content}>
+          <div className={styles['overall-status-card']}>
+            <div className={styles['overall-status-header']}>
+              <div className={styles['overall-status-title-wrapper']}>
+                <h2 className={styles['overall-status-title']}>
+                  Overall Tenant Status
+                </h2>
+              </div>
+              <span
+                className={`${styles['status-badge']} ${getReadinessClass(readiness.ready)}`}
+              >
+                {readiness.ready ? 'Ready' : 'Not Ready'}
+              </span>
+            </div>
+            <div className={styles['overall-status-info']}>
+              <div className={styles['info-row']}>
+                <span className={styles['info-label']}>Tenant Name:</span>
+                <span className={styles['info-value']}>{readiness.name}</span>
+              </div>
+              <div className={styles['info-row']}>
+                <span className={styles['info-label']}>Last Check:</span>
+                <span className={styles['info-value']}>
+                  {formatDateTime(readiness.last_check)}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className={styles['checks-grid']}>
+            {renderCheckDetail('Data Availability', readiness.data)}
+            {renderCheckDetail('Topology Configuration', readiness.topology)}
+            {renderCheckDetail('Reports', readiness.reports)}
+          </div>
+        </div>
+      )}
+
+      {!hasError && !readiness && !readinessLoading && (
+        <ErrorDisplay
+          error="No readiness information is currently available for this tenant."
+          context="readiness information"
+        />
+      )}
+    </div>
+  )
+}
+
+export default TenantReadiness

--- a/src/pages/TenantStatus.module.css
+++ b/src/pages/TenantStatus.module.css
@@ -3,7 +3,7 @@
   justify-content: space-between;
   align-items: flex-start;
   margin-bottom: 2rem;
-  max-width: 900px;
+  max-width: 1040px;
   margin-left: auto;
   margin-right: auto;
 }
@@ -12,7 +12,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  max-width: 900px;
+  max-width: 1040px;
   margin: 0 auto;
 }
 

--- a/src/pages/Tenants.module.css
+++ b/src/pages/Tenants.module.css
@@ -318,6 +318,14 @@
   background-color: #ecfdf5;
 }
 
+.action-button.readiness {
+  color: #7c3aed;
+}
+
+.action-button.readiness:hover {
+  background-color: #f5f3ff;
+}
+
 .action-button.delete {
   color: #dc2626;
 }

--- a/src/pages/Tenants.tsx
+++ b/src/pages/Tenants.tsx
@@ -16,6 +16,7 @@ import {
   ListBulletIcon,
   UserGroupIcon,
   Bars3Icon,
+  ShieldCheckIcon,
 } from '@heroicons/react/16/solid'
 import Button from '@/components/Button'
 import ConfirmDialog from '@/components/ConfirmDialog'
@@ -402,6 +403,20 @@ const Tenants = () => {
                         >
                           <ListBulletIcon className={styles['action-icon']} />
                         </button>
+                        {(isSuperAdmin || isTenantAdmin(tenant.name)) && (
+                          <button
+                            aria-label="Check Readiness"
+                            className={`${styles['action-button']} ${styles.readiness} tooltip`}
+                            data-tip="Check Readiness"
+                            onClick={() =>
+                              navigate(`/tenants/${tenant.id}/readiness`)
+                            }
+                          >
+                            <ShieldCheckIcon
+                              className={styles['action-icon']}
+                            />
+                          </button>
+                        )}
                         <button
                           aria-label="Delete Tenant"
                           className={`${styles['action-button']} ${styles.delete} tooltip`}

--- a/src/routing/ProtectedRoute.tsx
+++ b/src/routing/ProtectedRoute.tsx
@@ -1,33 +1,23 @@
 import { useEffect, useState } from 'react'
 import type { JSX } from 'react'
-import { Navigate, useLocation, useParams } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/auth/useAuth'
-import { useGetUserTenantById } from '@/hooks/useTenants'
-import type { UserGroup } from '@/types/profile'
 import LoadingSpinner from '@/components/LoadingSpinner'
 
 type RoleProtectedProps = {
   children: JSX.Element
   requiredRoles: string[]
   redirectTo?: string
-  checkTenantAccess?: boolean
 }
 
 function ProtectedRoute({
   children,
   requiredRoles,
   redirectTo = '/',
-  checkTenantAccess = false,
 }: RoleProtectedProps) {
   const { initialized, authenticated, profile } = useAuth()
   const location = useLocation()
-  const { id: tenantId } = useParams<{ id: string }>() || {}
   const [profileTimeout, setProfileTimeout] = useState(false)
-
-  const { data: tenantData, isLoading: tenantLoading } = useGetUserTenantById(
-    tenantId || '',
-    checkTenantAccess && !!tenantId && authenticated,
-  )
 
   // Set a timeout for profile loading (5 seconds)
   useEffect(() => {
@@ -46,10 +36,7 @@ function ProtectedRoute({
     return <Navigate to="/" state={{ from: location }} replace />
   }
 
-  if (
-    (checkTenantAccess && tenantId && tenantLoading) ||
-    (!profile && !profileTimeout)
-  ) {
+  if (!profile && !profileTimeout) {
     return (
       <div
         style={{
@@ -66,29 +53,11 @@ function ProtectedRoute({
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
 
-  const hasTenantAccess = (tenantName: string) => {
-    if (!tenantName || !profile?.groups) return false
-
-    const group = profile?.groups?.find(
-      (g: UserGroup) => g?.name === tenantName,
-    )
-    return group?.role === 'admin' || group?.role === 'viewer'
-  }
-
   const hasRequiredRole = (() => {
     if (isSuperAdmin) {
       return true
     }
 
-    // For tenant-specific routes
-    if (checkTenantAccess) {
-      if (!tenantData) {
-        return false
-      }
-      return hasTenantAccess(tenantData.info.name)
-    }
-
-    // For non-tenant routes, check role requirements
     if (!requiredRoles || requiredRoles.length === 0) {
       return true
     }

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -25,7 +25,7 @@ export type PageCreateRequest = {
   name: string
   slug: string
   tenant_id: string
-  ['report-id']: string
+  'report-id': string
   created_at?: string
   updated_at?: string
   config?: PageConfig

--- a/src/types/tenants.ts
+++ b/src/types/tenants.ts
@@ -192,3 +192,26 @@ export type ReportListResponse = {
   total_pages: number
   content: ReportListItem[]
 }
+
+export type ReadinessCheckDetail = {
+  ready: boolean
+  message: string
+}
+
+export type TenantReadinessData = {
+  id: string
+  name: string
+  ready: boolean
+  last_check: string
+  data: ReadinessCheckDetail
+  topology: ReadinessCheckDetail
+  reports: ReadinessCheckDetail
+}
+
+export type TenantReadinessResponse = {
+  status: {
+    message: string
+    code: string
+  }
+  data: TenantReadinessData
+}


### PR DESCRIPTION
This PR implements a tenant readiness page that allows administrators to view and verify the operational status of their tenants. The page displays detailed readiness checks across multiple categories and allows manual triggering of readiness verification.

- Added new TenantReadiness page with status checks and manual refresh capability
- Implemented "Check Readiness" button that triggers readiness verification
- Integrated new endpoint /v1/tenants/:id/readiness and its corresponding query hook
- Refactored ProtectedRoute component to remove tenant-scoped permission validation checks
- Removed unnecessary profile refetching mechanism from invitation components