### PR TITLE
[ARGO-5375] - Add hash-based routing for Tenant Details page tabs

### DIFF
--- a/src/pages/TenantDetails.tsx
+++ b/src/pages/TenantDetails.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { ArrowLeftIcon } from '@heroicons/react/16/solid'
 import { useAuth } from '../auth/useAuth'
 import { useGetTenantById, useGetUserTenantById } from '../hooks/useTenants'
@@ -12,8 +12,18 @@ import Button from '@/components/Button'
 const TenantDetails = () => {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const location = useLocation()
   const { profile } = useAuth()
-  const [activeTab, setActiveTab] = useState<'details' | 'reports'>('details')
+  const [activeTab, setActiveTab] = useState<'info' | 'reports'>('info')
+
+  useEffect(() => {
+    const hash = location?.hash
+    if (hash?.startsWith('#reports')) {
+      setActiveTab('reports')
+    } else {
+      setActiveTab('info')
+    }
+  }, [location.hash])
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
 
@@ -87,20 +97,26 @@ const TenantDetails = () => {
 
       <div className={styles.tabs}>
         <button
-          className={`${styles.tab} ${activeTab === 'details' ? styles['tab-active'] : ''}`}
-          onClick={() => setActiveTab('details')}
+          className={`${styles.tab} ${activeTab === 'info' ? styles['tab-active'] : ''}`}
+          onClick={() => {
+            setActiveTab('info')
+            window.location.hash = 'info'
+          }}
         >
-          Tenant Details
+          Tenant Info
         </button>
         <button
           className={`${styles.tab} ${activeTab === 'reports' ? styles['tab-active'] : ''}`}
-          onClick={() => setActiveTab('reports')}
+          onClick={() => {
+            setActiveTab('reports')
+            window.location.hash = 'reports'
+          }}
         >
           Reports
         </button>
       </div>
 
-      {activeTab === 'details' && (
+      {activeTab === 'info' && (
         <>
           {/* Tenant Information */}
           <div className={styles.section}>
@@ -136,7 +152,11 @@ const TenantDetails = () => {
                     <div className={styles['info-group']}>
                       <label className={styles.label}>Created At</label>
                       <p className={styles.value}>
-                        {new Date(info.created_at).toLocaleString()}
+                        {new Date(info.created_at).toLocaleString('en-GB', {
+                          day: 'numeric',
+                          month: 'short',
+                          year: 'numeric',
+                        })}
                       </p>
                     </div>
                   )}
@@ -144,7 +164,11 @@ const TenantDetails = () => {
                     <div className={styles['info-group']}>
                       <label className={styles.label}>Last Updated</label>
                       <p className={styles.value}>
-                        {new Date(info.updated_at).toLocaleString()}
+                        {new Date(info.updated_at).toLocaleString('en-GB', {
+                          day: 'numeric',
+                          month: 'short',
+                          year: 'numeric',
+                        })}
                       </p>
                     </div>
                   )}

--- a/src/pages/TenantReadiness.tsx
+++ b/src/pages/TenantReadiness.tsx
@@ -206,8 +206,7 @@ const TenantReadiness = () => {
               notifyCheckReadinessMutation.isPending ||
               checkReadinessJob?.status === 'IN_PROGRESS' ||
               checkReadinessJob?.status === 'INITIALISING' ||
-              checkReadinessJob?.status === 'INITIALISED' ||
-              checkReadinessJob?.status === 'COMPLETED'
+              checkReadinessJob?.status === 'INITIALISED'
             }
           >
             {notifyCheckReadinessMutation.isPending

--- a/src/pages/TenantReports.module.css
+++ b/src/pages/TenantReports.module.css
@@ -63,8 +63,8 @@
 .report-item-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
+  align-items: start;
+  gap: 1rem;
 }
 
 .report-name {

--- a/src/pages/TenantReports.tsx
+++ b/src/pages/TenantReports.tsx
@@ -68,6 +68,11 @@ const TenantReports = ({ tenantId }: { tenantId: string }) => {
               >
                 <div className={styles['report-item-header']}>
                   <span className={styles['report-name']}>{report.name}</span>
+                  {report.disabled ? (
+                    <span className={styles['status-disabled']}>Inactive</span>
+                  ) : (
+                    <span className={styles['status-enabled']}>Active</span>
+                  )}
                 </div>
                 {report.description && (
                   <p className={styles['report-item-description']}>
@@ -105,7 +110,7 @@ const TenantReports = ({ tenantId }: { tenantId: string }) => {
                 <div className={styles['meta-item']}>
                   <span className={styles['meta-label']}>Status:</span>
                   {reportDetail.disabled ? (
-                    <span className={styles['status-disabled']}>Disabled</span>
+                    <span className={styles['status-disabled']}>Inactive</span>
                   ) : (
                     <span className={styles['status-enabled']}>Active</span>
                   )}


### PR DESCRIPTION
This PR enables shareable URLs for the tenant details and reports tab in the Tenant Details page, allowing users to link directly to or share specific tabs via URL hash navigation