### PR TITLE
[ARGO-5440] - Implement Reusable Icon Button Component

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from 'react'
+
+interface IconButtonProps {
+  icon: ReactElement
+  label: string
+  onClick: () => void
+  className?: string
+  disabled?: boolean
+  type?: 'button' | 'submit' | 'reset'
+}
+
+const IconButton = ({
+  icon,
+  label,
+  onClick,
+  className = '',
+  disabled = false,
+  type = 'button',
+}: IconButtonProps) => (
+  <button
+    type={type}
+    aria-label={label}
+    data-tip={label}
+    onClick={onClick}
+    disabled={disabled}
+    className={`p-1.5 rounded-lg transition-all cursor-pointer border-none bg-transparent tooltip disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+  >
+    {icon}
+  </button>
+)
+
+export default IconButton

--- a/src/components/TenantCardFooter.tsx
+++ b/src/components/TenantCardFooter.tsx
@@ -9,11 +9,9 @@ import {
   Square3Stack3DIcon,
   ClipboardDocumentListIcon,
 } from '@heroicons/react/16/solid'
+import IconButton from '@/components/IconButton'
 
-const actionButtonBase =
-  'p-1 min-[940px]:p-1.5 rounded-lg transition-all cursor-pointer border-none bg-transparent tooltip'
-
-const actionIconClass = 'size-4 min-[940px]:size-5'
+const actionIconClass = 'size-4.5 min-[940px]:size-5'
 
 interface TenantCardFooterProps {
   isSuperAdmin: boolean
@@ -41,96 +39,78 @@ const TenantCardFooter = ({
   onDelete,
 }: TenantCardFooterProps) => (
   <>
-    <button
-      aria-label="View Tenant Details"
-      className={`${actionButtonBase} text-indigo-500 hover:bg-indigo-100`}
-      data-tip="View Tenant Details"
+    <IconButton
+      label="View Tenant Details"
+      icon={<Bars3Icon className={actionIconClass} />}
       onClick={onViewDetails}
-    >
-      <Bars3Icon className={actionIconClass} />
-    </button>
+      className="text-indigo-500 hover:bg-indigo-100"
+    />
 
     {(isSuperAdmin || isAdmin) && (
       <>
-        <button
-          aria-label="Edit Tenant"
-          className={`${actionButtonBase} text-muted hover:bg-gray-200`}
-          data-tip="Edit Tenant"
+        <IconButton
+          label="Edit Tenant"
+          icon={<PencilSquareIcon className={actionIconClass} />}
           onClick={onEdit}
-        >
-          <PencilSquareIcon className={actionIconClass} />
-        </button>
-        <button
-          aria-label="Manage Members"
-          className={`${actionButtonBase} text-violet-700 hover:bg-violet-100`}
-          data-tip="Manage Members"
+          className="text-muted hover:bg-gray-200"
+        />
+        <IconButton
+          label="Manage Members"
+          icon={<UserGroupIcon className={actionIconClass} />}
           onClick={onManageMembers}
-        >
-          <UserGroupIcon className={actionIconClass} />
-        </button>
+          className="text-violet-700 hover:bg-violet-100"
+        />
       </>
     )}
 
     {!isSuperAdmin && (
-      <button
-        aria-label="View Assigned Projects"
-        className={`${actionButtonBase} text-blue-600 hover:bg-brand-muted`}
-        data-tip="View Assigned Projects"
+      <IconButton
+        label="View Assigned Projects"
+        icon={<ClipboardDocumentListIcon className={actionIconClass} />}
         onClick={onAssignProjects}
-      >
-        <ClipboardDocumentListIcon className={actionIconClass} />
-      </button>
+        className="text-blue-600 hover:bg-brand-muted"
+      />
     )}
 
     {isSuperAdmin && (
-      <button
-        aria-label="Assign Projects"
-        className={`${actionButtonBase} text-blue-600 hover:bg-brand-muted`}
-        data-tip="Assign Projects"
+      <IconButton
+        label="Assign Projects"
+        icon={<PlusCircleIcon className={actionIconClass} />}
         onClick={onAssignProjects}
-      >
-        <PlusCircleIcon className={actionIconClass} />
-      </button>
+        className="text-blue-600 hover:bg-brand-muted"
+      />
     )}
 
     {(isSuperAdmin || isAdmin) && (
       <>
-        <button
-          aria-label="View Status"
-          className={`${actionButtonBase} text-emerald-600 hover:bg-green-50`}
-          data-tip="View Status"
+        <IconButton
+          label="View Status"
+          icon={<ListBulletIcon className={actionIconClass} />}
           onClick={onViewStatus}
-        >
-          <ListBulletIcon className={actionIconClass} />
-        </button>
-        <button
-          aria-label="Check Readiness"
-          className={`${actionButtonBase} text-cyan-600 hover:bg-cyan-50`}
-          data-tip="Check Readiness"
+          className="text-emerald-600 hover:bg-green-50"
+        />
+        <IconButton
+          label="Check Readiness"
+          icon={<ShieldCheckIcon className={actionIconClass} />}
           onClick={onReadiness}
-        >
-          <ShieldCheckIcon className={actionIconClass} />
-        </button>
-        <button
-          aria-label="Capabilities"
-          className={`${actionButtonBase} text-amber-600 hover:bg-amber-50`}
-          data-tip="Capabilities"
+          className="text-cyan-600 hover:bg-cyan-50"
+        />
+        <IconButton
+          label="Capabilities"
+          icon={<Square3Stack3DIcon className={actionIconClass} />}
           onClick={onCapabilities}
-        >
-          <Square3Stack3DIcon className="w-[1.3rem]" />
-        </button>
+          className="text-amber-600 hover:bg-amber-50"
+        />
       </>
     )}
 
     {isSuperAdmin && (
-      <button
-        aria-label="Delete Tenant"
-        className={`${actionButtonBase} text-red-600 hover:bg-red-50`}
-        data-tip="Delete Tenant"
+      <IconButton
+        label="Delete Tenant"
+        icon={<TrashIcon className={actionIconClass} />}
         onClick={onDelete}
-      >
-        <TrashIcon className={actionIconClass} />
-      </button>
+        className="text-red-600 hover:bg-red-50"
+      />
     )}
   </>
 )

--- a/src/pages/Build.tsx
+++ b/src/pages/Build.tsx
@@ -219,7 +219,7 @@ const Build = () => {
   }
 
   useEffect(() => {
-    if (!report && !tenantId && !groupsMutation.isPending)
+    if (report && tenantId && !groupsMutation.isPending)
       groupsMutation.mutate({ tenantId, reportId: report })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [report, tenantId])

--- a/src/pages/ManageTenantMembers.tsx
+++ b/src/pages/ManageTenantMembers.tsx
@@ -459,7 +459,7 @@ const ManageTenantMembers = () => {
             {activeTab === 'invite' && (
               <div className="animate-fade-in">
                 <form onSubmit={handleInviteSubmit} className="max-w-xl">
-                  <div className="bg-surface-subtle border border-line rounded-lg p-6">
+                  <div className="bg-surface-subtle border border-line rounded-lg px-6 py-4">
                     <h2 className="text-lg font-semibold text-gray-800 mb-2.5">
                       Invite New Member
                     </h2>
@@ -511,7 +511,7 @@ const ManageTenantMembers = () => {
                       </div>
                     </div>
 
-                    <div className="flex justify-start">
+                    <div className="flex justify-start pb-1">
                       <Button
                         variant="primary"
                         size="md"
@@ -533,7 +533,7 @@ const ManageTenantMembers = () => {
             {activeTab === 'add-direct' && isSuperAdmin && (
               <div className="animate-fade-in">
                 <form onSubmit={handleAddDirectSubmit} className="max-w-xl">
-                  <div className="bg-surface-subtle border border-line rounded-lg p-6">
+                  <div className="bg-surface-subtle border border-line rounded-lg px-6 py-4">
                     <h2 className="text-lg font-semibold text-gray-800 mb-2.5">
                       Add a Member Directly
                     </h2>
@@ -649,7 +649,7 @@ const ManageTenantMembers = () => {
                       </div>
                     </div>
 
-                    <div className="flex justify-start">
+                    <div className="flex justify-start pb-1">
                       <Button
                         variant="primary"
                         size="md"

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useGetProjects, useDeleteProjectMutation } from '@/hooks/useProjects'
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
 import Button from '@/components/Button'
+import IconButton from '@/components/IconButton'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import ConfirmDialog from '@/components/ConfirmDialog'
@@ -13,9 +14,6 @@ import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
 const pageSize = 9
-
-const actionButtonBase =
-  'p-1 min-[840px]:p-1.5 rounded-lg transition-all cursor-pointer border-none bg-transparent tooltip'
 
 const actionIconClass = 'size-4 min-[840px]:size-5'
 
@@ -153,24 +151,20 @@ const Projects = () => {
                   key={project.id}
                   footer={
                     <>
-                      <button
-                        aria-label="Edit Project"
-                        className={`${actionButtonBase} text-muted hover:bg-gray-200`}
-                        data-tip="Edit"
+                      <IconButton
+                        label="Edit Project"
+                        icon={<PencilSquareIcon className={actionIconClass} />}
                         onClick={() => handleEdit(project.id!)}
-                      >
-                        <PencilSquareIcon className={actionIconClass} />
-                      </button>
-                      <button
-                        aria-label="Delete Project"
-                        className={`${actionButtonBase} text-red-600 hover:bg-red-50`}
-                        data-tip="Delete"
+                        className="text-muted hover:bg-gray-200"
+                      />
+                      <IconButton
+                        label="Delete Project"
+                        icon={<TrashIcon className={actionIconClass} />}
                         onClick={() =>
                           handleDeleteClick(project.id!, project.name)
                         }
-                      >
-                        <TrashIcon className={actionIconClass} />
-                      </button>
+                        className="text-red-600 hover:bg-red-50"
+                      />
                     </>
                   }
                 >

--- a/src/pages/TenantInvitations.tsx
+++ b/src/pages/TenantInvitations.tsx
@@ -63,7 +63,9 @@ const TenantInvitations = ({
 
   return (
     <>
-      <h2 className="section-title">Tenant Invitations</h2>
+      <h2 className="text-lg font-semibold text-gray-800 mb-2.5">
+        Tenant Invitations
+      </h2>
       {invitationsError ? (
         <ErrorDisplay error={invitationsError} context="invitations" />
       ) : (


### PR DESCRIPTION
This PR introduces a reusable IconButton component to standardise icon-only action buttons across the application.

- Added IconButton component for icon-only buttons 
- Refactored TenantCardFooter and Projects to use IconButton, removing duplicated button styling
- Fixed an inverted condition in Build that was preventing a mutation from executing correctly
- Updated minor spacing and heading styles in TenantInvitations