### PR TITLE
[ARGO-5442] - Refactor Page Header Layout

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -33,8 +33,8 @@ function SidebarNavItem({
         [
           'flex items-center gap-3 px-4 py-3 text-sm transition-colors rounded-md mx-2',
           isActive
-            ? 'bg-brand-subtle text-brand font-medium border-l-4 border-blue-600'
-            : 'text-body hover:bg-gray-100 hover:text-blue-600',
+            ? 'bg-brand-subtle text-brand font-medium border-l-4 border-brand'
+            : 'text-body hover:bg-surface-strong hover:text-brand',
         ].join(' ')
       }
     >
@@ -143,10 +143,10 @@ export default function Layout() {
                 <Link
                   to="/profile"
                   onClick={closeMobileMenu}
-                  className="tooltip"
+                  className="tooltip focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                   data-tip="View Profile"
                 >
-                  <div className="flex items-center gap-2 min-w-0 flex-1 hover:bg-gray-100 p-2 -m-2 rounded-lg w-auto max-w-40 md:max-w-48">
+                  <div className="flex items-center gap-2 min-w-0 flex-1 hover:bg-surface-strong p-2 -m-2 rounded-lg w-auto max-w-40 md:max-w-48">
                     <div className="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0">
                       {(profile?.name || 'U').charAt(0).toUpperCase()}
                     </div>
@@ -159,7 +159,7 @@ export default function Layout() {
                   </div>
                 </Link>
                 <button
-                  className="me-2 p-1 hover:bg-gray-100 rounded-lg transition-colors flex-shrink-0 cursor-pointer tooltip"
+                  className="me-2 p-1 hover:bg-surface-strong rounded-lg transition-colors flex-shrink-0 cursor-pointer tooltip"
                   data-tip="Logout"
                   onClick={logout}
                   type="button"
@@ -175,7 +175,7 @@ export default function Layout() {
       {/* Page content */}
       <main className="flex-1 bg-white overflow-auto">
         <div
-          className={`${tDetsRoute ? '' : 'container mx-2 md:mx-auto py-6 px-4 md:px-6'}`}
+          className={`${tDetsRoute ? '' : 'container mx-2 md:mx-auto p-4 md:px-6'}`}
         >
           {!authenticated ? (
             <LoginPrompt

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import { type ButtonHTMLAttributes, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 
 type ButtonVariant =
   | 'primary'
@@ -11,17 +12,18 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant
   size?: ButtonSize
   children: ReactNode
+  href?: string
 }
 
 const variantClassMap: Record<ButtonVariant, string> = {
   primary:
-    'bg-brand text-white border-brand hover:enabled:bg-blue-800 hover:enabled:border-blue-800',
+    'bg-brand text-white border-brand hover:bg-brand-strong hover:border-brand-strong',
   secondary:
-    'bg-gray-600 text-white border-gray-600 hover:enabled:bg-gray-700 hover:enabled:border-gray-700',
+    'bg-gray-600 text-white border-gray-600 hover:bg-gray-700 hover:border-gray-700',
   'outline-primary':
-    'bg-white text-blue-600 border-blue-600 hover:enabled:bg-brand-subtle',
+    'bg-white text-brand border-brand font-medium hover:bg-brand-subtle',
   'outline-secondary':
-    'bg-white text-muted border-gray-600 hover:enabled:bg-surface-muted',
+    'bg-white text-body border-line-strong font-medium hover:bg-surface-strong hover:border-gray-400',
 }
 
 const sizeClassMap: Record<ButtonSize, string> = {
@@ -36,12 +38,13 @@ function Button({
   size = 'md',
   className = '',
   disabled,
+  href,
   children,
   ...props
 }: ButtonProps) {
   const buttonClasses = [
-    'inline-flex items-center justify-center gap-2 font-normal rounded-md border transition-colors cursor-pointer',
-    'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+    'inline-flex items-center justify-center gap-2 font-base rounded-md border transition-colors cursor-pointer',
+    'focus:outline-none',
     'disabled:opacity-50 disabled:cursor-not-allowed',
     variantClassMap[variant],
     sizeClassMap[size],
@@ -49,6 +52,14 @@ function Button({
   ]
     .filter(Boolean)
     .join(' ')
+
+  if (href) {
+    return (
+      <Link to={href} className={buttonClasses}>
+        {children}
+      </Link>
+    )
+  }
 
   return (
     <button className={buttonClasses} disabled={disabled} {...props}>

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import { XMarkIcon } from '@heroicons/react/16/solid'
-import Button from './Button'
+import Button from '@/components/Button'
 
 type ConfirmDialogProps = {
   isOpen: boolean
@@ -34,7 +34,7 @@ const ConfirmDialog = ({
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-line">
           <h3 className="text-xl font-semibold text-foreground m-0">{title}</h3>
           <button
-            className="p-1 rounded-full text-muted bg-transparent border-none cursor-pointer transition-colors hover:bg-gray-100 hover:text-foreground"
+            className="p-1 rounded-full text-muted bg-transparent border-none cursor-pointer transition-colors hover:bg-surface-strong hover:text-foreground"
             onClick={onCancel}
             aria-label="Close dialog"
           >

--- a/src/components/ContactInformation.tsx
+++ b/src/components/ContactInformation.tsx
@@ -5,7 +5,7 @@ import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
 const sectionClass =
   'grid grid-cols-1 md:grid-cols-[300px_1fr] gap-4 md:gap-8 mb-6 animate-fade-in'
 const sectionContentClass =
-  'bg-surface-subtle border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
+  'bg-surface-muted border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
 const iconButtonClass =
   'flex items-center justify-center size-7 rounded-md bg-blue-500 text-white border-none cursor-pointer hover:bg-blue-600'
 const iconButtonDangerClass =

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,9 +1,11 @@
 import type { ReactElement } from 'react'
+import { Link } from 'react-router-dom'
 
 interface IconButtonProps {
   icon: ReactElement
   label: string
-  onClick: () => void
+  onClick?: () => void
+  href?: string
   className?: string
   disabled?: boolean
   type?: 'button' | 'submit' | 'reset'
@@ -13,20 +15,38 @@ const IconButton = ({
   icon,
   label,
   onClick,
+  href,
   className = '',
   disabled = false,
   type = 'button',
-}: IconButtonProps) => (
-  <button
-    type={type}
-    aria-label={label}
-    data-tip={label}
-    onClick={onClick}
-    disabled={disabled}
-    className={`p-1.5 rounded-lg transition-all cursor-pointer border-none bg-transparent tooltip disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
-  >
-    {icon}
-  </button>
-)
+}: IconButtonProps) => {
+  const baseClasses = `p-1.5 rounded-lg transition-all cursor-pointer border-none bg-transparent tooltip focus:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:opacity-50 disabled:cursor-not-allowed ${className}`
+
+  if (href) {
+    return (
+      <Link
+        to={href}
+        aria-label={label}
+        data-tip={label}
+        className={baseClasses}
+      >
+        {icon}
+      </Link>
+    )
+  }
+
+  return (
+    <button
+      type={type}
+      aria-label={label}
+      data-tip={label}
+      onClick={onClick}
+      disabled={disabled}
+      className={baseClasses}
+    >
+      {icon}
+    </button>
+  )
+}
 
 export default IconButton

--- a/src/components/InfrastructureMetadata.tsx
+++ b/src/components/InfrastructureMetadata.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from '@/types/tenants'
 const sectionClass =
   'grid grid-cols-1 md:grid-cols-[300px_1fr] gap-4 md:gap-8 mb-6 animate-fade-in'
 const sectionContentClass =
-  'bg-surface-subtle border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
+  'bg-surface-muted border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
 const fieldGridClass =
   'grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-3'
 const iconButtonClass =

--- a/src/components/MetricProfileItem.tsx
+++ b/src/components/MetricProfileItem.tsx
@@ -61,7 +61,7 @@ const MetricProfileItem = ({
                   className="border border-line rounded-md overflow-hidden"
                 >
                   <button
-                    className="w-full flex items-center flex-wrap gap-2 px-3 py-2.5 bg-surface-subtle border-none cursor-pointer text-left transition-colors hover:bg-gray-100"
+                    className="w-full flex items-center flex-wrap gap-2 px-3 py-2.5 bg-surface-muted border-none cursor-pointer text-left transition-colors hover:bg-surface-strong"
                     onClick={() => onToggleService(service.service)}
                   >
                     <span className="text-[0.625rem] text-muted leading-none shrink-0">

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,20 +1,38 @@
+import { ArrowLeftIcon } from '@heroicons/react/16/solid'
+import { Link } from 'react-router-dom'
 import type { ReactNode } from 'react'
+
+interface NavigateTo {
+  label: string
+  to: string
+}
 
 interface PageHeaderProps {
   title: ReactNode
   subtitle?: ReactNode
   children?: ReactNode
   className?: string
+  navigateTo?: NavigateTo
 }
 
 const PageHeader = ({
   title,
   subtitle,
   children,
-  className = 'flex justify-between items-center mb-6',
+  className,
+  navigateTo,
 }: PageHeaderProps) => (
-  <div className={className}>
+  <div className={`flex justify-between items-center ${className ?? ''}`}>
     <div>
+      {navigateTo && (
+        <Link
+          to={navigateTo.to}
+          className="inline-flex items-center gap-1.5 text-base text-subtle hover:text-foreground no-underline mb-1 transition-colors"
+        >
+          <ArrowLeftIcon className="size-4" />
+          {navigateTo.label}
+        </Link>
+      )}
       <h1 className="text-[1.75rem] leading-8 font-bold text-gray-800">
         {title}
       </h1>

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -25,13 +25,13 @@ const SearchInput = ({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="w-full py-2 pl-10 pr-10 border border-line-strong rounded-lg text-sm transition-all focus:outline-none focus:border-blue-500 focus:ring-[3px] focus:ring-blue-500/10"
+        className="w-full py-2 pl-10 pr-10 border border-line-strong rounded-lg text-sm"
       />
       {value && (
         <button
           type="button"
           onClick={onClear}
-          className="absolute right-2 top-1/2 -translate-y-1/2 size-6 flex items-center justify-center p-3 bg-transparent border-none text-muted text-2xl cursor-pointer rounded-full transition-all hover:bg-gray-100 hover:text-body"
+          className="absolute right-2 top-1/2 -translate-y-1/2 size-6 flex items-center justify-center p-3 bg-transparent border-none text-muted text-2xl cursor-pointer rounded-full transition-all hover:bg-surface-strong hover:text-body"
           aria-label="Clear search"
         >
           ×

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -2,7 +2,7 @@ import type { ComponentType } from 'react'
 
 const tabBase =
   'px-6 py-3 pb-2 text-base font-medium bg-transparent border-0 rounded-t-md border-b-2 cursor-pointer transition-all -mb-0.5 relative flex items-center gap-1'
-const tabActive = 'text-blue-500 border-b-blue-500 hover:border-b-blue-500'
+const tabActive = 'text-brand border-b-brand hover:border-b-brand'
 const tabInactive =
   'text-muted border-b-transparent hover:text-body hover:bg-surface-muted hover:border-b-gray-300'
 
@@ -33,11 +33,11 @@ const Tabs = ({ tabs, activeTab, onChange, className }: TabsProps) => (
         >
           {Icon && <Icon className="size-5" />}
           {tab.label}
-          {tab.hasError !== undefined && (
+          {tab.hasError ? (
             <span
               className={`inline-block size-[6px] rounded-full bg-red-500 ml-[6px] transition-opacity ${tab.hasError ? 'opacity-100' : 'opacity-0'}`}
             />
-          )}
+          ) : null}
         </button>
       )
     })}

--- a/src/components/TenantCardFooter.tsx
+++ b/src/components/TenantCardFooter.tsx
@@ -16,33 +16,21 @@ const actionIconClass = 'size-4.5 min-[940px]:size-5'
 interface TenantCardFooterProps {
   isSuperAdmin: boolean
   isAdmin: boolean
-  onViewDetails: () => void
-  onEdit: () => void
-  onManageMembers: () => void
-  onAssignProjects: () => void
-  onViewStatus: () => void
-  onReadiness: () => void
-  onCapabilities: () => void
+  tenantId: string
   onDelete: () => void
 }
 
 const TenantCardFooter = ({
   isSuperAdmin,
   isAdmin,
-  onViewDetails,
-  onEdit,
-  onManageMembers,
-  onAssignProjects,
-  onViewStatus,
-  onReadiness,
-  onCapabilities,
+  tenantId,
   onDelete,
 }: TenantCardFooterProps) => (
   <>
     <IconButton
       label="View Tenant Details"
       icon={<Bars3Icon className={actionIconClass} />}
-      onClick={onViewDetails}
+      href={`/tenants/${tenantId}/details`}
       className="text-indigo-500 hover:bg-indigo-100"
     />
 
@@ -51,13 +39,13 @@ const TenantCardFooter = ({
         <IconButton
           label="Edit Tenant"
           icon={<PencilSquareIcon className={actionIconClass} />}
-          onClick={onEdit}
+          href={`/tenants/edit/${tenantId}`}
           className="text-muted hover:bg-gray-200"
         />
         <IconButton
           label="Manage Members"
           icon={<UserGroupIcon className={actionIconClass} />}
-          onClick={onManageMembers}
+          href={`/tenants/${tenantId}/members`}
           className="text-violet-700 hover:bg-violet-100"
         />
       </>
@@ -67,7 +55,7 @@ const TenantCardFooter = ({
       <IconButton
         label="View Assigned Projects"
         icon={<ClipboardDocumentListIcon className={actionIconClass} />}
-        onClick={onAssignProjects}
+        href={`/tenants/${tenantId}/projects/assign`}
         className="text-blue-600 hover:bg-brand-muted"
       />
     )}
@@ -76,7 +64,7 @@ const TenantCardFooter = ({
       <IconButton
         label="Assign Projects"
         icon={<PlusCircleIcon className={actionIconClass} />}
-        onClick={onAssignProjects}
+        href={`/tenants/${tenantId}/projects/assign`}
         className="text-blue-600 hover:bg-brand-muted"
       />
     )}
@@ -86,19 +74,19 @@ const TenantCardFooter = ({
         <IconButton
           label="View Status"
           icon={<ListBulletIcon className={actionIconClass} />}
-          onClick={onViewStatus}
+          href={`/tenants/${tenantId}/status`}
           className="text-emerald-600 hover:bg-green-50"
         />
         <IconButton
           label="Check Readiness"
           icon={<ShieldCheckIcon className={actionIconClass} />}
-          onClick={onReadiness}
+          href={`/tenants/${tenantId}/readiness`}
           className="text-cyan-600 hover:bg-cyan-50"
         />
         <IconButton
           label="Capabilities"
           icon={<Square3Stack3DIcon className={actionIconClass} />}
-          onClick={onCapabilities}
+          href={`/tenants/${tenantId}/capabilities`}
           className="text-amber-600 hover:bg-amber-50"
         />
       </>

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -241,7 +241,7 @@ export const useUpdateTenantStatusMutation = () => {
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: ['tenant-status', variables.id],
+        queryKey: ['user-tenant-status', variables.id],
       })
     },
     onError: (error) => {

--- a/src/index.css
+++ b/src/index.css
@@ -2,89 +2,36 @@
 @plugin "daisyui";
 
 @theme {
-  --color-foreground: #111827; /* gray-900 — primary text, headings, strong emphasis */
-  --color-body: #374151; /* gray-700 — default body/label text */
-  --color-muted: #6b7280; /* gray-500 — secondary, supporting text */
-  --color-subtle: #9ca3af; /* gray-400 — placeholder, de-emphasised text */
+  /* Text scale */
+  --color-foreground: #111827; /* gray-900 — primary text */
+  --color-body: #374151; /* gray-700 — body text */
+  --color-muted: #6b7280; /* gray-500 — secondary text */
+  --color-subtle: #9ca3af; /* gray-400 — de-emphasised text */
 
-  --color-surface-muted: #f9fafb; /* gray-50 — light backgrounds */
-  --color-surface-subtle: #fafafa; /* near-white — very light backgrounds */
+  /* Surface scale */
+  --color-surface-strong: #f3f4f6; /* gray-100 — prominent neutral background */
+  --color-surface-muted: #f9fafb; /* gray-50  — neutral background */
 
-  --color-brand: #1d4ed8; /* blue-700 — default for buttons and links */
-  --color-brand-muted: #dbeafe; /* blue-100 — badge backgrounds */
-  --color-brand-subtle: #eff6ff; /* blue-50  — hover and active surfaces */
+  /* Brand scale */
+  --color-brand-strong: #1e40af; /* blue-800 — hover/active */
+  --color-brand: #1d4ed8; /* blue-700 — fills */
+  --color-brand-muted: #dbeafe; /* blue-100 — tinted background */
+  --color-brand-subtle: #eff6ff; /* blue-50  — subtle tinted background */
 
   /* Border scale */
-  --color-line: #e5e7eb; /* gray-200 — default borders */
-  --color-line-strong: #d1d5db; /* gray-300 — bold borders */
+  --color-line-strong: #d1d5db; /* gray-300 — strong border */
+  --color-line: #e5e7eb; /* gray-200 — border */
 
   /* Custom animations */
   --animate-fade-in: fade-in 0.3s ease;
-  --animate-pulse-ring: pulse-ring 2s cubic-bezier(0.3, 0, 0.5, 1) infinite;
-  --animate-pulse-dot: pulse-dot 2s cubic-bezier(0.3, 0, 0.5, 1) infinite;
+  --animate-pulse-ring: pulse-ring 3s cubic-bezier(0.3, 0, 0.5, 1) infinite;
+  --animate-pulse-dot: pulse-dot 3s cubic-bezier(0.3, 0, 0.5, 1) infinite;
 }
 
 /* Global element defaults */
 @layer base {
-  input {
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--color-line-strong);
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    color: var(--color-foreground);
-    background: white;
-    transition: all 0.2s;
-    appearance: none;
-  }
-
-  input:focus {
-    outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
-  }
-
-  input:disabled {
-    background-color: #f3f4f6;
-    color: var(--color-muted);
-    cursor: not-allowed;
-    opacity: 0.7;
-  }
-
-  input::placeholder {
-    color: var(--color-subtle);
-  }
-
-  textarea {
-    min-height: 60px;
-    max-height: 200px;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--color-line-strong);
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    color: var(--color-foreground);
-    background: white;
-    resize: vertical;
-    font-family: inherit;
-    appearance: none;
-  }
-
-  textarea:focus {
-    outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
-  }
-
-  textarea:disabled {
-    background-color: #f3f4f6;
-    color: var(--color-muted);
-    cursor: not-allowed;
-    opacity: 0.7;
-  }
-
-  textarea::placeholder {
-    color: var(--color-subtle);
-  }
-
+  input,
+  textarea,
   select {
     padding: 0.5rem 0.75rem;
     border: 1px solid var(--color-line-strong);
@@ -92,9 +39,21 @@
     font-size: 0.875rem;
     color: var(--color-foreground);
     background: white;
-    transition: all 0.2s;
-    cursor: pointer;
+    transition:
+      border-color 0.2s,
+      box-shadow 0.2s;
     appearance: none;
+  }
+
+  textarea {
+    min-height: 60px;
+    max-height: 200px;
+    resize: vertical;
+    font-family: inherit;
+  }
+
+  select {
+    cursor: pointer;
     background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
     background-repeat: no-repeat;
     background-position: right 0.5rem center;
@@ -102,17 +61,27 @@
     padding-right: 2.5rem;
   }
 
+  input:focus,
+  textarea:focus,
   select:focus {
     outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+    border-color: var(--color-brand);
+    box-shadow: 0 0 0 2px
+      color-mix(in srgb, var(--color-brand) 10%, transparent);
   }
 
+  input:disabled,
+  textarea:disabled,
   select:disabled {
-    background-color: #f3f4f6;
+    background-color: var(--color-surface-strong);
     color: var(--color-muted);
     cursor: not-allowed;
     opacity: 0.7;
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: var(--color-subtle);
   }
 }
 
@@ -169,10 +138,12 @@
 @keyframes pulse-ring {
   0%,
   100% {
-    box-shadow: 0 0 0 6px rgba(59, 130, 246, 0.15);
+    box-shadow: 0 0 0 6px
+      color-mix(in srgb, var(--color-brand) 15%, transparent);
   }
   50% {
-    box-shadow: 0 0 0 10px rgba(59, 130, 246, 0.25);
+    box-shadow: 0 0 0 10px
+      color-mix(in srgb, var(--color-brand) 20%, transparent);
   }
 }
 

--- a/src/pages/AdminInvitations.tsx
+++ b/src/pages/AdminInvitations.tsx
@@ -143,7 +143,7 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
     return (
       <>
         <DataTable tableClassName="table-fixed min-w-[700px]">
-          <thead className="bg-gray-100 border-b border-line">
+          <thead className="bg-surface-strong border-b border-line">
             <tr>
               <th className={`${thBase} w-[22%]`}>
                 <SortableColumnHeader
@@ -212,7 +212,7 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
                     size="xs"
                     className={
                       roleBadgeClass[invitation.role] ??
-                      'bg-gray-100 text-muted'
+                      'bg-surface-strong text-muted'
                     }
                   >
                     {invitation.role === 'admin' ? 'Admin' : 'Viewer'}
@@ -221,7 +221,7 @@ const AdminInvitations = ({ isSuperAdmin }: AdminInvitationsProps) => {
                 <td className={tdBase}>
                   <Badge
                     size="xs"
-                    className={`capitalize ${invitationStatusBadgeClass[invitation.status] ?? 'bg-gray-100 text-muted'}`}
+                    className={`capitalize ${invitationStatusBadgeClass[invitation.status] ?? 'bg-surface-strong text-muted'}`}
                   >
                     {invitation.status === 'PENDING'
                       ? 'Pending'

--- a/src/pages/Administration.tsx
+++ b/src/pages/Administration.tsx
@@ -10,7 +10,7 @@ import SearchInput from '@/components/SearchInput'
 import Tabs from '@/components/Tabs'
 import DataTable, { thBase, SortableColumnHeader } from '@/components/DataTable'
 import Pagination from '@/components/Pagination'
-import { useNavigate } from 'react-router-dom'
+import IconButton from '@/components/IconButton'
 import { squishEmail } from '@/utils/profile'
 
 type SortColumn = 'username' | 'firstName' | 'lastName' | 'email' | 'tenants'
@@ -28,7 +28,6 @@ const Administration = () => {
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [currentPage, setCurrentPage] = useState(1)
-  const navigate = useNavigate()
 
   const { profile } = useAuth()
   const isSuperAdmin = profile?.roles?.includes('super_admin')
@@ -108,7 +107,7 @@ const Administration = () => {
       <PageHeader
         title="Administration Panel"
         subtitle="Central management and configuration"
-        className="mb-6"
+        className="mb-2"
       />
 
       <Tabs
@@ -141,7 +140,7 @@ const Administration = () => {
             <>
               {filteredUsers.length > 0 ? (
                 <DataTable tableClassName="table-fixed min-w-[700px]">
-                  <thead className="bg-gray-100 border-b border-line">
+                  <thead className="bg-surface-strong border-b border-line">
                     <tr>
                       <th className={`${thBase} w-[15%]`}>
                         <SortableColumnHeader
@@ -249,18 +248,14 @@ const Administration = () => {
                         </td>
                         <td className="px-4 py-3 break-words text-sm">
                           <div className="flex items-center gap-1 ml-2.5">
-                            <button
-                              onClick={() =>
-                                navigate(
-                                  `/administration/users/${encodeURIComponent(user?.username?.split('@')[0] || '')}`,
-                                )
+                            <IconButton
+                              href={`/administration/users/${encodeURIComponent(user?.username?.split('@')[0] || '')}`}
+                              icon={
+                                <UserCircleIcon className="size-[1.125rem] md:size-[1.375rem]" />
                               }
-                              className="tooltip p-1.5 text-muted bg-transparent border-none rounded-lg flex items-center justify-center cursor-pointer transition-all hover:bg-gray-200 hover:text-foreground"
-                              data-tip="Manage user"
-                              aria-label="Manage user"
-                            >
-                              <UserCircleIcon className="size-[1.125rem] md:size-[1.375rem]" />
-                            </button>
+                              label="Manage user"
+                              className="text-muted hover:bg-gray-200 hover:text-foreground"
+                            />
                           </div>
                         </td>
                       </tr>

--- a/src/pages/AssignProjects.tsx
+++ b/src/pages/AssignProjects.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/hooks/useTenants'
 import { useGetAllProjects } from '@/hooks/useProjects'
 import { GripVertical } from 'lucide-react'
-import { ArrowLeftIcon } from '@heroicons/react/16/solid'
 import type { ProjectItem } from '@/types/projects'
 import { useAuth } from '@/auth/useAuth'
 import LoadingSpinner from '@/components/LoadingSpinner'
@@ -29,7 +28,7 @@ const columnClass =
   'flex flex-col bg-white border border-line rounded-lg overflow-hidden'
 
 const columnHeaderClass =
-  'flex justify-between items-center px-5 py-3.5 bg-gray-100 border-b border-line'
+  'flex justify-between items-center px-5 py-3.5 bg-surface-strong border-b border-line'
 
 const listContainerClass =
   'bg-surface-muted min-h-[300px] max-h-[400px] md:min-h-[400px] md:max-h-[500px] overflow-y-auto'
@@ -211,10 +210,6 @@ const AssignProjects = () => {
     )
   }
 
-  const handleCancel = () => {
-    navigate('/tenants')
-  }
-
   if (!isInitialized) {
     return (
       <div className="loading-container">
@@ -250,13 +245,9 @@ const AssignProjects = () => {
               </strong>
             </span>
           }
-          className="flex flex-col gap-4 items-stretch pb-4 mb-4 md:flex-row md:items-start md:justify-between"
-        >
-          <Button onClick={handleCancel} size="sm" variant="secondary">
-            <ArrowLeftIcon className="size-4" />
-            Back to Tenants
-          </Button>
-        </PageHeader>
+          className="pb-1 mb-1"
+          navigateTo={{ label: 'Back to Tenants', to: '/tenants' }}
+        />
 
         {!isReadOnly && (
           <div className="flex justify-end mb-4">

--- a/src/pages/CreateProject.tsx
+++ b/src/pages/CreateProject.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { ArrowLeftIcon } from '@heroicons/react/16/solid'
 import {
   useCreateProjectMutation,
   useUpdateProjectMutation,
@@ -9,13 +8,13 @@ import {
 import { toast } from 'sonner'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
-import Button from '../components/Button'
+import Button from '@/components/Button'
 import PageHeader from '@/components/PageHeader'
 
 const sectionClass =
   'grid grid-cols-1 md:grid-cols-[300px_1fr] gap-4 md:gap-8 mb-6 animate-fade-in'
 const sectionContentClass =
-  'bg-surface-subtle border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
+  'bg-surface-muted border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
 
 const CreateProject = () => {
   const { id: projectId } = useParams<{ id?: string }>()
@@ -224,17 +223,9 @@ const CreateProject = () => {
                   ? 'Update the project information'
                   : 'Fill in the details to create a new project'
               }
-              className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-1 pb-1"
-            >
-              <Button
-                onClick={() => navigate('/projects')}
-                size="sm"
-                variant="secondary"
-              >
-                <ArrowLeftIcon className="size-4" />
-                Back to Projects
-              </Button>
-            </PageHeader>
+              className="mb-1 pb-1"
+              navigateTo={{ label: 'Back to Projects', to: '/projects' }}
+            />
 
             <div className="flex justify-end mb-4">
               <Button

--- a/src/pages/CreateTenant.tsx
+++ b/src/pages/CreateTenant.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useDropzone } from 'react-dropzone'
 import { PhotoIcon, XMarkIcon } from '@heroicons/react/16/solid'
-import { ArrowLeftIcon } from '@heroicons/react/16/solid'
 import {
   useCreateTenantMutation,
   useGetUserTenantById,
@@ -11,7 +10,7 @@ import {
 import type { Metadata } from '@/types/tenants'
 import { toast } from 'sonner'
 import ErrorDisplay from '@/components/ErrorDisplay'
-import Button from '../components/Button'
+import Button from '@/components/Button'
 import ContactInformation from '../components/ContactInformation'
 import InfrastructureMetadata from '../components/InfrastructureMetadata'
 import LoadingSpinner from '@/components/LoadingSpinner'
@@ -23,7 +22,7 @@ const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 const sectionClass =
   'grid grid-cols-1 md:grid-cols-[300px_1fr] gap-4 md:gap-8 mb-6 animate-fade-in'
 const sectionContentClass =
-  'bg-surface-subtle border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
+  'bg-surface-muted border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -453,17 +452,9 @@ const CreateTenant = () => {
                   'Fill in the details to create a new tenant'
                 )
               }
-              className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-1 pb-1"
-            >
-              <Button
-                onClick={() => navigate('/tenants')}
-                size="sm"
-                variant="secondary"
-              >
-                <ArrowLeftIcon className="size-4" />
-                Back to Tenants
-              </Button>
-            </PageHeader>
+              className="mb-1 pb-1"
+              navigateTo={{ label: 'Back to Tenants', to: '/tenants' }}
+            />
 
             <div className="flex justify-between items-center">
               <div className="flex items-center gap-[3px]">
@@ -609,7 +600,7 @@ const CreateTenant = () => {
                       </label>
                       <div
                         {...getRootProps()}
-                        className={`border-2 border-dashed rounded-lg p-2 text-center cursor-pointer transition-all min-h-[80px] flex flex-col items-center justify-center ${isDragActive ? 'border-blue-500 bg-brand-muted' : 'border-line-strong bg-white hover:border-gray-400 hover:bg-gray-100'}`}
+                        className={`border-2 border-dashed rounded-lg p-2 text-center cursor-pointer transition-all min-h-[80px] flex flex-col items-center justify-center ${isDragActive ? 'border-blue-500 bg-brand-muted' : 'border-line-strong bg-white hover:border-gray-400 hover:bg-surface-strong'}`}
                       >
                         <input {...getInputProps()} />
                         {imagePreview ? (

--- a/src/pages/InvitationReview.tsx
+++ b/src/pages/InvitationReview.tsx
@@ -113,11 +113,7 @@ export const InvitationReview = () => {
               context="invitation"
             />
             <div className="mt-6">
-              <Button
-                variant="secondary"
-                size="md"
-                onClick={() => navigate('/')}
-              >
+              <Button variant="secondary" size="md" href="/">
                 Go to Home
               </Button>
             </div>
@@ -157,7 +153,7 @@ export const InvitationReview = () => {
                   variant="primary"
                   size="md"
                   className="w-full sm:w-auto"
-                  onClick={() => navigate('/tenants')}
+                  href="/tenants"
                 >
                   View Tenants
                 </Button>
@@ -166,7 +162,7 @@ export const InvitationReview = () => {
                 variant="secondary"
                 size="md"
                 className="w-full sm:w-auto"
-                onClick={() => navigate('/')}
+                href="/"
               >
                 Go to Home
               </Button>
@@ -268,7 +264,7 @@ export const InvitationReview = () => {
                 </>
               ) : (
                 <>
-                  <XCircleIcon className="size-5" />
+                  <XCircleIcon className="size-6" />
                   Reject Invitation
                 </>
               )}
@@ -288,7 +284,7 @@ export const InvitationReview = () => {
                 </>
               ) : (
                 <>
-                  <CheckCircleIcon className="size-5" />
+                  <CheckCircleIcon className="size-6" />
                   Accept Invitation
                 </>
               )}

--- a/src/pages/ManageTenantMembers.tsx
+++ b/src/pages/ManageTenantMembers.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useCreateTenantInvitation } from '@/hooks/useInvitations'
 import {
   useGetTenantMembers,
@@ -10,11 +10,7 @@ import {
 } from '@/hooks/useTenants'
 import { useAuth } from '@/auth/useAuth'
 import ErrorDisplay from '@/components/ErrorDisplay'
-import {
-  ArrowLeftIcon,
-  UserMinusIcon,
-  XMarkIcon,
-} from '@heroicons/react/16/solid'
+import { UserMinusIcon, XMarkIcon } from '@heroicons/react/16/solid'
 import { toast } from 'sonner'
 import Button from '@/components/Button'
 import ConfirmDialog from '@/components/ConfirmDialog'
@@ -35,7 +31,6 @@ const roleOptions = [
 
 const ManageTenantMembers = () => {
   const { id: tenantId } = useParams<{ id: string }>()
-  const navigate = useNavigate()
   const { profile } = useAuth()
   const { data: tenantData, error: tenantError } = useGetUserTenantById(
     tenantId || '',
@@ -287,10 +282,6 @@ const ManageTenantMembers = () => {
     setMemberToRemove(null)
   }
 
-  const handleBack = () => {
-    navigate('/tenants')
-  }
-
   const isLoading = membersLoading
 
   if (tenantError) {
@@ -316,13 +307,9 @@ const ManageTenantMembers = () => {
               </strong>
             </>
           }
-          className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-2 pb-2"
-        >
-          <Button onClick={handleBack} size="sm" variant="secondary">
-            <ArrowLeftIcon className="size-4" />
-            Back to Tenants
-          </Button>
-        </PageHeader>
+          className="mb-2 pb-2"
+          navigateTo={{ label: 'Back to Tenants', to: '/tenants' }}
+        />
 
         <Tabs
           tabs={[
@@ -400,7 +387,7 @@ const ManageTenantMembers = () => {
                                   className={
                                     roleBadgeClass[
                                       tenantInfo?.role ?? 'viewer'
-                                    ] ?? 'bg-gray-100 text-muted'
+                                    ] ?? 'bg-surface-strong text-muted'
                                   }
                                 >
                                   {tenantInfo?.role === 'admin'
@@ -459,7 +446,7 @@ const ManageTenantMembers = () => {
             {activeTab === 'invite' && (
               <div className="animate-fade-in">
                 <form onSubmit={handleInviteSubmit} className="max-w-xl">
-                  <div className="bg-surface-subtle border border-line rounded-lg px-6 py-4">
+                  <div className="bg-surface-muted border border-line rounded-lg px-6 py-4">
                     <h2 className="text-lg font-semibold text-gray-800 mb-2.5">
                       Invite New Member
                     </h2>
@@ -533,7 +520,7 @@ const ManageTenantMembers = () => {
             {activeTab === 'add-direct' && isSuperAdmin && (
               <div className="animate-fade-in">
                 <form onSubmit={handleAddDirectSubmit} className="max-w-xl">
-                  <div className="bg-surface-subtle border border-line rounded-lg px-6 py-4">
+                  <div className="bg-surface-muted border border-line rounded-lg px-6 py-4">
                     <h2 className="text-lg font-semibold text-gray-800 mb-2.5">
                       Add a Member Directly
                     </h2>

--- a/src/pages/MyInvitations.tsx
+++ b/src/pages/MyInvitations.tsx
@@ -3,7 +3,7 @@ import {
   useGetUserInvitations,
   useRespondToInvitation,
 } from '@/hooks/useInvitations'
-import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/solid'
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/16/solid'
 import { toast } from 'sonner'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
@@ -11,6 +11,7 @@ import PageHeader from '@/components/PageHeader'
 import DataTable, { thBase, tdBase } from '@/components/DataTable'
 import Pagination from '@/components/Pagination'
 import Badge from '@/components/Badge'
+import IconButton from '@/components/IconButton'
 import { roleBadgeClass, invitationStatusBadgeClass } from '@/utils/badges'
 
 const pageSize = 10
@@ -50,7 +51,7 @@ const MyInvitations = () => {
         <PageHeader
           title="My Invitations"
           subtitle="View and respond to your tenant invitations"
-          className="mb-8"
+          className="mb-6"
         />
 
         {isLoading ? (
@@ -67,7 +68,7 @@ const MyInvitations = () => {
                   className=""
                   tableClassName="table-fixed min-w-[700px]"
                 >
-                  <thead className="bg-gray-100 border-b border-line">
+                  <thead className="bg-surface-strong border-b border-line">
                     <tr>
                       <th className={`${thBase} w-[20%]`}>Tenant Name</th>
                       <th className={`${thBase} w-[20%]`}>Email</th>
@@ -98,7 +99,7 @@ const MyInvitations = () => {
                             size="xs"
                             className={
                               roleBadgeClass[invitation.role] ??
-                              'bg-gray-100 text-muted'
+                              'bg-surface-strong text-muted'
                             }
                           >
                             {invitation.role === 'admin'
@@ -109,7 +110,7 @@ const MyInvitations = () => {
                         <td className={tdBase}>
                           <Badge
                             size="xs"
-                            className={`capitalize ${invitationStatusBadgeClass[invitation.status] ?? 'bg-gray-100 text-muted'}`}
+                            className={`capitalize ${invitationStatusBadgeClass[invitation.status] ?? 'bg-surface-strong text-muted'}`}
                           >
                             {invitation.status === 'PENDING'
                               ? 'Pending'
@@ -134,30 +135,32 @@ const MyInvitations = () => {
                         </td>
                         <td className={tdBase}>
                           {invitation.status === 'PENDING' ? (
-                            <div className="flex items-center gap-5 flex-col md:flex-row md:gap-5">
-                              <button
+                            <div className="flex items-center gap-2 flex-col md:flex-row">
+                              <IconButton
+                                label="Accept invitation"
+                                icon={
+                                  <CheckCircleIcon className="size-7 shrink-0" />
+                                }
                                 onClick={() =>
                                   handleRespond(invitation.id, 'ACCEPT')
                                 }
-                                className="tooltip p-1 rounded-lg border flex items-center justify-center cursor-pointer transition-all w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed bg-emerald-50 border-emerald-500 text-emerald-600 hover:enabled:bg-emerald-100 hover:enabled:border-emerald-600 hover:enabled:text-emerald-700"
-                                data-tip="Accept invitation"
                                 disabled={respondMutation.isPending}
-                              >
-                                <CheckCircleIcon className="size-6 shrink-0" />
-                              </button>
-                              <button
+                                className="text-emerald-600 bg-emerald-50 hover:bg-emerald-100 w-auto"
+                              />
+                              <IconButton
+                                label="Reject invitation"
+                                icon={
+                                  <XCircleIcon className="size-7 shrink-0" />
+                                }
                                 onClick={() =>
                                   handleRespond(invitation.id, 'REJECT')
                                 }
-                                className="tooltip p-1 rounded-lg border flex items-center justify-center cursor-pointer transition-all w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed bg-red-50 border-red-500 text-red-600 hover:enabled:bg-red-100 hover:enabled:border-red-600 hover:enabled:text-red-700"
-                                data-tip="Reject invitation"
                                 disabled={respondMutation.isPending}
-                              >
-                                <XCircleIcon className="size-6 shrink-0" />
-                              </button>
+                                className="text-red-600 bg-red-50 hover:bg-red-100 w-auto"
+                              />
                             </div>
                           ) : (
-                            <span className="w-1/2 block text-muted text-sm text-center">
+                            <span className="w-1/3 block text-muted text-sm text-center">
                               -
                             </span>
                           )}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import Button from '@/components/Button'
 
 const NotFound = () => (
   <div className="page-container flex flex-col items-center justify-center min-h-[60vh] text-center py-16">
@@ -8,15 +8,12 @@ const NotFound = () => (
     <h1 className="text-2xl font-semibold text-foreground my-2">
       Page Not Found
     </h1>
-    <p className="text-muted mb-6 max-w-sm">
+    <p className="text-muted mb-4 max-w-sm">
       The page you're looking for doesn't exist or has been moved.
     </p>
-    <Link
-      to="/"
-      className="inline-flex items-center gap-2 px-4 py-2 bg-brand text-white text-sm font-medium rounded-lg hover:bg-blue-800 transition-colors"
-    >
+    <Button href="/" size="sm">
       Go to Home
-    </Link>
+    </Button>
   </div>
 )
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,6 +1,6 @@
 import { UserCircleIcon } from '@heroicons/react/16/solid'
-import { ArrowLeftIcon, UserMinusIcon } from '@heroicons/react/24/solid'
-import { Navigate, useNavigate, useParams } from 'react-router-dom'
+import { UserMinusIcon } from '@heroicons/react/24/solid'
+import { Navigate, useParams } from 'react-router-dom'
 import { useState } from 'react'
 import { useAuth } from '../auth/useAuth'
 import {
@@ -10,7 +10,6 @@ import {
 } from '@/hooks/useTenants'
 import { squishEmail } from '@/utils/profile'
 import LoadingSpinner from '@/components/LoadingSpinner'
-import Button from '@/components/Button'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import { toast } from 'sonner'
 import ErrorDisplay from '@/components/ErrorDisplay'
@@ -27,7 +26,6 @@ export const Profile = () => {
   const { username } = useParams<{ username: string }>()
 
   const { profile } = useAuth()
-  const navigate = useNavigate()
   const isSuperAdmin = profile?.roles?.includes('super_admin')
 
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false)
@@ -53,10 +51,6 @@ export const Profile = () => {
   // Determine which profile to display based on route
   const isViewingOtherUser = !!username
   const displayProfile = isViewingOtherUser ? userProfileData : null
-
-  const handleBack = () => {
-    navigate('/administration')
-  }
 
   const handleRemoveClick = (tenantName: string, role: string) => {
     setTenantToRemove({ id: '', name: tenantName, role })
@@ -126,13 +120,12 @@ export const Profile = () => {
           <PageHeader
             title="Manage User"
             subtitle="View and manage user account"
-            className="flex justify-between items-start mb-6"
-          >
-            <Button variant="secondary" size="md" onClick={handleBack}>
-              <ArrowLeftIcon className="size-4" />
-              Back to Administration
-            </Button>
-          </PageHeader>
+            className="mb-6"
+            navigateTo={{
+              label: 'Back to Administration',
+              to: '/administration',
+            }}
+          />
           <ErrorDisplay error={error.message} context="user profile" />
         </div>
       </div>
@@ -196,15 +189,13 @@ export const Profile = () => {
               ? 'View and manage user account'
               : 'View your account information'
           }
-          className="flex justify-between items-start mb-6"
-        >
-          {isViewingOtherUser && (
-            <Button variant="secondary" size="md" onClick={handleBack}>
-              <ArrowLeftIcon className="size-4" />
-              Back to Administration
-            </Button>
-          )}
-        </PageHeader>
+          className="mb-6"
+          navigateTo={
+            isViewingOtherUser
+              ? { label: 'Back to Administration', to: '/administration' }
+              : undefined
+          }
+        />
 
         {(profile || displayProfile) && (
           <div className="bg-white border border-line rounded-lg shadow-sm overflow-hidden">
@@ -301,7 +292,7 @@ export const Profile = () => {
                           {currentGroups.map((tenant, index) => (
                             <div
                               key={index}
-                              className="w-fit flex items-center justify-between px-3 py-2 bg-surface-muted border border-line rounded-lg transition-all hover:bg-gray-100"
+                              className="w-fit flex items-center justify-between px-3 py-2 bg-surface-muted border border-line rounded-lg transition-all hover:bg-surface-strong"
                             >
                               <div className="flex items-center gap-5 flex-1">
                                 <span className="text-sm font-medium text-gray-800">

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -10,7 +10,6 @@ import PageHeader from '@/components/PageHeader'
 import SearchInput from '@/components/SearchInput'
 import Pagination from '@/components/Pagination'
 import Card from '@/components/Card'
-import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
 const pageSize = 9
@@ -42,8 +41,6 @@ const Projects = () => {
     name: string
   } | null>(null)
 
-  const navigate = useNavigate()
-
   // Debounced search effect
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -53,10 +50,6 @@ const Projects = () => {
 
     return () => clearTimeout(timer)
   }, [searchInput])
-
-  const handleEdit = (projectId: string) => {
-    navigate(`/projects/edit/${projectId}`)
-  }
 
   const handleDeleteClick = (id: string, name: string) => {
     setProjectToDelete({ id, name })
@@ -117,14 +110,11 @@ const Projects = () => {
         onCancel={handleDeleteCancel}
       />
       <PageHeader
+        className="mb-6"
         title="Projects"
         subtitle="Manage and create projects for the monitoring service"
       >
-        <Button
-          variant="primary"
-          size="md"
-          onClick={() => navigate('/projects/create')}
-        >
+        <Button variant="primary" size="md" href="/projects/create">
           Create New Project
         </Button>
       </PageHeader>
@@ -154,7 +144,7 @@ const Projects = () => {
                       <IconButton
                         label="Edit Project"
                         icon={<PencilSquareIcon className={actionIconClass} />}
-                        onClick={() => handleEdit(project.id!)}
+                        href={`/projects/edit/${project.id}`}
                         className="text-muted hover:bg-gray-200"
                       />
                       <IconButton

--- a/src/pages/TenantCapabilities.tsx
+++ b/src/pages/TenantCapabilities.tsx
@@ -4,7 +4,6 @@ import PageHeader from '@/components/PageHeader'
 import { useGetUserTenantById } from '@/hooks/useTenants'
 import {
   ArrowBigUp,
-  ArrowLeftIcon,
   Check,
   ChevronRight,
   ClockIcon,
@@ -16,7 +15,7 @@ import {
   ZapIcon,
 } from 'lucide-react'
 import { useEffect, useRef, useState, type ReactElement } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 
@@ -250,7 +249,7 @@ const TenantCapabilities = () => {
   return (
     <div className="min-h-scrdeen">
       <PageHeader
-        className="max-w-7xl mx-auto flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-4 pb-2"
+        className="max-w-7xl mx-auto mb-4 pb-2"
         title="Capabilities"
         subtitle={
           <>
@@ -258,15 +257,8 @@ const TenantCapabilities = () => {
             <strong>{tenantData.info.name}</strong>
           </>
         }
-      >
-        <Link
-          to="/tenants"
-          className="inline-flex items-center gap-2 px-4 py-2 bg-gray-600 hover:bg-gray-800 text-white text-sm font-normal rounded-lg transition-colors duration-200 no-underline"
-        >
-          <ArrowLeftIcon className="size-4" />
-          <span>Back to Tenants</span>
-        </Link>
-      </PageHeader>
+        navigateTo={{ label: 'Back to Tenants', to: '/tenants' }}
+      />
 
       <div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-4">
         <CapabilityCard

--- a/src/pages/TenantDetails.tsx
+++ b/src/pages/TenantDetails.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useParams, useLocation, useNavigate } from 'react-router-dom'
+import { useParams, useLocation, Link } from 'react-router-dom'
 import { useGetUserTenantById } from '../hooks/useTenants'
 import { useGetUserTenantProjects } from '../hooks/useTenants'
 import LoadingSpinner from '@/components/LoadingSpinner'
@@ -37,7 +37,6 @@ const noDataClass = 'text-sm text-subtle italic'
 
 const TenantDetails = () => {
   const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
   const location = useLocation()
   const [activeTab, setActiveTab] = useState<'info' | 'reports'>('info')
 
@@ -67,14 +66,6 @@ const TenantDetails = () => {
 
   const projects =
     projectsData?.pages?.flatMap((page) => page.content || []) || []
-
-  const handleBack = () => {
-    navigate('/tenants')
-  }
-
-  const handleEdit = () => {
-    navigate(`/tenants/edit/${id}`)
-  }
 
   if (isLoading) {
     return (
@@ -109,23 +100,40 @@ const TenantDetails = () => {
 
   return (
     <div className="w-[100%] max-w-[1480px]">
-      <header className="bg-white my-1">
-        <div className="px-6 py-3 flex flex-col xl:flex-row items-start xl:items-center gap-4 xl:gap-6">
-          {tenantData?.info?.image ? (
-            <div className="flex-shrink-0 w-16 h-16 bg-white border border-line rounded flex items-center justify-center p-1 shadow-sm">
-              <img
-                src={tenantData.info.image}
-                alt="Logo"
-                className="object-contain"
-              />
-            </div>
-          ) : (
-            <div className="size-16 rounded-lg bg-slate-500 flex items-center justify-center flex-shrink-0">
-              <span className="text-2xl font-bold text-white">
-                {tenantData.info.name.charAt(0).toUpperCase()}
-              </span>
-            </div>
-          )}
+      <header className="px-6">
+        <Link
+          to="/tenants"
+          className="inline-flex items-center gap-1.5 text-base text-subtle hover:text-foreground no-underline transition-colors py-2"
+        >
+          <ArrowLeftIcon className="size-4" />
+          Back to Tenants
+        </Link>
+        <div className="flex flex-col xl:flex-row items-start xl:items-center gap-4 xl:gap-6">
+          <div className="flex w-full items-start justify-between xl:contents">
+            {tenantData?.info?.image ? (
+              <div className="flex-shrink-0 w-16 h-16 bg-white border border-line rounded flex items-center justify-center p-1 shadow-sm">
+                <img
+                  src={tenantData.info.image}
+                  alt="Logo"
+                  className="object-contain"
+                />
+              </div>
+            ) : (
+              <div className="size-16 rounded-lg bg-slate-500 flex items-center justify-center flex-shrink-0">
+                <span className="text-2xl font-bold text-white">
+                  {tenantData.info.name.charAt(0).toUpperCase()}
+                </span>
+              </div>
+            )}
+            <Button
+              href={`/tenants/edit/${id}`}
+              size="sm"
+              variant="primary"
+              className="whitespace-nowrap flex-shrink-0 xl:order-last xl:ml-auto self-start"
+            >
+              Edit Tenant
+            </Button>
+          </div>
 
           <div className="flex-shrink-0 xl:border-r border-gray-100 xl:pr-6 xl:mr-2 w-full xl:w-auto">
             <div className="flex items-center gap-2 flex-wrap">
@@ -184,26 +192,6 @@ const TenantDetails = () => {
               </span>
             </div>
           </div>
-
-          <div className="flex flex-row gap-3 ml-auto self-start xl:flex-col xl:items-end flex-shrink-0">
-            <Button
-              onClick={handleBack}
-              size="sm"
-              variant="secondary"
-              className="whitespace-nowrap"
-            >
-              <ArrowLeftIcon className="size-4 shrink-0" />
-              Back to Tenants
-            </Button>
-            <Button
-              onClick={handleEdit}
-              size="sm"
-              variant="primary"
-              className="whitespace-nowrap"
-            >
-              Edit Tenant
-            </Button>
-          </div>
         </div>
 
         <Tabs
@@ -216,7 +204,7 @@ const TenantDetails = () => {
             setActiveTab(id as 'info' | 'reports')
             window.location.hash = id
           }}
-          className="mx-5 mt-2"
+          className="mt-2"
         />
       </header>
 

--- a/src/pages/TenantInvitations.tsx
+++ b/src/pages/TenantInvitations.tsx
@@ -89,7 +89,7 @@ const TenantInvitations = ({
                       <Badge
                         className={
                           roleBadgeClass[invitation.role] ??
-                          'bg-gray-100 text-muted'
+                          'bg-surface-strong text-muted'
                         }
                       >
                         {invitation.role === 'admin'
@@ -101,7 +101,7 @@ const TenantInvitations = ({
                       <Badge
                         className={
                           invitationStatusBadgeClass[invitation.status] ??
-                          'bg-gray-100 text-muted'
+                          'bg-surface-strong text-muted'
                         }
                       >
                         {invitation.status === 'PENDING'

--- a/src/pages/TenantReadiness.tsx
+++ b/src/pages/TenantReadiness.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
-import { ArrowLeftIcon } from '@heroicons/react/16/solid'
+import { useParams } from 'react-router-dom'
 import {
   useGetTenantReadiness,
   useGetUserTenantById,
@@ -20,7 +19,6 @@ const READINESS_CHECK_INTERVAL_MS = 10000
 
 const TenantReadiness = () => {
   const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [isRecentlyChecked, setIsRecentlyChecked] = useState(false)
 
@@ -44,10 +42,6 @@ const TenantReadiness = () => {
   const checkReadinessJob = statusData?.status?.jobs?.find(
     (job) => job.name === 'CHECK_READINESS',
   )
-
-  const handleBackClick = () => {
-    navigate('/tenants')
-  }
 
   useEffect(() => {
     return () => {
@@ -115,7 +109,7 @@ const TenantReadiness = () => {
     if (status === 'INITIALISED') return 'bg-brand-muted text-blue-600'
     if (status === 'FAILED') return 'bg-red-100 text-red-800'
     if (status === 'FAILED_INITIALISATION') return 'bg-red-100 text-red-800'
-    return 'bg-gray-100 text-muted'
+    return 'bg-surface-strong text-muted'
   }
 
   const shouldShowJobStatus = (status?: JobStatus): boolean => {
@@ -163,8 +157,9 @@ const TenantReadiness = () => {
   }
 
   return (
-    <div className="max-w-[1240px] flex flex-col gap-4 mx-auto mb-6">
+    <div className="max-w-[1240px] flex flex-col gap-2 mx-auto mb-6">
       <PageHeader
+        className="mb-2"
         title="Tenant Readiness"
         subtitle={
           <>
@@ -174,17 +169,12 @@ const TenantReadiness = () => {
             </strong>
           </>
         }
-        className="flex flex-col gap-4 items-stretch md:flex-row md:items-start md:justify-between"
-      >
-        <Button variant="secondary" size="sm" onClick={handleBackClick}>
-          <ArrowLeftIcon className="size-4" />
-          Back to Tenants
-        </Button>
-      </PageHeader>
+        navigateTo={{ label: 'Back to Tenants', to: '/tenants' }}
+      />
       <div className="flex items-center">
         <div className="flex flex-col gap-2 mb-2">
           <div className="flex flex-col gap-1 max-w-full">
-            <p className="text-sm text-muted leading-relaxed m-0">
+            <p className="text-[0.9375rem] text-muted leading-relaxed m-0">
               Trigger a manual readiness check to verify tenant status
             </p>
           </div>

--- a/src/pages/TenantReports.tsx
+++ b/src/pages/TenantReports.tsx
@@ -8,7 +8,7 @@ import Badge from '@/components/Badge'
 const cardClass =
   'bg-white border border-line rounded-lg px-4 py-3 flex flex-col gap-2'
 const simpleItemClass =
-  'flex items-center justify-between px-3 py-2 bg-surface-subtle border border-line rounded-md gap-2'
+  'flex items-center justify-between px-3 py-2 bg-surface-muted border border-line rounded-md gap-2'
 const simpleItemTitleClass =
   'text-sm font-semibold text-body leading-[1.4] flex-1 break-words'
 
@@ -85,7 +85,7 @@ const TenantReports = ({ tenantId }: { tenantId: string }) => {
                 className={`p-3 bg-white border rounded-md cursor-pointer transition-all ${
                   selectedReportId === report.id
                     ? 'border-blue-500 bg-brand-subtle hover:opacity-85'
-                    : 'border-line hover:border-line-strong hover:bg-surface-subtle'
+                    : 'border-line hover:border-line-strong hover:bg-surface-muted'
                 }`}
                 onClick={() => setSelectedReportId(report.id)}
               >

--- a/src/pages/TenantStatus.tsx
+++ b/src/pages/TenantStatus.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import {
   useGetUserTenantById,
   useGetUserTenantStatus,
@@ -7,7 +7,6 @@ import {
 import { useAuth } from '@/auth/useAuth'
 import { useState, Fragment } from 'react'
 import {
-  ArrowLeftIcon,
   CheckCircleIcon,
   XCircleIcon,
   ClockIcon,
@@ -18,9 +17,9 @@ import {
 import { toast } from 'sonner'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
-import Button from '@/components/Button'
 import PageHeader from '@/components/PageHeader'
 import Badge from '@/components/Badge'
+import Button from '@/components/Button'
 import { formatDateTime } from '@/utils/formatDateTime'
 import type { Job, JobStatus } from '@/types/tenants'
 
@@ -31,7 +30,7 @@ const JOB_NAMES: Record<string, string> = {
 }
 
 const JOB_STATUS_BADGE_CLASS: Record<string, string> = {
-  UNKNOWN: 'bg-gray-100 text-muted',
+  UNKNOWN: 'bg-surface-strong text-muted',
   INITIALISING: 'bg-indigo-100 text-indigo-700',
   INITIALISED: 'bg-brand-muted text-blue-600',
   FAILED_INITIALISATION: 'bg-red-100 text-red-800',
@@ -67,7 +66,6 @@ const STATUS_OPTIONS: { value: JobStatus; label: string }[] = [
 
 const TenantStatus = () => {
   const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
   const { profile } = useAuth()
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
@@ -219,17 +217,9 @@ const TenantStatus = () => {
               </strong>
             </>
           }
-          className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between pb-2 mb-6 max-w-[1040px] mx-auto"
-        >
-          <Button
-            onClick={() => navigate('/tenants')}
-            size="sm"
-            variant="secondary"
-          >
-            <ArrowLeftIcon className="size-4" />
-            Back to Tenants
-          </Button>
-        </PageHeader>
+          className="pb-2 mb-4 max-w-[1040px] mx-auto"
+          navigateTo={{ label: 'Back to Tenants', to: '/tenants' }}
+        />
 
         {statusLoading && (
           <div className="loading-container">
@@ -273,7 +263,7 @@ const TenantStatus = () => {
                       <div className="flex items-center gap-2">
                         <Badge
                           size="lg"
-                          className={`capitalize ${JOB_STATUS_BADGE_CLASS[job.status] ?? 'bg-gray-100 text-muted'}`}
+                          className={`capitalize ${JOB_STATUS_BADGE_CLASS[job.status] ?? 'bg-surface-strong text-muted'}`}
                         >
                           {job.status?.toLowerCase()}
                         </Badge>
@@ -367,7 +357,7 @@ const TenantStatus = () => {
                                       e.target.value as JobStatus,
                                     )
                                   }
-                                  className="w-full px-3 py-2 text-sm font-medium border border-line-strong rounded-md bg-white text-muted cursor-pointer transition-all focus:outline-none focus:border-blue-500 focus:ring-3 focus:ring-blue-500/10"
+                                  className="w-full px-3 py-2 text-sm font-medium"
                                 >
                                   {STATUS_OPTIONS.map((option) => (
                                     <option
@@ -393,24 +383,21 @@ const TenantStatus = () => {
                                     setJobMessage(e.target.value)
                                   }
                                   placeholder="Enter a description for this status change"
-                                  className="w-full px-3 py-2 text-sm border border-line-strong rounded-md bg-white text-muted resize-y leading-[1.5] transition-all focus:outline-none focus:border-blue-500 focus:ring-3 focus:ring-blue-500/10 placeholder:text-subtle"
+                                  className="w-full px-3 py-2 text-sm leading-[1.5]"
                                   rows={2}
                                 />
                               </div>
                             </div>
-                            <div className="flex gap-2 justify-end">
-                              <button
+                            <div className="flex gap-4 justify-end">
+                              <Button
                                 onClick={handleCancelEdit}
-                                className="px-4 py-2 text-sm font-semibold text-body bg-white border border-line-strong rounded-md cursor-pointer transition-all hover:bg-surface-muted hover:border-gray-400 active:bg-gray-100"
+                                variant="outline-secondary"
                               >
                                 Cancel
-                              </button>
-                              <button
-                                onClick={() => handleSaveStatus(job)}
-                                className="px-4 py-2 text-sm font-semibold text-white bg-blue-600 border-none rounded-md cursor-pointer transition-all hover:bg-brand active:bg-blue-800"
-                              >
+                              </Button>
+                              <Button onClick={() => handleSaveStatus(job)}>
                                 Save
-                              </button>
+                              </Button>
                             </div>
                           </div>
                         )}
@@ -428,12 +415,13 @@ const TenantStatus = () => {
                             {isSuperAdmin &&
                               job.mode === 'MANUAL' &&
                               editingJob !== job.name && (
-                                <button
+                                <Button
                                   onClick={() => handleEditClick(job)}
-                                  className="w-fit px-3 py-1.5 text-sm font-semibold text-blue-600 bg-white border border-blue-600 rounded-md cursor-pointer transition-all hover:bg-brand-subtle active:bg-brand-muted"
+                                  size="sm"
+                                  variant="outline-primary"
                                 >
                                   Edit Status
-                                </button>
+                                </Button>
                               )}
                           </div>
                           <div className="grid grid-cols-1 gap-1 md:grid-cols-[120px_1fr] md:gap-3 py-1.5 border-b border-gray-50 last:border-b-0">
@@ -459,13 +447,13 @@ const TenantStatus = () => {
                     )}
                   </div>
                 ))
-            ) : (
+            ) : !statusLoading && !statusError ? (
               <div className="bg-surface-muted border border-line rounded-lg p-12 text-center">
                 <p className="text-muted">
                   No status information available for this tenant.
                 </p>
               </div>
-            )}
+            ) : null}
           </div>
         )}
       </div>

--- a/src/pages/Tenants.tsx
+++ b/src/pages/Tenants.tsx
@@ -13,7 +13,6 @@ import Card from '@/components/Card'
 import TenantCardFooter from '@/components/TenantCardFooter'
 import Badge from '@/components/Badge'
 import { roleBadgeClass } from '@/utils/badges'
-import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import type { UserGroup } from '@/types/profile'
 import type { Job, JobStatus } from '@/types/tenants'
@@ -21,7 +20,7 @@ import type { Job, JobStatus } from '@/types/tenants'
 const pageSize = 9
 
 const getStatusBadgeClass = (status: JobStatus): string => {
-  if (status === 'UNKNOWN') return 'bg-gray-100 text-subtle'
+  if (status === 'UNKNOWN') return 'bg-surface-strong text-subtle'
   if (status === 'INITIALISING') return 'bg-amber-100 text-amber-700'
   if (status === 'INITIALISED') return 'bg-brand-muted text-blue-600'
   if (status === 'FAILED_INITIALISATION') return 'bg-red-50 text-red-500'
@@ -42,7 +41,6 @@ const Tenants = () => {
   } | null>(null)
 
   const { profile } = useAuth()
-  const navigate = useNavigate()
   const { data: userProfileData } = useGetUserProfile()
 
   const isSuperAdmin = profile?.roles?.includes('super_admin')
@@ -94,34 +92,6 @@ const Tenants = () => {
         status: tenant?.status,
       }))) ||
     []
-
-  const handleEdit = (tenantId: string) => {
-    navigate(`/tenants/edit/${tenantId}`)
-  }
-
-  const handleAssignProjects = (tenantId: string) => {
-    navigate(`/tenants/${tenantId}/projects/assign`)
-  }
-
-  const handleManageMembers = (tenantId: string) => {
-    navigate(`/tenants/${tenantId}/members`)
-  }
-
-  const handleViewDetails = (tenantId: string) => {
-    navigate(`/tenants/${tenantId}/details`)
-  }
-
-  const handleViewStatus = (tenantId: string) => {
-    navigate(`/tenants/${tenantId}/status`)
-  }
-
-  const handleReadiness = (tenantId: string) => {
-    navigate(`/tenants/${tenantId}/readiness`)
-  }
-
-  const handleCapabilities = (tenantId: string) => {
-    navigate(`/tenants/${tenantId}/capabilities`)
-  }
 
   const handleDeleteClick = (id: string, name: string) => {
     setTenantToDelete({ id, name })
@@ -182,6 +152,7 @@ const Tenants = () => {
         onCancel={handleDeleteCancel}
       />
       <PageHeader
+        className="mb-6"
         title="Tenants"
         subtitle={
           isSuperAdmin
@@ -190,11 +161,7 @@ const Tenants = () => {
         }
       >
         {isSuperAdmin && (
-          <Button
-            variant="primary"
-            size="md"
-            onClick={() => navigate('/tenants/create')}
-          >
+          <Button variant="primary" size="md" href="/tenants/create">
             Create New Tenant
           </Button>
         )}
@@ -224,13 +191,7 @@ const Tenants = () => {
                     <TenantCardFooter
                       isSuperAdmin={!!isSuperAdmin}
                       isAdmin={isTenantAdmin(tenant.name)}
-                      onViewDetails={() => handleViewDetails(tenant.id!)}
-                      onEdit={() => handleEdit(tenant.id!)}
-                      onManageMembers={() => handleManageMembers(tenant.id!)}
-                      onAssignProjects={() => handleAssignProjects(tenant.id!)}
-                      onViewStatus={() => handleViewStatus(tenant.id!)}
-                      onReadiness={() => handleReadiness(tenant.id!)}
-                      onCapabilities={() => handleCapabilities(tenant.id!)}
+                      tenantId={tenant.id!}
                       onDelete={() =>
                         handleDeleteClick(tenant.id!, tenant.name)
                       }
@@ -265,7 +226,7 @@ const Tenants = () => {
                             const role = getRoleForTenant(tenant.name)
                             return role ? (
                               <Badge
-                                className={`shrink-0 mt-0.5 ${roleBadgeClass[role.toLowerCase()] ?? 'bg-gray-100 text-muted'}`}
+                                className={`shrink-0 mt-0.5 ${roleBadgeClass[role.toLowerCase()] ?? 'bg-surface-strong text-muted'}`}
                               >
                                 {role.toLowerCase() === 'admin'
                                   ? 'Admin'

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -151,14 +151,10 @@ const View = () => {
         <PageHeader
           title="Status Pages"
           subtitle="View and manage your pages"
-          className="pb-1 mb-4 md:mb-6 px-2 md:px-0 flex items-center justify-between"
+          className="pb-1 mb-4 md:mb-6 px-2 md:px-0"
         >
           {canCreateStatusPage && (
-            <Button
-              variant="primary"
-              size="md"
-              onClick={() => navigate('/status-pages/build')}
-            >
+            <Button variant="primary" size="md" href="/status-pages/build">
               Create Status Page
             </Button>
           )}
@@ -302,7 +298,7 @@ const View = () => {
                               onClick={() =>
                                 handlePageEdit(item.id, item.tenant_id)
                               }
-                              className="tooltip p-1 md:p-1.5 text-muted hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+                              className="tooltip p-1 md:p-1.5 text-muted hover:bg-surface-strong rounded-lg transition-colors cursor-pointer"
                               data-tip="Edit"
                               aria-label="Edit Page"
                             >


### PR DESCRIPTION
This PR refactors the PageHeader component to support back-navigation links, with several design system and component improvements included.

- Updated PageHeader to support an optional back-navigation link above the title
- Added href prop to Button and IconButton to support navigation links
- Refactored the design system into four named scales with a unified naming convention
- Updated outline button styles to be more consistent with the rest of the UI
- Fixed incorrect query key in the update tenant status mutation