### PR TITLE
[ARGO-5462] - Refactor topology endpoints list and create flow

### DIFF
--- a/src/api/topology.ts
+++ b/src/api/topology.ts
@@ -8,10 +8,11 @@ const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 
 export const fetchTopologyEndpoints = async (
   tenantId: string,
+  date: string,
   token: string,
 ): Promise<EndpointTopologyItem[]> => {
   const response = await fetch(
-    `${BACKEND_API}/v1/tenants/${tenantId}/topology/endpoints`,
+    `${BACKEND_API}/v1/tenants/${tenantId}/topology/endpoints${date ? `?date=${date}` : ''}`,
     {
       headers: {
         'Content-Type': 'application/json',

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -19,6 +19,17 @@ const ErrorDisplay = ({ error, context = 'data' }: ErrorDisplayProps) => {
   const isForbidden =
     errorMessageLower.includes('status code 403') ||
     errorMessageLower.includes('forbidden')
+  const isNotFound =
+    errorMessageLower.includes('status code 404') ||
+    errorMessageLower.includes('not found')
+
+  if (isNotFound) {
+    return (
+      <div className="text-center px-8 py-3 bg-surface-muted rounded-lg">
+        <p className="text-muted text-sm italic">No {context} found</p>
+      </div>
+    )
+  }
 
   const getTitle = () => {
     if (isUnauthorized) return 'Authentication Required'
@@ -43,7 +54,7 @@ const ErrorDisplay = ({ error, context = 'data' }: ErrorDisplayProps) => {
     : message
 
   return (
-    <div className="flex flex-col items-center justify-center gap-1 p-3 bg-red-50 border border-red-200 rounded-lg my-1 text-center">
+    <div className="flex flex-col items-center justify-center gap-1 px-3 py-2 bg-red-50 rounded-lg my-1 text-center">
       <ExclamationCircleIcon className="size-6 text-red-700" />
       <h2 className="text-base font-semibold text-red-800">{getTitle()}</h2>
       <p

--- a/src/hooks/useTopology.ts
+++ b/src/hooks/useTopology.ts
@@ -13,16 +13,17 @@ import type {
 
 export const useGetTopologyEndpoints = (
   tenantId: string,
+  date: string = '',
   enabled: boolean = true,
 ) => {
   const { token } = useAuth()
 
   return useQuery<EndpointTopologyItem[], Error>({
-    queryKey: ['topology-endpoints', tenantId],
+    queryKey: ['topology-endpoints', tenantId, date],
     queryFn: () => {
       if (!token) throw new Error('No authentication token available')
       if (!tenantId) throw new Error('Tenant ID is required')
-      return fetchTopologyEndpoints(tenantId, token)
+      return fetchTopologyEndpoints(tenantId, date, token)
     },
     retry: false,
     enabled: enabled && !!token && !!tenantId,

--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -1,10 +1,11 @@
 import { useState, useRef, useEffect } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
 import {
+  useGetTopologyEndpoints,
   useGetTopologyServiceTypes,
   useCreateTopologyEndpointMutation,
 } from '@/hooks/useTopology'
 import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useParams, useNavigate } from 'react-router-dom'
 import {
   PlusIcon,
   TrashIcon,
@@ -13,6 +14,7 @@ import {
 import { toast } from 'sonner'
 import PageHeader from '@/components/PageHeader'
 import Button from '@/components/Button'
+import IconButton from '@/components/IconButton'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 
@@ -25,12 +27,17 @@ const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const today = new Date().toISOString().split('T')[0]
 
+interface Contact {
+  id: string
+  value: string
+}
+
 interface FormData {
   service: string
   hostname: string
   monitored: boolean
   notificationsEnabled: boolean
-  contacts: string[]
+  contacts: Contact[]
 }
 
 interface FormErrors {
@@ -45,6 +52,7 @@ const CreateTopologyEndpoint = () => {
   const navigate = useNavigate()
 
   const { data: tenantData } = useGetUserTenantById(tenantId)
+  const { data: existingEndpoints } = useGetTopologyEndpoints(tenantId, today)
   const {
     data: serviceTypes,
     isLoading: isLoadingTypes,
@@ -57,7 +65,7 @@ const CreateTopologyEndpoint = () => {
     hostname: '',
     monitored: true,
     notificationsEnabled: false,
-    contacts: [''],
+    contacts: [{ id: crypto.randomUUID(), value: '' }],
   })
 
   const [errors, setErrors] = useState<FormErrors>({
@@ -96,9 +104,12 @@ const CreateTopologyEndpoint = () => {
   }
 
   const handleContactChange = (index: number, value: string) => {
-    const updated = [...formData.contacts]
-    updated[index] = value
-    setFormData((prev) => ({ ...prev, contacts: updated }))
+    setFormData((prev) => ({
+      ...prev,
+      contacts: prev.contacts.map((c, i) =>
+        i === index ? { ...c, value } : c,
+      ),
+    }))
 
     const updatedErrors = [...errors.contacts]
     if (!value.trim() || emailRegex.test(value)) {
@@ -110,7 +121,10 @@ const CreateTopologyEndpoint = () => {
   }
 
   const handleAddContact = () => {
-    setFormData((prev) => ({ ...prev, contacts: [...prev.contacts, ''] }))
+    setFormData((prev) => ({
+      ...prev,
+      contacts: [...prev.contacts, { id: crypto.randomUUID(), value: '' }],
+    }))
     setErrors((prev) => ({ ...prev, contacts: [...prev.contacts, ''] }))
   }
 
@@ -146,14 +160,14 @@ const CreateTopologyEndpoint = () => {
 
     if (formData.notificationsEnabled) {
       const hasValidContact = formData.contacts.some(
-        (c) => c.trim() && emailRegex.test(c),
+        (c) => c.value.trim() && emailRegex.test(c.value),
       )
       if (!hasValidContact) {
         newErrors.contacts[0] = 'At least one valid email is required'
         hasError = true
       }
       formData.contacts.forEach((c, i) => {
-        if (c.trim() && !emailRegex.test(c)) {
+        if (c.value.trim() && !emailRegex.test(c.value)) {
           newErrors.contacts[i] = 'Invalid email'
           hasError = true
         }
@@ -166,6 +180,7 @@ const CreateTopologyEndpoint = () => {
     }
 
     const payload = [
+      ...(existingEndpoints ?? []),
       {
         date: today,
         group: 'DEFAULT',
@@ -175,12 +190,12 @@ const CreateTopologyEndpoint = () => {
         tags: {
           monitored: formData.monitored ? '1' : '0',
         },
-        ...(formData.notificationsEnabled && {
-          notifications: {
-            enabled: true,
-            contacts: formData.contacts.filter((c) => c.trim()),
-          },
-        }),
+        notifications: {
+          enabled: formData.notificationsEnabled,
+          contacts: formData.contacts
+            .filter((c) => c.value.trim() && emailRegex.test(c.value))
+            .map((c) => c.value),
+        },
       },
     ]
 
@@ -205,10 +220,10 @@ const CreateTopologyEndpoint = () => {
   return (
     <div className="page-container">
       <PageHeader
-        title="Create Topology Endpoint"
+        title="Add Topology Endpoint"
         subtitle={
           <>
-            Add a new endpoint for tenant{' '}
+            Configure and register a new topology endpoint for tenant{' '}
             <strong>{tenantData?.info.name ?? '...'}</strong>
           </>
         }
@@ -231,7 +246,7 @@ const CreateTopologyEndpoint = () => {
               Creating...
             </>
           ) : (
-            'Create Endpoint'
+            'Add Endpoint'
           )}
         </Button>
       </div>
@@ -355,10 +370,7 @@ const CreateTopologyEndpoint = () => {
               className="toggle toggle-brand"
               checked={formData.monitored}
               onChange={() =>
-                setFormData((prev) => ({
-                  ...prev,
-                  monitored: !prev.monitored,
-                }))
+                setFormData((prev) => ({ ...prev, monitored: !prev.monitored }))
               }
             />
             <div>
@@ -406,11 +418,11 @@ const CreateTopologyEndpoint = () => {
                 Contact Emails <span className="required">*</span>
               </p>
               {formData.contacts.map((contact, index) => (
-                <div key={index} className="flex items-start gap-2">
+                <div key={contact.id} className="flex items-start gap-1">
                   <div className="flex flex-col flex-1">
                     <input
                       type="email"
-                      value={contact}
+                      value={contact.value}
                       onChange={(e) =>
                         handleContactChange(index, e.target.value)
                       }
@@ -428,14 +440,14 @@ const CreateTopologyEndpoint = () => {
                     )}
                   </div>
                   {formData.contacts.length > 1 && (
-                    <button
-                      type="button"
-                      onClick={() => handleRemoveContact(index)}
-                      className="flex items-center justify-center size-7 rounded-md bg-red-500 text-white border-none cursor-pointer hover:bg-red-600"
-                      title="Remove contact"
-                    >
-                      <TrashIcon className="size-4" />
-                    </button>
+                    <div className="mt-1">
+                      <IconButton
+                        icon={<TrashIcon className="size-4.5" />}
+                        label="Remove contact"
+                        onClick={() => handleRemoveContact(index)}
+                        className="text-red-600 hover:bg-red-50"
+                      />
+                    </div>
                   )}
                 </div>
               ))}

--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -1,23 +1,139 @@
+import { useState, useEffect, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import { useGetUserTenantById } from '@/hooks/useTenants'
 import { useGetTopologyEndpoints } from '@/hooks/useTopology'
 import PageHeader from '@/components/PageHeader'
 import Button from '@/components/Button'
-import DataTable, { thBase, tdBase } from '@/components/DataTable'
+import SearchInput from '@/components/SearchInput'
+import Pagination from '@/components/Pagination'
+import DataTable, {
+  thBase,
+  tdBase,
+  SortableColumnHeader,
+} from '@/components/DataTable'
 import Badge from '@/components/Badge'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
+type SortColumn = 'service' | 'group' | 'monitored'
+type DateMode = 'latest' | 'custom'
+
+const pageSize = 15
 
 const TenantTopology = () => {
   const { id } = useParams<{ id: string }>()
   const tenantId = id ?? ''
 
   const { data: tenantData } = useGetUserTenantById(tenantId)
+
+  const [searchInput, setSearchInput] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [sortColumn, setSortColumn] = useState<SortColumn>('monitored')
+  const [sortAsc, setSortAsc] = useState(false)
+  const [dateMode, setDateMode] = useState<DateMode>('latest')
+  const [customDate, setCustomDate] = useState('')
+  const [committedDate, setCommittedDate] = useState('')
+  const dateInputRef = useRef<HTMLInputElement>(null)
+
+  const effectiveDate = dateMode === 'latest' ? '' : committedDate
+
   const {
     data: endpoints,
     isLoading,
     error,
-  } = useGetTopologyEndpoints(tenantId)
+  } = useGetTopologyEndpoints(tenantId, effectiveDate)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchQuery(searchInput)
+      setCurrentPage(1)
+    }, 500)
+    return () => clearTimeout(timer)
+  }, [searchInput])
+
+  /* Use native DOM `change` (not React's onChange) so the API is called only when the user picks a full date, not on every arrow-key increment in the date input. */
+  useEffect(() => {
+    const input = dateInputRef.current
+    if (!input) return
+
+    const handleChange = (e: Event) => {
+      const value = (e.target as HTMLInputElement).value
+      setCommittedDate(value)
+      setCurrentPage(1)
+    }
+
+    input.addEventListener('change', handleChange)
+
+    return () => input.removeEventListener('change', handleChange)
+  }, [dateMode])
+
+  const latestDate = endpoints?.length
+    ? endpoints.reduce(
+        (max, e) => (e.date > max ? e.date : max),
+        endpoints[0].date,
+      )
+    : ''
+
+  const handleDateModeChange = (mode: string) => {
+    setDateMode(mode as DateMode)
+    if (mode === 'custom') {
+      setCustomDate(latestDate)
+      setCommittedDate(latestDate)
+    }
+    setCurrentPage(1)
+  }
+
+  const handleCustomDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCustomDate(e.target.value)
+  }
+
+  const handleSortChange = (column: SortColumn) => {
+    if (sortColumn === column) {
+      setSortAsc((prev) => !prev)
+    } else {
+      setSortColumn(column)
+      setSortAsc(true)
+    }
+    setCurrentPage(1)
+  }
+
+  const handleSearchClear = () => {
+    setSearchInput('')
+    setSearchQuery('')
+    setCurrentPage(1)
+  }
+
+  const filtered = (endpoints ?? []).filter((e) => {
+    if (!searchQuery) return true
+    const q = searchQuery.toLowerCase()
+    const monitoredLabel =
+      e.tags?.monitored === '1' ? 'monitored' : 'not monitored'
+    return (
+      e.service.toLowerCase().includes(q) ||
+      e.group.toLowerCase().includes(q) ||
+      monitoredLabel.includes(q)
+    )
+  })
+
+  const sorted = [...filtered].sort((a, b) => {
+    let cmp = 0
+    if (sortColumn === 'service') {
+      cmp = a.service.localeCompare(b.service)
+    } else if (sortColumn === 'group') {
+      cmp = a.group.localeCompare(b.group)
+    } else {
+      const aVal = a.tags?.monitored ?? '0'
+      const bVal = b.tags?.monitored ?? '0'
+      cmp = aVal.localeCompare(bVal)
+    }
+    return sortAsc ? cmp : -cmp
+  })
+
+  const totalPages = Math.ceil(sorted.length / pageSize)
+  const paginated = sorted.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize,
+  )
 
   return (
     <div className="page-container">
@@ -31,39 +147,106 @@ const TenantTopology = () => {
         }
         className="pb-2 mb-4"
       >
-        <Button
-          variant="primary"
-          size="md"
-          href={`/tenants/${tenantId}/topology/create`}
-        >
-          Create Topology Endpoint
-        </Button>
+        {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
+          <Button
+            variant="primary"
+            size="md"
+            href={`/tenants/${tenantId}/topology/create`}
+          >
+            Add Topology Endpoint
+          </Button>
+        )}
       </PageHeader>
 
-      {isLoading ? (
-        <div className="loading-container">
-          <LoadingSpinner size="md" />
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <SearchInput
+          value={searchInput}
+          onChange={setSearchInput}
+          onClear={handleSearchClear}
+          placeholder="Search by service, group or monitored status..."
+          className="!mb-0 w-full"
+        />
+        <div className="flex items-center gap-2 shrink-0">
+          {dateMode === 'custom' && (
+            <input
+              ref={dateInputRef}
+              type="date"
+              value={customDate}
+              onChange={handleCustomDateChange}
+              className="text-sm"
+            />
+          )}
+          <select
+            value={dateMode}
+            onChange={(e) => handleDateModeChange(e.target.value)}
+            className="text-sm"
+          >
+            <option value="latest">Latest</option>
+            <option value="custom">Select date</option>
+          </select>
         </div>
-      ) : error ? (
-        <ErrorDisplay error={error} context="topology endpoints" />
-      ) : !endpoints?.length ? (
-        <div className="text-center p-8 bg-surface-muted rounded-lg border border-line">
-          <p className="text-muted text-lg">No topology endpoints found</p>
-        </div>
-      ) : (
-        <DataTable>
-          <thead className="bg-surface-strong border-b border-line">
+      </div>
+
+      <DataTable>
+        <thead className="bg-surface-strong border-b border-line">
+          <tr>
+            <th className={`${thBase} min-w-28`}>
+              <SortableColumnHeader
+                isActive={sortColumn === 'service'}
+                isAscending={sortAsc}
+                onClick={() => handleSortChange('service')}
+              >
+                Service
+              </SortableColumnHeader>
+            </th>
+            <th className={`${thBase} min-w-40`}>URL</th>
+            <th className={`${thBase} min-w-24`}>
+              <SortableColumnHeader
+                isActive={sortColumn === 'group'}
+                isAscending={sortAsc}
+                onClick={() => handleSortChange('group')}
+              >
+                Group
+              </SortableColumnHeader>
+            </th>
+            <th className={`${thBase} min-w-24`}>
+              <SortableColumnHeader
+                isActive={sortColumn === 'monitored'}
+                isAscending={sortAsc}
+                onClick={() => handleSortChange('monitored')}
+              >
+                Monitored
+              </SortableColumnHeader>
+            </th>
+            <th className={`${thBase} min-w-28`}>Date</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {isLoading ? (
             <tr>
-              <th className={`${thBase} min-w-28`}>Service</th>
-              <th className={`${thBase} min-w-40`}>URL</th>
-              <th className={`${thBase} min-w-24`}>Group</th>
-              <th className={`${thBase} min-w-20`}>Type</th>
-              <th className={`${thBase} min-w-24`}>Monitored</th>
-              <th className={`${thBase} min-w-28`}>Date</th>
+              <td colSpan={5} className="py-12">
+                <div className="flex justify-center">
+                  <LoadingSpinner size="md" />
+                </div>
+              </td>
             </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
-            {endpoints.map((endpoint, index) => (
+          ) : error ? (
+            <tr>
+              <td colSpan={5} className="py-6 px-12">
+                <ErrorDisplay error={error} context="topology endpoints" />
+              </td>
+            </tr>
+          ) : !endpoints?.length ? (
+            <tr>
+              <td
+                colSpan={5}
+                className="text-center text-sm text-subtle italic py-6 px-12"
+              >
+                No topology endpoints found
+              </td>
+            </tr>
+          ) : (
+            paginated.map((endpoint, index) => (
               <tr
                 key={endpoint.id ?? index}
                 className="hover:bg-surface-muted transition-colors"
@@ -73,7 +256,6 @@ const TenantTopology = () => {
                   {endpoint.hostname}
                 </td>
                 <td className={tdBase}>{endpoint.group}</td>
-                <td className={tdBase}>{endpoint.type}</td>
                 <td className={tdBase}>
                   {endpoint.tags?.monitored !== undefined ? (
                     <Badge
@@ -92,10 +274,19 @@ const TenantTopology = () => {
                 </td>
                 <td className={tdBase}>{endpoint.date}</td>
               </tr>
-            ))}
-          </tbody>
-        </DataTable>
-      )}
+            ))
+          )}
+        </tbody>
+      </DataTable>
+
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalElements={sorted.length}
+        itemLabel="endpoints"
+        onPrev={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+        onNext={() => setCurrentPage((prev) => prev + 1)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
This PR refactors the topology endpoints pages to support client-side filtering, sorting, pagination, date-based filtering, and a create flow that loads existing endpoints before submission.

- Added client-side search, sortable columns and pagination to TenantTopology
- Added date selector (latest/custom) to filter endpoints by date
- Updated CreateTopologyEndpoint to fetch existing endpoints for the selected date before submitting
- Added "GOCDB" check that hides the create button when the tenant topology source is "GOCDB"
- Updated notifications payload to always include the fields "enabled" and "contacts", even when disabled
- Updated ErrorDisplay component to render a neutral style for 404 responses