### PR TITLE
[ARGO-5467] - Implement reusable dropdown select component

### DIFF
--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -1,0 +1,92 @@
+import { useState, useRef, useEffect } from 'react'
+import { ChevronUpDownIcon } from '@heroicons/react/16/solid'
+
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+interface SelectDropdownProps {
+  value: string
+  onChange: (value: string) => void
+  options: SelectOption[]
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+}
+
+const SelectDropdown = ({
+  value,
+  onChange,
+  options,
+  placeholder = 'Select an option...',
+  disabled = false,
+  className,
+}: SelectDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleMouseDown = (e: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => document.removeEventListener('mousedown', handleMouseDown)
+  }, [isOpen])
+
+  const selectedLabel = options.find((o) => o.value === value)?.label
+
+  const handleToggle = () => {
+    if (!disabled) setIsOpen((prev) => !prev)
+  }
+
+  const handleSelect = (optionValue: string) => {
+    onChange(optionValue)
+    setIsOpen(false)
+  }
+
+  return (
+    <div className={`relative ${className ?? ''}`} ref={dropdownRef}>
+      <input
+        type="text"
+        readOnly
+        value={selectedLabel ?? ''}
+        placeholder={placeholder}
+        disabled={disabled}
+        onClick={handleToggle}
+        className="w-full cursor-pointer pr-9"
+      />
+      <ChevronUpDownIcon className="absolute right-2.5 top-1/2 -translate-y-1/2 size-4 text-muted shrink-0 pointer-events-none" />
+
+      {isOpen && (
+        <div className="absolute z-10 mt-1 w-full bg-white border border-line rounded-md shadow-lg overflow-hidden animate-fade-in">
+          <ul className="max-h-60 overflow-y-auto" role="listbox">
+            {options.map((option) => (
+              <li
+                key={option.value}
+                role="option"
+                aria-selected={option.value === value}
+                onClick={() => handleSelect(option.value)}
+                className={`px-4 py-1.5 mb-px last:mb-0 rounded-md text-sm cursor-pointer transition-colors ${
+                  option.value === value
+                    ? 'bg-brand-subtle text-brand font-medium'
+                    : 'text-foreground hover:bg-surface-muted'
+                }`}
+              >
+                {option.label}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SelectDropdown

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react'
 
 const tabBase =
-  'px-6 py-3 pb-2 text-base font-medium bg-transparent border-0 rounded-t-md border-b-2 cursor-pointer transition-all -mb-0.5 relative flex items-center gap-1'
+  'px-6 py-2 pb-1 text-base font-medium bg-transparent border-0 rounded-t-md border-b-2 cursor-pointer transition-all -mb-0.5 relative flex items-center gap-1'
 const tabActive = 'text-brand border-b-brand hover:border-b-brand'
 const tabInactive =
   'text-muted border-b-transparent hover:text-body hover:bg-surface-muted hover:border-b-gray-300'

--- a/src/pages/MyInvitations.tsx
+++ b/src/pages/MyInvitations.tsx
@@ -188,8 +188,10 @@ const MyInvitations = () => {
                 )}
               </>
             ) : (
-              <div className="bg-surface-muted border border-line rounded-lg py-8 px-12 text-center">
-                <p className="text-muted text-base m-0">No invitations found</p>
+              <div className="text-center bg-surface-muted rounded-lg">
+                <p className="text-sm text-subtle italic py-6 px-12">
+                  No invitations found
+                </p>
               </div>
             )}
           </>

--- a/src/pages/administration/AdminInvitationsTab.tsx
+++ b/src/pages/administration/AdminInvitationsTab.tsx
@@ -130,8 +130,8 @@ const AdminInvitationsTab = ({ isSuperAdmin }: AdminInvitationsProps) => {
 
     if (!invitationsData?.content || invitationsData.content.length === 0) {
       return (
-        <div className="bg-surface-muted border border-line rounded-lg p-12 text-center">
-          <p className="text-muted text-base m-0">
+        <div className="text-center bg-surface-muted rounded-lg">
+          <p className="text-sm text-subtle italic py-6 px-12">
             {searchInput
               ? 'No invitations found matching your search'
               : 'No invitations found'}
@@ -295,6 +295,7 @@ const AdminInvitationsTab = ({ isSuperAdmin }: AdminInvitationsProps) => {
   return (
     <>
       <SearchInput
+        className="mb-3"
         value={searchInput}
         onChange={setSearchInput}
         onClear={handleClearSearch}

--- a/src/pages/administration/ProjectManagementTab.tsx
+++ b/src/pages/administration/ProjectManagementTab.tsx
@@ -108,7 +108,7 @@ const ProjectManagementTab = () => {
         onCancel={handleDeleteCancel}
       />
 
-      <div className="flex flex-wrap justify-between items-start gap-3 mb-4">
+      <div className="flex flex-wrap justify-between items-start gap-3 mb-1">
         <SearchInput
           className="min-w-[24rem]"
           value={searchInput}
@@ -211,8 +211,10 @@ const ProjectManagementTab = () => {
       {!projectsError &&
       !isLoading &&
       (!data || data?.content?.length === 0) ? (
-        <div className="text-center p-8 bg-surface-muted rounded-lg border border-line">
-          <p className="text-muted text-lg">No projects found</p>
+        <div className="text-center bg-surface-muted rounded-lg">
+          <p className="text-sm text-subtle italic py-6 px-12">
+            No projects found
+          </p>
         </div>
       ) : null}
 

--- a/src/pages/administration/UsersTab.tsx
+++ b/src/pages/administration/UsersTab.tsx
@@ -89,6 +89,7 @@ const UsersTab = () => {
   return (
     <>
       <SearchInput
+        className="mb-3"
         value={searchInput}
         onChange={setSearchInput}
         onClear={handleClearSearch}
@@ -227,8 +228,8 @@ const UsersTab = () => {
               </tbody>
             </DataTable>
           ) : (
-            <div className="bg-surface-muted border border-line rounded-lg p-12 text-center">
-              <p className="text-muted text-base m-0">
+            <div className="text-center bg-surface-muted rounded-lg">
+              <p className="text-sm text-subtle italic py-6 px-12">
                 {searchInput
                   ? 'No users found matching your search'
                   : 'No users available'}

--- a/src/pages/build-status-page/BuildConfigTab.tsx
+++ b/src/pages/build-status-page/BuildConfigTab.tsx
@@ -1,5 +1,6 @@
 import { CheckBadgeIcon } from '@heroicons/react/24/solid'
 import type { TenantList, ReportListItem } from '@/types/tenants'
+import SelectDropdown from '@/components/SelectDropdown'
 
 interface BuildConfigTabProps {
   name: string
@@ -10,7 +11,7 @@ interface BuildConfigTabProps {
   reportsData: ReportListItem[] | undefined
   onNameChange: (value: string) => void
   onSlugChange: (value: string) => void
-  onTenantChange: (event: React.ChangeEvent<HTMLSelectElement>) => void
+  onTenantChange: (value: string) => void
 }
 
 const BuildConfigTab = ({
@@ -75,19 +76,20 @@ const BuildConfigTab = ({
           <label className="block text-sm font-medium text-body mb-2">
             Tenant: <span className="required">*</span>
           </label>
-          <select
-            className="w-full"
+          <SelectDropdown
             value={tenantId}
             onChange={onTenantChange}
+            options={
+              tenantsData?.content
+                .filter((tenant) => tenant.id)
+                .map((tenant) => ({
+                  value: tenant.id as string,
+                  label: tenant.info.name,
+                })) ?? []
+            }
+            placeholder="Select a tenant"
             disabled={isEditMode}
-          >
-            <option value="">Select a tenant</option>
-            {tenantsData?.content.map((tenant) => (
-              <option key={tenant.id} value={tenant.id}>
-                {tenant.info.name}
-              </option>
-            ))}
-          </select>
+          />
           {isEditMode && (
             <p className="text-xs text-muted mt-1">
               Tenant cannot be changed when editing a page

--- a/src/pages/build-status-page/BuildItemsTab.tsx
+++ b/src/pages/build-status-page/BuildItemsTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import SelectDropdown from '@/components/SelectDropdown'
 import { StatusItem } from './StatusItem'
 import type { StatusItemType, StatusGroupType } from '@/types/common'
 import type { ReportListItem } from '@/types/tenants'
@@ -16,7 +17,7 @@ interface BuildItemsTabProps {
   statusGroups: StatusGroupType[]
   selectIcon: string
   selectText: string
-  onReportChange: (event: React.ChangeEvent<HTMLSelectElement>) => void
+  onReportChange: (value: string) => void
 }
 
 const BuildItemsTab = ({
@@ -75,21 +76,16 @@ const BuildItemsTab = ({
                 <label className="block text-sm font-medium text-body mb-1">
                   Report:
                 </label>
-                <select
+                <SelectDropdown
                   value={report}
-                  className="w-full"
                   onChange={onReportChange}
+                  options={reportsData.map((item) => ({
+                    value: item.id,
+                    label: item.name,
+                  }))}
+                  placeholder="Select a report"
                   disabled={statusGroups.length > 0}
-                >
-                  <option value="" disabled={true}>
-                    Select a report
-                  </option>
-                  {reportsData.map((item) => (
-                    <option key={item.id} value={item.id}>
-                      {item.name}
-                    </option>
-                  ))}
-                </select>
+                />
               </div>
 
               {groupsMutationIsPending && (

--- a/src/pages/build-status-page/BuildStatusPage.tsx
+++ b/src/pages/build-status-page/BuildStatusPage.tsx
@@ -142,8 +142,8 @@ const BuildStatusPage = () => {
     nextGroupIdRef.current = newGroupId + 1
   }
 
-  const handleReportChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setReport(event.target.value)
+  const handleReportChange = (value: string) => {
+    setReport(value)
   }
 
   const handlePageSave = () => {
@@ -224,8 +224,8 @@ const BuildStatusPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [report, tenantId])
 
-  const handleTenantChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setTenantId(event.target.value)
+  const handleTenantChange = (value: string) => {
+    setTenantId(value)
     setReport('')
   }
 

--- a/src/pages/create-tenant/ContactInformation.tsx
+++ b/src/pages/create-tenant/ContactInformation.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useGetUserContactTypes } from '@/hooks/useTenants'
 import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
+import SelectDropdown from '@/components/SelectDropdown'
 
 const sectionClass =
   'grid grid-cols-1 md:grid-cols-[300px_1fr] gap-4 md:gap-8 mb-6 animate-fade-in'
@@ -44,15 +45,12 @@ const ContactInformation = ({
 
   const handleChange = (
     index: number,
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+    e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const { name, value } = e.target
 
     const updatedContacts = [...contacts]
-    updatedContacts[index] = {
-      ...updatedContacts[index],
-      [name]: value,
-    }
+    updatedContacts[index] = { ...updatedContacts[index], [name]: value }
     onContactsChange(updatedContacts)
 
     if (name === 'email') {
@@ -67,6 +65,12 @@ const ContactInformation = ({
       }
       setErrors(updatedErrors)
     }
+  }
+
+  const handleTypeChange = (index: number, value: string) => {
+    const updatedContacts = [...contacts]
+    updatedContacts[index] = { ...updatedContacts[index], type: value }
+    onContactsChange(updatedContacts)
   }
 
   const handleAddContact = () => {
@@ -166,19 +170,19 @@ const ContactInformation = ({
               {isContactTypesLoading ? (
                 <div className="text-sm text-muted">Loading...</div>
               ) : (
-                <select
-                  name="type"
+                <SelectDropdown
                   value={contact.type}
-                  onChange={(e) => handleChange(index, e)}
-                  className="capitalize"
-                >
-                  <option value="">Select contact type</option>
-                  {contactTypes?.map((type) => (
-                    <option key={type} value={type} className="capitalize">
-                      {type.toLowerCase()}
-                    </option>
-                  ))}
-                </select>
+                  onChange={(value) => handleTypeChange(index, value)}
+                  options={
+                    contactTypes?.map((type) => ({
+                      value: type,
+                      label:
+                        type.charAt(0).toUpperCase() +
+                        type.slice(1).toLowerCase(),
+                    })) ?? []
+                  }
+                  placeholder="Select contact type"
+                />
               )}
             </div>
           </div>

--- a/src/pages/create-tenant/InfrastructureMetadata.tsx
+++ b/src/pages/create-tenant/InfrastructureMetadata.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useGetUserContactTypes } from '@/hooks/useTenants'
 import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
 import type { Metadata } from '@/types/tenants'
+import SelectDropdown from '@/components/SelectDropdown'
 
 const sectionClass =
   'grid grid-cols-1 md:grid-cols-[300px_1fr] gap-4 md:gap-8 mb-6 animate-fade-in'
@@ -60,9 +61,17 @@ const InfrastructureMetadata = ({
   const urlErrorMesage =
     'Please enter a valid URL (must start with http:// or https://)'
 
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-  ) => {
+  const handleTopologyTypeChange = (value: string) => {
+    onMetadataChange({ ...metadata, topology_type: value })
+  }
+
+  const handleInternalListTypeChange = (index: number, value: string) => {
+    const updatedLists = [...metadata.internalLists]
+    updatedLists[index] = { ...updatedLists[index], type: value }
+    onMetadataChange({ ...metadata, internalLists: updatedLists })
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value: fieldValue } = e.target
     const urlRegex = /^https?:\/\/.+\..+/
 
@@ -134,7 +143,7 @@ const InfrastructureMetadata = ({
 
   const handleInternalListChange = (
     index: number,
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+    e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const { name, value } = e.target
     const updatedLists = [...metadata.internalLists]
@@ -270,15 +279,15 @@ const InfrastructureMetadata = ({
               {isContactTypesLoading ? (
                 <div className="text-sm text-muted">Loading...</div>
               ) : (
-                <select
-                  name="topology_type"
+                <SelectDropdown
                   value={metadata.topology_type}
-                  onChange={handleChange}
-                >
-                  <option value="">Select type</option>
-                  <option value="GOCDB">GOCdb</option>
-                  <option value="CSV">CSV</option>
-                </select>
+                  onChange={handleTopologyTypeChange}
+                  options={[
+                    { value: 'GOCDB', label: 'GOCdb' },
+                    { value: 'CSV', label: 'CSV' },
+                  ]}
+                  placeholder="Select type"
+                />
               )}
             </div>
 
@@ -383,19 +392,21 @@ const InfrastructureMetadata = ({
                   {isContactTypesLoading ? (
                     <div className="text-sm text-muted">Loading...</div>
                   ) : (
-                    <select
-                      name="type"
+                    <SelectDropdown
                       value={list.type}
-                      onChange={(e) => handleInternalListChange(index, e)}
-                      className="capitalize"
-                    >
-                      <option value="">Select type</option>
-                      {contactTypes?.map((type) => (
-                        <option key={type} value={type} className="capitalize">
-                          {type.toLowerCase()}
-                        </option>
-                      ))}
-                    </select>
+                      onChange={(value) =>
+                        handleInternalListTypeChange(index, value)
+                      }
+                      options={
+                        contactTypes?.map((type) => ({
+                          value: type,
+                          label:
+                            type.charAt(0).toUpperCase() +
+                            type.slice(1).toLowerCase(),
+                        })) ?? []
+                      }
+                      placeholder="Select type"
+                    />
                   )}
                 </div>
               </div>

--- a/src/pages/manage-tenant-members/AddDirectTab.tsx
+++ b/src/pages/manage-tenant-members/AddDirectTab.tsx
@@ -3,6 +3,7 @@ import { useGetMembers, useAddMemberDirectly } from '@/hooks/useTenants'
 import { XMarkIcon } from '@heroicons/react/16/solid'
 import { toast } from 'sonner'
 import Button from '@/components/Button'
+import SelectDropdown from '@/components/SelectDropdown'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import type { InvitationRole } from '@/types/invitations'
 
@@ -47,21 +48,19 @@ const AddDirectTab = ({ tenantId }: AddDirectTabProps) => {
     return () => clearTimeout(timer)
   }, [searchInput])
 
-  const handleFormChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-  ) => {
-    const { name, value } = e.target
+  const handleFormChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target
 
-    if (name === 'search') {
-      setSearchInput(value)
-      setShowSearchResults(true)
-      if (!value.trim()) {
-        setShowSearchResults(false)
-        setAddDirectErrors((prev) => ({ ...prev, search: '' }))
-      }
-    } else if (name === 'role') {
-      setAddDirectForm((prev) => ({ ...prev, role: value as InvitationRole }))
+    setSearchInput(value)
+    setShowSearchResults(true)
+    if (!value.trim()) {
+      setShowSearchResults(false)
+      setAddDirectErrors((prev) => ({ ...prev, search: '' }))
     }
+  }
+
+  const handleRoleChange = (value: string) => {
+    setAddDirectForm((prev) => ({ ...prev, role: value as InvitationRole }))
   }
 
   const handleUserSelect = (user: {
@@ -227,17 +226,11 @@ const AddDirectTab = ({ tenantId }: AddDirectTabProps) => {
               <label className="text-sm font-medium text-body mb-1.5">
                 Role <span className="required">*</span>
               </label>
-              <select
-                name="role"
+              <SelectDropdown
                 value={addDirectForm.role}
-                onChange={handleFormChange}
-              >
-                {roleOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
+                onChange={handleRoleChange}
+                options={roleOptions}
+              />
             </div>
           </div>
 

--- a/src/pages/manage-tenant-members/InviteTab.tsx
+++ b/src/pages/manage-tenant-members/InviteTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useCreateTenantInvitation } from '@/hooks/useInvitations'
 import { toast } from 'sonner'
 import Button from '@/components/Button'
+import SelectDropdown from '@/components/SelectDropdown'
 import type { InvitationRole } from '@/types/invitations'
 
 const roleOptions = [
@@ -24,22 +25,22 @@ const InviteTab = ({ tenantId }: InviteTabProps) => {
 
   const createInvitationMutation = useCreateTenantInvitation()
 
-  const handleFormChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-  ) => {
-    const { name, value } = e.target
+  const handleFormChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target
 
-    setInviteForm((prev) => ({ ...prev, [name]: value }))
+    setInviteForm((prev) => ({ ...prev, email: value }))
 
-    if (name === 'email') {
-      if (!value.trim()) {
-        setErrors((prev) => ({ ...prev, email: 'Email is required' }))
-      } else if (!emailRegex.test(value)) {
-        setErrors((prev) => ({ ...prev, email: 'Invalid email format' }))
-      } else {
-        setErrors((prev) => ({ ...prev, email: '' }))
-      }
+    if (!value.trim()) {
+      setErrors((prev) => ({ ...prev, email: 'Email is required' }))
+    } else if (!emailRegex.test(value)) {
+      setErrors((prev) => ({ ...prev, email: 'Invalid email format' }))
+    } else {
+      setErrors((prev) => ({ ...prev, email: '' }))
     }
+  }
+
+  const handleRoleChange = (value: string) => {
+    setInviteForm((prev) => ({ ...prev, role: value as InvitationRole }))
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -115,17 +116,11 @@ const InviteTab = ({ tenantId }: InviteTabProps) => {
               <label className="text-sm font-medium text-body mb-1.5">
                 Role <span className="required">*</span>
               </label>
-              <select
-                name="role"
+              <SelectDropdown
                 value={inviteForm.role}
-                onChange={handleFormChange}
-              >
-                {roleOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
+                onChange={handleRoleChange}
+                options={roleOptions}
+              />
             </div>
           </div>
 

--- a/src/pages/manage-tenant-members/MembersTab.tsx
+++ b/src/pages/manage-tenant-members/MembersTab.tsx
@@ -82,7 +82,7 @@ const MembersTab = ({ tenantId, tenantName }: MembersTabProps) => {
         ) : (
           <>
             <DataTable tableClassName="min-w-[700px]">
-              <thead className="bg-surface-muted border-b border-line">
+              <thead className="bg-surface-strong border-b border-line">
                 <tr>
                   <th className="px-4 py-3 text-left text-sm font-semibold text-body whitespace-nowrap">
                     First Name
@@ -130,7 +130,7 @@ const MembersTab = ({ tenantId, tenantName }: MembersTabProps) => {
                               : 'Member'}
                           </Badge>
                         </td>
-                        <td className="px-4 py-3.5 text-sm text-gray-800">
+                        <td className="px-6 py-3 text-sm text-gray-800">
                           <IconButton
                             icon={<UserMinusIcon className="size-5" />}
                             label="Remove member"

--- a/src/pages/manage-tenant-members/TenantInvitations.tsx
+++ b/src/pages/manage-tenant-members/TenantInvitations.tsx
@@ -71,7 +71,7 @@ const TenantInvitations = ({
       ) : (
         <>
           <DataTable>
-            <thead className="bg-surface-muted border-b border-line">
+            <thead className="bg-surface-strong border-b border-line">
               <tr>
                 <th className={thBase}>Email</th>
                 <th className={thBase}>Role</th>

--- a/src/pages/tenant-details/TenantDetails.tsx
+++ b/src/pages/tenant-details/TenantDetails.tsx
@@ -161,7 +161,7 @@ const TenantDetails = () => {
             setActiveTab(id as 'info' | 'status' | 'readiness')
             window.location.hash = id
           }}
-          className="mt-2"
+          className="mt-3"
         />
       </header>
 

--- a/src/pages/tenant-details/TenantStatusTab.tsx
+++ b/src/pages/tenant-details/TenantStatusTab.tsx
@@ -17,6 +17,7 @@ import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import Badge from '@/components/Badge'
 import Button from '@/components/Button'
+import SelectDropdown from '@/components/SelectDropdown'
 import { formatDateTime } from '@/utils/formatDateTime'
 import type { Job, JobStatus } from '@/types/tenants'
 
@@ -330,20 +331,13 @@ const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
                           >
                             Change Status:
                           </label>
-                          <select
-                            id={`status-${job.name}`}
+                          <SelectDropdown
                             value={selectedStatus || job.status}
-                            onChange={(e) =>
-                              setSelectedStatus(e.target.value as JobStatus)
+                            onChange={(value) =>
+                              setSelectedStatus(value as JobStatus)
                             }
-                            className="w-full px-3 py-2 text-sm font-medium"
-                          >
-                            {STATUS_OPTIONS.map((option) => (
-                              <option key={option.value} value={option.value}>
-                                {option.label}
-                              </option>
-                            ))}
-                          </select>
+                            options={STATUS_OPTIONS}
+                          />
                         </div>
                         <div className="flex flex-col gap-1 flex-1">
                           <label

--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import {
   useGetTopologyEndpoints,
   useGetTopologyServiceTypes,
@@ -6,17 +6,14 @@ import {
 } from '@/hooks/useTopology'
 import { useGetUserTenantById } from '@/hooks/useTenants'
 import { useParams, useNavigate } from 'react-router-dom'
-import {
-  PlusIcon,
-  TrashIcon,
-  ChevronUpDownIcon,
-} from '@heroicons/react/16/solid'
+import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
 import { toast } from 'sonner'
 import PageHeader from '@/components/PageHeader'
 import Button from '@/components/Button'
 import IconButton from '@/components/IconButton'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
+import SelectDropdown from '@/components/SelectDropdown'
 
 const sectionClass =
   'grid grid-cols-1 md:grid-cols-[360px_1fr] gap-4 md:gap-8 mb-8 animate-fade-in'
@@ -74,27 +71,9 @@ const CreateTopologyEndpoint = () => {
     contacts: [''],
   })
 
-  const [isServiceOpen, setIsServiceOpen] = useState(false)
-  const serviceDropdownRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!isServiceOpen) return
-    const handleMouseDown = (e: MouseEvent) => {
-      if (
-        serviceDropdownRef.current &&
-        !serviceDropdownRef.current.contains(e.target as Node)
-      ) {
-        setIsServiceOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleMouseDown)
-    return () => document.removeEventListener('mousedown', handleMouseDown)
-  }, [isServiceOpen])
-
-  const handleServiceSelect = (value: string) => {
+  const handleServiceChange = (value: string) => {
     setFormData((prev) => ({ ...prev, service: value }))
     if (value) setErrors((prev) => ({ ...prev, service: '' }))
-    setIsServiceOpen(false)
   }
 
   const handleHostnameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -273,48 +252,17 @@ const CreateTopologyEndpoint = () => {
             ) : typesError ? (
               <ErrorDisplay error={typesError} context="service types" />
             ) : (
-              <div className="relative" ref={serviceDropdownRef}>
-                <button
-                  type="button"
-                  onClick={() => setIsServiceOpen((prev) => !prev)}
-                  className={`w-full flex items-center justify-between gap-2 px-3 py-2 text-sm rounded-md border bg-white text-left transition-colors focus:outline-none focus:ring-2 focus:ring-brand/20 focus:border-brand ${
-                    errors.service
-                      ? 'border-red-500 focus:border-red-500 focus:ring-red-500/10'
-                      : 'border-line-strong hover:border-gray-400'
-                  }`}
-                >
-                  <span
-                    className={
-                      formData.service ? 'text-foreground' : 'text-subtle'
-                    }
-                  >
-                    {formData.service || 'Select a service type...'}
-                  </span>
-                  <ChevronUpDownIcon className="size-4 text-muted shrink-0" />
-                </button>
-
-                {isServiceOpen && (
-                  <div className="absolute z-10 mt-1 w-full bg-white border border-line rounded-md shadow-lg overflow-hidden animate-fade-in">
-                    <ul className="max-h-80 overflow-y-auto py-1">
-                      {serviceTypes?.map((st) => (
-                        <li key={st.name}>
-                          <button
-                            type="button"
-                            onClick={() => handleServiceSelect(st.name)}
-                            className={`w-full px-3 py-2 text-sm text-left cursor-pointer transition-colors ${
-                              formData.service === st.name
-                                ? 'bg-brand-subtle text-brand font-medium'
-                                : 'text-foreground hover:bg-brand-subtle'
-                            }`}
-                          >
-                            {st.name}
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-              </div>
+              <SelectDropdown
+                value={formData.service}
+                onChange={handleServiceChange}
+                options={
+                  serviceTypes?.map((st) => ({
+                    value: st.name,
+                    label: st.name,
+                  })) ?? []
+                }
+                placeholder="Select a service type..."
+              />
             )}
             {errors.service && (
               <span className="text-xs text-red-500 mt-1">

--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -14,6 +14,7 @@ import DataTable, {
 import Badge from '@/components/Badge'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
+import SelectDropdown from '@/components/SelectDropdown'
 type SortColumn = 'service' | 'group' | 'monitored'
 type DateMode = 'latest' | 'custom'
 
@@ -173,17 +174,19 @@ const TenantTopology = () => {
               type="date"
               value={customDate}
               onChange={handleCustomDateChange}
+              onClick={(e) => e.currentTarget.showPicker?.()}
               className="text-sm"
             />
           )}
-          <select
+          <SelectDropdown
             value={dateMode}
-            onChange={(e) => handleDateModeChange(e.target.value)}
-            className="text-sm"
-          >
-            <option value="latest">Latest</option>
-            <option value="custom">Select date</option>
-          </select>
+            onChange={handleDateModeChange}
+            options={[
+              { value: 'latest', label: 'Latest' },
+              { value: 'custom', label: 'Select date' },
+            ]}
+            className="w-36"
+          />
         </div>
       </div>
 
@@ -243,6 +246,15 @@ const TenantTopology = () => {
                 className="text-center text-sm text-subtle italic py-6 px-12"
               >
                 No topology endpoints found
+              </td>
+            </tr>
+          ) : searchQuery && !paginated.length ? (
+            <tr>
+              <td
+                colSpan={5}
+                className="text-center text-sm text-subtle italic py-6 px-12"
+              >
+                No results match your search
               </td>
             </tr>
           ) : (


### PR DESCRIPTION
This PR implements a reusable SelectDropdown component and replaces all select elements across the application.

- Added SelectDropdown reusable component with custom project styles, replacing all native select elements
- Refactored affected event handlers to accept a plain string value instead of HTMLSelectElement
- Updated empty-state styling across several pages to use a consistent text pattern
- Added a "No results" empty state to the topology endpoints table when search returns no matches