### PR TITLE
[ARGO-5472] - Add node configuration panel to tenant capabilities

### DIFF
--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -523,3 +523,49 @@ export const notifyAmsCheckReadiness = async (
 
   return response.json()
 }
+
+export const setTenantNode = async (
+  id: string,
+  node: boolean,
+  token: string,
+): Promise<void> => {
+  const response = await fetch(`${BACKEND_API}/v1/tenants/${id}/set-node`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ node }),
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+}
+
+export const setNodeReport = async (
+  tenantId: string,
+  reportId: string,
+  token: string,
+): Promise<void> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/reports/${reportId}/set-node-report`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+}

--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -1,5 +1,7 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useId } from 'react'
+import { createPortal } from 'react-dom'
 import { ChevronUpDownIcon } from '@heroicons/react/16/solid'
+import type { KeyboardEvent } from 'react'
 
 export interface SelectOption {
   value: string
@@ -24,67 +26,158 @@ const SelectDropdown = ({
   className,
 }: SelectDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false)
-  const dropdownRef = useRef<HTMLDivElement>(null)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const [menuPos, setMenuPos] = useState({ top: 0, left: 0, width: 0 })
+  const containerRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const listboxId = useId()
 
   useEffect(() => {
     if (!isOpen) return
     const handleMouseDown = (e: MouseEvent) => {
       if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
+        !containerRef.current?.contains(e.target as Node) &&
+        !menuRef.current?.contains(e.target as Node)
       ) {
         setIsOpen(false)
+        setActiveIndex(-1)
       }
     }
     document.addEventListener('mousedown', handleMouseDown)
     return () => document.removeEventListener('mousedown', handleMouseDown)
   }, [isOpen])
 
+  useEffect(() => {
+    if (!isOpen) return
+    const handleResize = () => setIsOpen(false)
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [isOpen])
+
+  useEffect(() => {
+    if (activeIndex < 0 || !isOpen) return
+    document
+      .getElementById(`${listboxId}-option-${activeIndex}`)
+      ?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex, isOpen, listboxId])
+
   const selectedLabel = options.find((o) => o.value === value)?.label
 
-  const handleToggle = () => {
-    if (!disabled) setIsOpen((prev) => !prev)
+  const openMenu = () => {
+    if (!containerRef.current) return
+    const rect = containerRef.current.getBoundingClientRect()
+    setMenuPos({ top: rect.bottom + 4, left: rect.left, width: rect.width })
+    setActiveIndex(options.findIndex((o) => o.value === value))
+    setIsOpen(true)
   }
 
   const handleSelect = (optionValue: string) => {
     onChange(optionValue)
     setIsOpen(false)
+    setActiveIndex(-1)
+  }
+
+  const handleToggle = () => {
+    if (disabled) return
+    if (isOpen) {
+      setIsOpen(false)
+      setActiveIndex(-1)
+    } else {
+      openMenu()
+    }
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) return
+    switch (e.key) {
+      case 'Enter':
+      case ' ':
+        e.preventDefault()
+        if (isOpen && activeIndex >= 0) {
+          handleSelect(options[activeIndex].value)
+        } else {
+          handleToggle()
+        }
+        break
+      case 'Escape':
+        e.preventDefault()
+        setIsOpen(false)
+        setActiveIndex(-1)
+        break
+      case 'ArrowDown':
+        e.preventDefault()
+        if (!isOpen) {
+          openMenu()
+        } else {
+          setActiveIndex((prev) => Math.min(prev + 1, options.length - 1))
+        }
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        if (isOpen) {
+          setActiveIndex((prev) => Math.max(prev - 1, 0))
+        }
+        break
+    }
   }
 
   return (
-    <div className={`relative ${className ?? ''}`} ref={dropdownRef}>
+    <div className={`relative ${className ?? ''}`} ref={containerRef}>
       <input
         type="text"
         readOnly
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
+        aria-activedescendant={
+          activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined
+        }
         value={selectedLabel ?? ''}
         placeholder={placeholder}
         disabled={disabled}
         onClick={handleToggle}
-        className="w-full cursor-pointer pr-9"
+        onKeyDown={handleKeyDown}
+        className="w-full cursor-pointer pr-9 py-1.5"
       />
       <ChevronUpDownIcon className="absolute right-2.5 top-1/2 -translate-y-1/2 size-4 text-muted shrink-0 pointer-events-none" />
 
-      {isOpen && (
-        <div className="absolute z-10 mt-1 w-full bg-white border border-line rounded-md shadow-lg overflow-hidden animate-fade-in">
-          <ul className="max-h-60 overflow-y-auto" role="listbox">
-            {options.map((option) => (
-              <li
-                key={option.value}
-                role="option"
-                aria-selected={option.value === value}
-                onClick={() => handleSelect(option.value)}
-                className={`px-4 py-1.5 mb-px last:mb-0 rounded-md text-sm cursor-pointer transition-colors ${
-                  option.value === value
-                    ? 'bg-brand-subtle text-brand font-medium'
-                    : 'text-foreground hover:bg-surface-muted'
-                }`}
-              >
-                {option.label}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      {isOpen &&
+        createPortal(
+          <div
+            ref={menuRef}
+            style={{
+              top: menuPos.top,
+              left: menuPos.left,
+              width: menuPos.width,
+            }}
+            className="fixed z-50 bg-white border border-line rounded-md shadow-lg overflow-hidden animate-fade-in"
+          >
+            <ul
+              id={listboxId}
+              className="max-h-60 overflow-y-auto"
+              role="listbox"
+            >
+              {options.map((option, index) => (
+                <li
+                  id={`${listboxId}-option-${index}`}
+                  key={option.value}
+                  role="option"
+                  aria-selected={option.value === value}
+                  onClick={() => handleSelect(option.value)}
+                  className={`px-4 py-1.5 mb-px last:mb-0 rounded-md text-sm cursor-pointer transition-colors ${
+                    option.value === value || index === activeIndex
+                      ? 'bg-brand-subtle text-brand font-medium'
+                      : 'text-foreground hover:bg-surface-muted'
+                  }`}
+                >
+                  {option.label}
+                </li>
+              ))}
+            </ul>
+          </div>,
+          document.body,
+        )}
     </div>
   )
 }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -134,12 +134,14 @@ function Sidebar({
             <SidebarSectionLabel>Account</SidebarSectionLabel>
             <SidebarNavItem to="/my-invitations" onClick={onCloseMobileMenu}>
               <EnvelopeIcon className="size-4" aria-hidden />
-              My Invitations
-              {pendingCount > 0 && (
-                <span className="bg-red-500 text-white text-[0.65rem] font-semibold rounded-full min-w-5 h-5 flex items-center justify-center px-1 shrink-0">
-                  {pendingCount > 99 ? '99+' : pendingCount}
-                </span>
-              )}
+              <span className="relative">
+                My Invitations
+                {pendingCount > 0 && (
+                  <span className="absolute -top-1 -right-4.5 bg-red-500 text-white text-[0.7rem] font-semibold rounded-full min-w-4 h-4 flex items-center justify-center px-1">
+                    {pendingCount > 99 ? '99+' : pendingCount}
+                  </span>
+                )}
+              </span>
             </SidebarNavItem>
           </div>
 

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -26,6 +26,8 @@ import {
   fetchTenantMetricProfile,
   fetchTenantReadiness,
   notifyAmsCheckReadiness,
+  setTenantNode,
+  setNodeReport,
 } from '@/api/tenants'
 import type {
   Job,
@@ -521,6 +523,51 @@ export const useCheckReadinessMutation = () => {
     },
     onError: (error) => {
       console.error('Failed to notify AMS check readiness:', error)
+    },
+  })
+}
+
+export const useSetTenantNodeMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<void, Error, { id: string; node: boolean }>({
+    mutationFn: ({ id, node }) => {
+      if (!token) throw new Error('No authentication token available')
+      if (!id) throw new Error('Tenant ID is required')
+      return setTenantNode(id, node, token)
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['user-tenant', variables.id] })
+      queryClient.invalidateQueries({ queryKey: ['user-tenants'] })
+    },
+    onError: (error) => {
+      console.error('Set tenant node error:', error)
+    },
+  })
+}
+
+export const useSetNodeReportMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<void, Error, { tenantId: string; reportId: string }>({
+    mutationFn: ({ tenantId, reportId }) => {
+      if (!token) throw new Error('No authentication token available')
+      if (!tenantId) throw new Error('Tenant ID is required')
+      if (!reportId) throw new Error('Report ID is required')
+      return setNodeReport(tenantId, reportId, token)
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['tenant-reports', variables.tenantId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['user-tenant', variables.tenantId],
+      })
+    },
+    onError: (error) => {
+      console.error('Set node report error:', error)
     },
   })
 }

--- a/src/pages/administration/StatusPagesManagementTab.tsx
+++ b/src/pages/administration/StatusPagesManagementTab.tsx
@@ -9,6 +9,7 @@ import Pagination from '@/components/Pagination'
 import SelectDropdown from '@/components/SelectDropdown'
 import type { SelectOption } from '@/components/SelectDropdown'
 import StatusPagesTable from '@/pages/status-pages/StatusPagesTable'
+import Button from '@/components/Button'
 
 const pageSize = 10
 
@@ -121,13 +122,25 @@ const StatusPagesManagementTab = () => {
         onConfirm={handleDeleteConfirm}
         onCancel={handleDeleteCancel}
       />
+
+      <div className="flex items-center justify-end mb-3">
+        <Button
+          variant="primary"
+          size="md"
+          href="/status-pages/build"
+          className=""
+        >
+          Create Status Page
+        </Button>
+      </div>
+
       <div className="bg-white border border-line rounded-lg shadow-sm overflow-hidden">
-        <div className="bg-surface-strong p-4 border-b border-line flex items-center gap-3">
+        <div className="bg-surface-strong px-4 py-3 border-b border-line flex items-center gap-2">
           <label className="block text-sm font-medium text-body">
             Select Tenant:
           </label>
           <SelectDropdown
-            className="max-w-md"
+            className="min-w-[280px] max-w-md"
             value={isAllSelected ? 'all' : tenantId}
             options={
               [

--- a/src/pages/manage-tenant-members/ManageTenantMembers.tsx
+++ b/src/pages/manage-tenant-members/ManageTenantMembers.tsx
@@ -23,13 +23,6 @@ const ManageTenantMembers = () => {
     'members' | 'invite' | 'add-direct' | 'invitations'
   >('members')
 
-  if (tenantError)
-    return (
-      <div className="page-container">
-        <ErrorDisplay error={tenantError} context="tenant" />
-      </div>
-    )
-
   return (
     <div className="page-container">
       <PageHeader
@@ -45,42 +38,50 @@ const ManageTenantMembers = () => {
         className="mb-2 pb-2"
       />
 
-      <Tabs
-        tabs={[
-          { id: 'members', label: 'Members' },
-          { id: 'invite', label: 'Invite Member' },
-          ...(isSuperAdmin ? [{ id: 'add-direct', label: 'Add Member' }] : []),
-          { id: 'invitations', label: 'Invitations' },
-        ]}
-        activeTab={activeTab}
-        onChange={(id) =>
-          setActiveTab(
-            id as 'members' | 'invite' | 'add-direct' | 'invitations',
-          )
-        }
-        className="mb-4"
-      />
-
-      {activeTab === 'members' && (
-        <MembersTab
-          tenantId={tenantId || ''}
-          tenantName={tenantData?.info.name || ''}
-        />
-      )}
-
-      {activeTab === 'invite' && <InviteTab tenantId={tenantId || ''} />}
-
-      {activeTab === 'add-direct' && isSuperAdmin && (
-        <AddDirectTab tenantId={tenantId || ''} />
-      )}
-
-      {activeTab === 'invitations' && (
-        <div className="animate-fade-in">
-          <TenantInvitations
-            tenantId={tenantId || ''}
-            tenantName={tenantData?.info.name || ''}
+      {tenantError ? (
+        <ErrorDisplay error={tenantError} context="tenant" />
+      ) : (
+        <>
+          <Tabs
+            tabs={[
+              { id: 'members', label: 'Members' },
+              { id: 'invite', label: 'Invite Member' },
+              ...(isSuperAdmin
+                ? [{ id: 'add-direct', label: 'Add Member' }]
+                : []),
+              { id: 'invitations', label: 'Invitations' },
+            ]}
+            activeTab={activeTab}
+            onChange={(id) =>
+              setActiveTab(
+                id as 'members' | 'invite' | 'add-direct' | 'invitations',
+              )
+            }
+            className="mb-4"
           />
-        </div>
+
+          {activeTab === 'members' && (
+            <MembersTab
+              tenantId={tenantId || ''}
+              tenantName={tenantData?.info.name || ''}
+            />
+          )}
+
+          {activeTab === 'invite' && <InviteTab tenantId={tenantId || ''} />}
+
+          {activeTab === 'add-direct' && isSuperAdmin && (
+            <AddDirectTab tenantId={tenantId || ''} />
+          )}
+
+          {activeTab === 'invitations' && (
+            <div className="animate-fade-in">
+              <TenantInvitations
+                tenantId={tenantId || ''}
+                tenantName={tenantData?.info.name || ''}
+              />
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/src/pages/status-pages/TenantStatusPages.tsx
+++ b/src/pages/status-pages/TenantStatusPages.tsx
@@ -7,6 +7,7 @@ import ConfirmDialog from '@/components/ConfirmDialog'
 import PageHeader from '@/components/PageHeader'
 import Pagination from '@/components/Pagination'
 import StatusPagesTable from './StatusPagesTable'
+import Button from '@/components/Button'
 
 const pageSize = 10
 
@@ -118,7 +119,11 @@ const TenantStatusPages = () => {
             </>
           }
           className="pb-1 mb-2 md:mb-4 px-2 md:px-0"
-        />
+        >
+          <Button variant="primary" size="md" href="/status-pages/build">
+            Create Status Page
+          </Button>
+        </PageHeader>
         <StatusPagesTable
           data={data}
           isLoading={isLoading}

--- a/src/pages/tenant-capabilities/NodeConfigPanel.tsx
+++ b/src/pages/tenant-capabilities/NodeConfigPanel.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect } from 'react'
+import {
+  useGetTenantReports,
+  useSetTenantNodeMutation,
+  useSetNodeReportMutation,
+} from '@/hooks/useTenants'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/16/solid'
+import { toast } from 'sonner'
+import SelectDropdown from '@/components/SelectDropdown'
+import Button from '@/components/Button'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+interface NodeConfigPanelProps {
+  tenantId: string
+  currentNode: boolean
+}
+
+const NodeConfigPanel = ({ tenantId, currentNode }: NodeConfigPanelProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [nodeEnabled, setNodeEnabled] = useState(currentNode)
+  const [selectedReportId, setSelectedReportId] = useState('')
+  const [reportError, setReportError] = useState('')
+
+  const { data: reports, isLoading: reportsLoading } = useGetTenantReports(
+    tenantId,
+    undefined,
+    isOpen,
+  )
+
+  useEffect(() => {
+    setNodeEnabled(currentNode)
+  }, [currentNode])
+
+  useEffect(() => {
+    if (reports) {
+      setSelectedReportId(reports.find((r) => r.node_report)?.id ?? '')
+    }
+  }, [reports])
+
+  const setNodeMutation = useSetTenantNodeMutation()
+  const setNodeReportMutation = useSetNodeReportMutation()
+
+  const reportOptions =
+    reports?.map((r) => ({ value: r.id, label: r.name })) ?? []
+  const hasReports = reports && reports?.length > 0
+  const isPending = setNodeMutation.isPending || setNodeReportMutation.isPending
+
+  const handleCancel = () => {
+    setNodeEnabled(currentNode)
+    setSelectedReportId(reports?.find((r) => r.node_report)?.id ?? '')
+    setReportError('')
+    setIsOpen(false)
+  }
+
+  const handleSave = async () => {
+    if (nodeEnabled && !selectedReportId) {
+      setReportError('A report is required when node is enabled')
+      return
+    }
+    setReportError('')
+
+    const toastId = toast.loading('Saving node configuration...')
+
+    try {
+      await setNodeMutation.mutateAsync({ id: tenantId, node: nodeEnabled })
+
+      if (selectedReportId) {
+        await setNodeReportMutation.mutateAsync({
+          tenantId,
+          reportId: selectedReportId,
+        })
+      }
+
+      toast.dismiss(toastId)
+      toast.success('Node configuration saved')
+      setIsOpen(false)
+    } catch (error) {
+      toast.dismiss(toastId)
+      toast.error(
+        `Failed to save: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      )
+    }
+  }
+
+  return (
+    <div className={isOpen ? 'mb-8' : 'mb-5'}>
+      <p className="text-sm text-muted mb-1">
+        Enable this tenant as a node and assign a default node report
+      </p>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex items-center justify-between w-full max-w-lg px-3 py-2 text-sm font-semibold text-muted hover:text-body bg-white border border-line rounded-lg hover:bg-surface-muted transition-colors cursor-pointer"
+      >
+        Configure Node
+        {isOpen ? (
+          <ChevronUpIcon className="size-5" />
+        ) : (
+          <ChevronDownIcon className="size-5" />
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="mt-2 p-4 bg-white border border-line rounded-lg shadow-sm max-w-lg animate-fade-in">
+          {reportsLoading ? (
+            <div className="flex justify-center py-4">
+              <LoadingSpinner size="sm" />
+            </div>
+          ) : !hasReports ? (
+            <p className="text-sm text-amber-600 font-medium mb-3">
+              There are no available reports to select.
+            </p>
+          ) : null}
+
+          {!reportsLoading && (
+            <>
+              <div className="flex flex-col gap-3">
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="toggle toggle-brand"
+                    checked={nodeEnabled}
+                    onChange={() => setNodeEnabled((prev) => !prev)}
+                    disabled={isPending}
+                  />
+                  <span className="text-sm font-semibold text-body">
+                    {nodeEnabled ? 'Node enabled' : 'Node disabled'}
+                  </span>
+                </label>
+
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm font-semibold text-muted px-1">
+                    Node report <span className="required">*</span>
+                  </label>
+                  <SelectDropdown
+                    value={selectedReportId}
+                    onChange={(value) => {
+                      setSelectedReportId(value)
+                      if (value) setReportError('')
+                    }}
+                    options={reportOptions}
+                    placeholder="Select a report"
+                    disabled={!hasReports || isPending}
+                  />
+                  {reportError && (
+                    <span className="text-xs text-red-500 mt-1 px-1">
+                      {reportError}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex gap-4 justify-end mt-4">
+                <Button
+                  onClick={handleCancel}
+                  size="sm"
+                  variant="outline-secondary"
+                >
+                  Cancel
+                </Button>
+                <Button onClick={handleSave} size="sm" disabled={isPending}>
+                  Save
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default NodeConfigPanel

--- a/src/pages/tenant-capabilities/TenantCapabilities.tsx
+++ b/src/pages/tenant-capabilities/TenantCapabilities.tsx
@@ -1,11 +1,19 @@
 import { useParams } from 'react-router-dom'
 import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useAuth } from '@/auth/useAuth'
 import PageHeader from '@/components/PageHeader'
 import TenantCapabilitiesTab from './TenantCapabilitiesTab'
+import NodeConfigPanel from './NodeConfigPanel'
 
 const TenantCapabilities = () => {
   const { id } = useParams<{ id: string }>()
+  const { profile } = useAuth()
   const { data: tenantData } = useGetUserTenantById(id || '')
+  const isSuperAdmin = profile?.roles?.includes('super_admin')
+  const isTenantAdmin = profile?.groups?.some(
+    (g) => g.name === tenantData?.info.name && g.role === 'admin',
+  )
+  const canConfigureNode = isSuperAdmin || isTenantAdmin
 
   return (
     <div className="page-container">
@@ -19,8 +27,14 @@ const TenantCapabilities = () => {
             </strong>
           </>
         }
-        className="pb-2 mb-4"
+        className="pb-2 mb-2"
       />
+      {canConfigureNode && tenantData !== undefined && (
+        <NodeConfigPanel
+          tenantId={id || ''}
+          currentNode={tenantData.node ?? false}
+        />
+      )}
       <TenantCapabilitiesTab tenantId={id || ''} />
     </div>
   )

--- a/src/pages/tenant-details/TenantDetails.tsx
+++ b/src/pages/tenant-details/TenantDetails.tsx
@@ -46,14 +46,14 @@ const TenantDetails = () => {
 
   if (error)
     return (
-      <div className="page-container">
+      <div className="page-container p-12">
         <ErrorDisplay error={error} context="tenant" />
       </div>
     )
 
   if (!tenantData)
     return (
-      <div className="page-container">
+      <div className="page-container p-12">
         <ErrorDisplay
           error="The tenant you are looking for does not exist or has been removed."
           context="tenant"
@@ -165,7 +165,7 @@ const TenantDetails = () => {
         />
       </header>
 
-      <div className="py-4 px-10">
+      <div className="px-10">
         {activeTab === 'info' && <TenantInfoTab tenantId={tenantId || ''} />}
         {activeTab === 'status' && (
           <TenantStatusTab tenantId={tenantId || ''} />

--- a/src/pages/tenant-details/TenantInfoTab.tsx
+++ b/src/pages/tenant-details/TenantInfoTab.tsx
@@ -73,8 +73,8 @@ const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
           <h2 className="text-lg font-semibold text-foreground">Projects</h2>
         </div>
         {projectsLoading ? (
-          <div className={cardClass}>
-            <LoadingSpinner size="sm" inline />
+          <div className={`${cardClass} items-center max-w-[180px]`}>
+            <LoadingSpinner size="xs" inline />
           </div>
         ) : projects && projects.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-4">

--- a/src/pages/tenant-details/TenantStatusTab.tsx
+++ b/src/pages/tenant-details/TenantStatusTab.tsx
@@ -79,7 +79,7 @@ const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
     data: statusData,
     isLoading: statusLoading,
     error: statusError,
-  } = useGetUserTenantStatus(tenantId)
+  } = useGetUserTenantStatus(tenantId, 10000) // Refetch every 10 seconds to keep status updated
 
   const updateStatusMutation = useUpdateTenantStatusMutation()
 
@@ -214,7 +214,7 @@ const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
     return <ErrorDisplay error={statusError} context="tenant status" />
 
   return (
-    <div className="flex flex-col gap-6 max-w-[1040px] mx-auto">
+    <div className="flex flex-col gap-6 max-w-[1040px] mx-auto py-1">
       {jobs && jobs.length > 0 ? (
         jobs
           .filter((job) => job.name !== 'CHECK_READINESS')

--- a/src/pages/tenant-reports/TenantReportsContent.tsx
+++ b/src/pages/tenant-reports/TenantReportsContent.tsx
@@ -104,7 +104,7 @@ const TenantReportsTab = ({ tenantId }: { tenantId: string }) => {
                   )}
                 </div>
                 {report.description && (
-                  <p className="text-xs text-muted mt-2 leading-[1.4]">
+                  <p className="text-xs text-muted leading-[1.4]">
                     {report.description}
                   </p>
                 )}

--- a/src/types/tenants.ts
+++ b/src/types/tenants.ts
@@ -71,6 +71,7 @@ export type Tenant = {
   metadata?: Metadata
   updated_by?: string
   status?: TenantStatus
+  node?: boolean
   ['group-status']?: 'UNKNOWN' | 'NOT_FOUND' | 'EXISTS'
 }
 
@@ -117,6 +118,7 @@ export type ReportListItem = {
   disabled: boolean
   created_at: string
   updated_at: string
+  node_report?: boolean
 }
 
 export type ReportProfile = {


### PR DESCRIPTION
This PR adds a node configuration panel to the tenant capabilities page, along with various improvements

- Added NodeConfigPanel component with a collapsible form to toggle node status and select a default node report
- Added setTenantNode and setNodeReport API functions to support node configuration
- Updated TenantCapabilities to render NodeConfigPanel based on user role
- Improved SelectDropdown component with better UX and keyboard navigation
- Added Create Status Page button to TenantStatusPages and StatusPagesManagementTab
- Fixed error handling in ManageTenantMembers to render inline instead of returning early
- Adjusted loading spinner size in TenantInfoTab projects section
- Minor layout and spacing fixes in TenantDetails