### PR TITLE
[ARGO-5475] - Add edit and delete actions for topology endpoints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -208,6 +208,14 @@ function App() {
                     </AuthProtected>
                   }
                 />
+                <Route
+                  path="tenants/:id/topology/edit/:endpointId"
+                  element={
+                    <AuthProtected>
+                      <CreateTopologyEndpoint />
+                    </AuthProtected>
+                  }
+                />
                 <Route path="*" element={<NotFound />} />
               </Route>
             </Route>

--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import {
   useGetTopologyEndpoints,
   useGetTopologyServiceTypes,
@@ -6,6 +6,7 @@ import {
 } from '@/hooks/useTopology'
 import { useGetUserTenantById } from '@/hooks/useTenants'
 import { useParams, useNavigate } from 'react-router-dom'
+import type { EndpointTopologyItem } from '@/types/topology'
 import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
 import { toast } from 'sonner'
 import PageHeader from '@/components/PageHeader'
@@ -44,12 +45,14 @@ interface FormErrors {
 }
 
 const CreateTopologyEndpoint = () => {
-  const { id } = useParams<{ id: string }>()
+  const { id, endpointId } = useParams<{ id: string; endpointId?: string }>()
   const tenantId = id ?? ''
+  const isEditMode = !!endpointId
   const navigate = useNavigate()
 
   const { data: tenantData } = useGetUserTenantById(tenantId)
-  const { data: existingEndpoints } = useGetTopologyEndpoints(tenantId, today)
+  const { data: existingEndpoints, isLoading: isLoadingEndpoints } =
+    useGetTopologyEndpoints(tenantId, today)
   const {
     data: serviceTypes,
     isLoading: isLoadingTypes,
@@ -70,6 +73,49 @@ const CreateTopologyEndpoint = () => {
     hostname: '',
     contacts: [''],
   })
+
+  const formInitialized = useRef(false)
+
+  useEffect(() => {
+    if (!isEditMode || formInitialized.current || !existingEndpoints) {
+      return
+    }
+    const endpoint = existingEndpoints.find((e) => e.id === endpointId)
+    if (!endpoint) {
+      return
+    }
+
+    setFormData({
+      service: endpoint.service,
+      hostname: endpoint.hostname,
+      monitored: endpoint.tags?.monitored === '1',
+      notificationsEnabled: endpoint.notifications?.enabled ?? false,
+      contacts: endpoint.notifications?.contacts?.length
+        ? endpoint.notifications.contacts.map((email) => ({
+            id: crypto.randomUUID(),
+            value: email,
+          }))
+        : [{ id: crypto.randomUUID(), value: '' }],
+    })
+    formInitialized.current = true
+  }, [isEditMode, endpointId, existingEndpoints])
+
+  if (isEditMode && isLoadingEndpoints)
+    return (
+      <div className="page-container">
+        <LoadingSpinner size="md" />
+      </div>
+    )
+
+  if (isEditMode && !existingEndpoints?.find((e) => e.id === endpointId))
+    return (
+      <div className="page-container">
+        <ErrorDisplay
+          error={new Error('Endpoint not found')}
+          context="loading endpoint for editing"
+        />
+      </div>
+    )
 
   const handleServiceChange = (value: string) => {
     setFormData((prev) => ({ ...prev, service: value }))
@@ -158,35 +204,49 @@ const CreateTopologyEndpoint = () => {
       return
     }
 
-    const payload = [
-      ...(existingEndpoints ?? []),
-      {
-        date: today,
-        group: 'DEFAULT',
-        type: 'SERVICEGROUPS',
-        service: formData.service,
-        hostname: formData.hostname.trim(),
-        tags: {
-          monitored: formData.monitored ? '1' : '0',
-        },
-        notifications: {
-          enabled: formData.notificationsEnabled,
-          contacts: formData.contacts
-            .filter((c) => c.value.trim() && emailRegex.test(c.value))
-            .map((c) => c.value),
-        },
+    const updatedFields = {
+      service: formData.service,
+      hostname: formData.hostname.trim(),
+      tags: { monitored: formData.monitored ? '1' : '0' },
+      notifications: {
+        enabled: formData.notificationsEnabled,
+        contacts: formData.contacts
+          .filter((c) => c.value.trim() && emailRegex.test(c.value))
+          .map((c) => c.value),
       },
-    ]
+    }
+
+    const payload = isEditMode
+      ? (existingEndpoints ?? []).map((endpoint) =>
+          endpoint.id === endpointId
+            ? { ...endpoint, ...updatedFields }
+            : endpoint,
+        )
+      : [
+          ...(existingEndpoints ?? []),
+          {
+            date: today,
+            group: 'DEFAULT',
+            type: 'SERVICEGROUPS',
+            ...updatedFields,
+          } as unknown as EndpointTopologyItem,
+        ]
 
     createMutation.mutate(
       { tenantId, data: payload },
       {
         onSuccess: () => {
-          toast.success('Topology endpoint created successfully!')
+          toast.success(
+            isEditMode
+              ? 'Topology endpoint updated successfully!'
+              : 'Topology endpoint created successfully!',
+          )
           navigate(`/tenants/${tenantId}/topology`)
         },
         onError: (error) => {
-          toast.error(`Failed to create topology endpoint: ${error.message}`)
+          toast.error(
+            `Failed to ${isEditMode ? 'update' : 'create'} topology endpoint: ${error.message}`,
+          )
         },
       },
     )
@@ -199,10 +259,12 @@ const CreateTopologyEndpoint = () => {
   return (
     <div className="page-container">
       <PageHeader
-        title="Add Topology Endpoint"
+        title={isEditMode ? 'Edit Topology Endpoint' : 'Add Topology Endpoint'}
         subtitle={
           <>
-            Configure and register a new topology endpoint for tenant{' '}
+            {isEditMode
+              ? 'Update the topology endpoint for tenant '
+              : 'Configure and register a new topology endpoint for tenant '}
             <strong>{tenantData?.info.name ?? '...'}</strong>
           </>
         }
@@ -222,8 +284,10 @@ const CreateTopologyEndpoint = () => {
           {createMutation.isPending ? (
             <>
               <LoadingSpinner size="xs" />
-              Creating...
+              Saving...
             </>
+          ) : isEditMode ? (
+            'Update Endpoint'
           ) : (
             'Add Endpoint'
           )}

--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -1,9 +1,16 @@
 import { useState, useEffect, useRef } from 'react'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
+import { toast } from 'sonner'
+import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
 import { useGetUserTenantById } from '@/hooks/useTenants'
-import { useGetTopologyEndpoints } from '@/hooks/useTopology'
+import {
+  useGetTopologyEndpoints,
+  useCreateTopologyEndpointMutation,
+} from '@/hooks/useTopology'
 import PageHeader from '@/components/PageHeader'
 import Button from '@/components/Button'
+import IconButton from '@/components/IconButton'
+import ConfirmDialog from '@/components/ConfirmDialog'
 import SearchInput from '@/components/SearchInput'
 import Pagination from '@/components/Pagination'
 import DataTable, {
@@ -15,14 +22,17 @@ import Badge from '@/components/Badge'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import SelectDropdown from '@/components/SelectDropdown'
+import type { EndpointTopologyItem } from '@/types/topology'
 type SortColumn = 'service' | 'group' | 'monitored'
 type DateMode = 'latest' | 'custom'
 
 const pageSize = 15
+const today = new Date().toISOString().split('T')[0]
 
 const TenantTopology = () => {
   const { id } = useParams<{ id: string }>()
   const tenantId = id ?? ''
+  const navigate = useNavigate()
 
   const { data: tenantData } = useGetUserTenantById(tenantId)
 
@@ -35,6 +45,9 @@ const TenantTopology = () => {
   const [customDate, setCustomDate] = useState('')
   const [committedDate, setCommittedDate] = useState('')
   const dateInputRef = useRef<HTMLInputElement>(null)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [endpointToDelete, setEndpointToDelete] =
+    useState<EndpointTopologyItem | null>(null)
 
   const effectiveDate = dateMode === 'latest' ? '' : committedDate
 
@@ -43,6 +56,36 @@ const TenantTopology = () => {
     isLoading,
     error,
   } = useGetTopologyEndpoints(tenantId, effectiveDate)
+
+  const deleteMutation = useCreateTopologyEndpointMutation()
+
+  const handleDeleteClick = (endpoint: EndpointTopologyItem) => {
+    setEndpointToDelete(endpoint)
+    setDeleteDialogOpen(true)
+  }
+
+  const handleDeleteConfirm = () => {
+    if (!endpointToDelete) return
+    const updatedEndpoints = (endpoints ?? []).filter(
+      (e) => e.id !== endpointToDelete.id,
+    )
+    deleteMutation.mutate(
+      { tenantId, data: updatedEndpoints },
+      {
+        onSuccess: () => {
+          toast.success('Topology endpoint deleted successfully!')
+          setDeleteDialogOpen(false)
+          setEndpointToDelete(null)
+          if (paginated.length === 1 && currentPage > 1) {
+            setCurrentPage((prev) => prev - 1)
+          }
+        },
+        onError: (error) => {
+          toast.error(`Failed to delete endpoint: ${error.message}`)
+        },
+      },
+    )
+  }
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -137,169 +180,217 @@ const TenantTopology = () => {
   )
 
   return (
-    <div className="page-container">
-      <PageHeader
-        title="Topology Endpoints"
-        subtitle={
+    <>
+      <div className="page-container">
+        <PageHeader
+          title="Topology Endpoints"
+          subtitle={
+            <>
+              Manage topology endpoints for tenant{' '}
+              <strong>{tenantData?.info.name ?? '...'}</strong>
+            </>
+          }
+          className="pb-2 mb-4"
+        >
+          {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
+            <Button
+              variant="primary"
+              size="md"
+              href={`/tenants/${tenantId}/topology/create`}
+            >
+              Add Topology Endpoint
+            </Button>
+          )}
+        </PageHeader>
+
+        <div className="flex items-center justify-between gap-3 mb-3">
+          <SearchInput
+            value={searchInput}
+            onChange={setSearchInput}
+            onClear={handleSearchClear}
+            placeholder="Search by service, group or monitored status..."
+            className="!mb-0 w-full"
+          />
+          <div className="flex items-center gap-2 shrink-0">
+            {dateMode === 'custom' && (
+              <input
+                ref={dateInputRef}
+                type="date"
+                value={customDate}
+                onChange={handleCustomDateChange}
+                onClick={(e) => e.currentTarget.showPicker?.()}
+                className="text-sm"
+              />
+            )}
+            <SelectDropdown
+              value={dateMode}
+              onChange={handleDateModeChange}
+              options={[
+                { value: 'latest', label: 'Latest' },
+                { value: 'custom', label: 'Select date' },
+              ]}
+              className="w-36"
+            />
+          </div>
+        </div>
+
+        <DataTable>
+          <thead className="bg-surface-strong border-b border-line">
+            <tr>
+              <th className={`${thBase} min-w-28`}>
+                <SortableColumnHeader
+                  isActive={sortColumn === 'service'}
+                  isAscending={sortAsc}
+                  onClick={() => handleSortChange('service')}
+                >
+                  Service
+                </SortableColumnHeader>
+              </th>
+              <th className={`${thBase} min-w-40`}>URL</th>
+              <th className={`${thBase} min-w-24`}>
+                <SortableColumnHeader
+                  isActive={sortColumn === 'group'}
+                  isAscending={sortAsc}
+                  onClick={() => handleSortChange('group')}
+                >
+                  Group
+                </SortableColumnHeader>
+              </th>
+              <th className={`${thBase} min-w-24`}>
+                <SortableColumnHeader
+                  isActive={sortColumn === 'monitored'}
+                  isAscending={sortAsc}
+                  onClick={() => handleSortChange('monitored')}
+                >
+                  Monitored
+                </SortableColumnHeader>
+              </th>
+              <th className={`${thBase} min-w-28`}>Date</th>
+              <th className={`${thBase} w-24`}>Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {isLoading ? (
+              <tr>
+                <td colSpan={6} className="py-12">
+                  <div className="flex justify-center">
+                    <LoadingSpinner size="md" />
+                  </div>
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={6} className="py-6 px-12">
+                  <ErrorDisplay error={error} context="topology endpoints" />
+                </td>
+              </tr>
+            ) : !endpoints?.length ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="text-center text-sm text-subtle italic py-6 px-12"
+                >
+                  No topology endpoints found
+                </td>
+              </tr>
+            ) : searchQuery && !paginated.length ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="text-center text-sm text-subtle italic py-6 px-12"
+                >
+                  No results match your search
+                </td>
+              </tr>
+            ) : (
+              paginated.map((endpoint) => (
+                <tr
+                  key={endpoint.id}
+                  className="hover:bg-surface-muted transition-colors"
+                >
+                  <td className={tdBase}>{endpoint.service}</td>
+                  <td className={`${tdBase} font-mono text-xs break-all`}>
+                    {endpoint.hostname}
+                  </td>
+                  <td className={tdBase}>{endpoint.group}</td>
+                  <td className={tdBase}>
+                    {endpoint.tags?.monitored !== undefined ? (
+                      <Badge
+                        size="sm"
+                        className={
+                          endpoint.tags.monitored === '1'
+                            ? 'bg-emerald-50 text-emerald-600'
+                            : 'bg-surface-strong text-muted'
+                        }
+                      >
+                        {endpoint.tags.monitored === '1'
+                          ? 'Monitored'
+                          : 'Not Monitored'}
+                      </Badge>
+                    ) : null}
+                  </td>
+                  <td className={tdBase}>{endpoint.date}</td>
+                  <td className={`${tdBase} whitespace-nowrap`}>
+                    {endpoint.date === today && (
+                      <div className="flex items-center gap-1">
+                        <IconButton
+                          icon={
+                            <PencilSquareIcon className="size-4 md:size-5" />
+                          }
+                          label="Edit"
+                          onClick={() =>
+                            navigate(
+                              `/tenants/${tenantId}/topology/edit/${endpoint.id}`,
+                            )
+                          }
+                          className="text-muted hover:bg-surface-strong"
+                        />
+                        <IconButton
+                          icon={<TrashIcon className="size-4 md:size-5" />}
+                          label="Delete"
+                          onClick={() => handleDeleteClick(endpoint)}
+                          className="text-red-600 hover:bg-red-50"
+                        />
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </DataTable>
+
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalElements={sorted.length}
+          itemLabel="endpoints"
+          onPrev={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+          onNext={() => setCurrentPage((prev) => prev + 1)}
+        />
+      </div>
+      <ConfirmDialog
+        isOpen={deleteDialogOpen}
+        title="Delete Topology Endpoint"
+        message={
           <>
-            Manage topology endpoints for tenant{' '}
-            <strong>{tenantData?.info.name ?? '...'}</strong>
+            Are you sure you want to delete the endpoint with URL{' '}
+            <strong>{endpointToDelete?.hostname}</strong> ?
+            <br />
+            <span className="text-amber-600 font-medium">
+              This action cannot be undone.
+            </span>
           </>
         }
-        className="pb-2 mb-4"
-      >
-        {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
-          <Button
-            variant="primary"
-            size="md"
-            href={`/tenants/${tenantId}/topology/create`}
-          >
-            Add Topology Endpoint
-          </Button>
-        )}
-      </PageHeader>
-
-      <div className="flex items-center justify-between gap-3 mb-3">
-        <SearchInput
-          value={searchInput}
-          onChange={setSearchInput}
-          onClear={handleSearchClear}
-          placeholder="Search by service, group or monitored status..."
-          className="!mb-0 w-full"
-        />
-        <div className="flex items-center gap-2 shrink-0">
-          {dateMode === 'custom' && (
-            <input
-              ref={dateInputRef}
-              type="date"
-              value={customDate}
-              onChange={handleCustomDateChange}
-              onClick={(e) => e.currentTarget.showPicker?.()}
-              className="text-sm"
-            />
-          )}
-          <SelectDropdown
-            value={dateMode}
-            onChange={handleDateModeChange}
-            options={[
-              { value: 'latest', label: 'Latest' },
-              { value: 'custom', label: 'Select date' },
-            ]}
-            className="w-36"
-          />
-        </div>
-      </div>
-
-      <DataTable>
-        <thead className="bg-surface-strong border-b border-line">
-          <tr>
-            <th className={`${thBase} min-w-28`}>
-              <SortableColumnHeader
-                isActive={sortColumn === 'service'}
-                isAscending={sortAsc}
-                onClick={() => handleSortChange('service')}
-              >
-                Service
-              </SortableColumnHeader>
-            </th>
-            <th className={`${thBase} min-w-40`}>URL</th>
-            <th className={`${thBase} min-w-24`}>
-              <SortableColumnHeader
-                isActive={sortColumn === 'group'}
-                isAscending={sortAsc}
-                onClick={() => handleSortChange('group')}
-              >
-                Group
-              </SortableColumnHeader>
-            </th>
-            <th className={`${thBase} min-w-24`}>
-              <SortableColumnHeader
-                isActive={sortColumn === 'monitored'}
-                isAscending={sortAsc}
-                onClick={() => handleSortChange('monitored')}
-              >
-                Monitored
-              </SortableColumnHeader>
-            </th>
-            <th className={`${thBase} min-w-28`}>Date</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-100">
-          {isLoading ? (
-            <tr>
-              <td colSpan={5} className="py-12">
-                <div className="flex justify-center">
-                  <LoadingSpinner size="md" />
-                </div>
-              </td>
-            </tr>
-          ) : error ? (
-            <tr>
-              <td colSpan={5} className="py-6 px-12">
-                <ErrorDisplay error={error} context="topology endpoints" />
-              </td>
-            </tr>
-          ) : !endpoints?.length ? (
-            <tr>
-              <td
-                colSpan={5}
-                className="text-center text-sm text-subtle italic py-6 px-12"
-              >
-                No topology endpoints found
-              </td>
-            </tr>
-          ) : searchQuery && !paginated.length ? (
-            <tr>
-              <td
-                colSpan={5}
-                className="text-center text-sm text-subtle italic py-6 px-12"
-              >
-                No results match your search
-              </td>
-            </tr>
-          ) : (
-            paginated.map((endpoint, index) => (
-              <tr
-                key={endpoint.id ?? index}
-                className="hover:bg-surface-muted transition-colors"
-              >
-                <td className={tdBase}>{endpoint.service}</td>
-                <td className={`${tdBase} font-mono text-xs break-all`}>
-                  {endpoint.hostname}
-                </td>
-                <td className={tdBase}>{endpoint.group}</td>
-                <td className={tdBase}>
-                  {endpoint.tags?.monitored !== undefined ? (
-                    <Badge
-                      size="sm"
-                      className={
-                        endpoint.tags.monitored === '1'
-                          ? 'bg-emerald-50 text-emerald-600'
-                          : 'bg-surface-strong text-muted'
-                      }
-                    >
-                      {endpoint.tags.monitored === '1'
-                        ? 'Monitored'
-                        : 'Not Monitored'}
-                    </Badge>
-                  ) : null}
-                </td>
-                <td className={tdBase}>{endpoint.date}</td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </DataTable>
-
-      <Pagination
-        currentPage={currentPage}
-        totalPages={totalPages}
-        totalElements={sorted.length}
-        itemLabel="endpoints"
-        onPrev={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
-        onNext={() => setCurrentPage((prev) => prev + 1)}
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => {
+          setDeleteDialogOpen(false)
+          setEndpointToDelete(null)
+        }}
       />
-    </div>
+    </>
   )
 }
 

--- a/src/types/topology.ts
+++ b/src/types/topology.ts
@@ -6,7 +6,7 @@ export type TopologyNotifications = {
 }
 
 export type EndpointTopologyItem = {
-  id?: string
+  id: string
   date: string
   group: string
   type: string


### PR DESCRIPTION
This PR adds edit and delete actions to the topology endpoints table, allowing users to update an existing endpoint via a pre-populated form or remove it through a confirmation dialog.

- Added Actions column to TenantTopology with Edit and Delete buttons
- Extended CreateTopologyEndpoint to support edit mode, pre-populating the form and replacing the endpoint on save
- Implemented delete flow with ConfirmDialog, sending the remaining items on confirm
- Added edit route /tenants/:id/topology/edit/:endpointId in App component
