### PR TITLE
[ARGO-5481] - Refactor topology endpoint editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -208,14 +208,6 @@ function App() {
                     </AuthProtected>
                   }
                 />
-                <Route
-                  path="tenants/:id/topology/edit/:endpointId"
-                  element={
-                    <AuthProtected>
-                      <CreateTopologyEndpoint />
-                    </AuthProtected>
-                  }
-                />
                 <Route path="*" element={<NotFound />} />
               </Route>
             </Route>

--- a/src/api/topology.ts
+++ b/src/api/topology.ts
@@ -35,9 +35,10 @@ export const fetchCreateTopologyEndpoints = async (
   tenantId: string,
   data: EndpointTopologyItem[],
   token: string,
+  force: boolean = true,
 ): Promise<CreateTopologyEndpointResponse> => {
   const response = await fetch(
-    `${BACKEND_API}/v1/tenants/${tenantId}/topology/endpoints`,
+    `${BACKEND_API}/v1/tenants/${tenantId}/topology/endpoints?force=${force}`,
     {
       method: 'POST',
       headers: {

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react'
 interface NavigateTo {
   label: string
   to: string
+  onClick?: () => void
 }
 
 interface PageHeaderProps {
@@ -27,6 +28,7 @@ const PageHeader = ({
       {navigateTo && (
         <Link
           to={navigateTo.to}
+          onClick={navigateTo.onClick}
           className="inline-flex items-center gap-1.5 text-base text-subtle hover:text-foreground no-underline mb-1 transition-colors"
         >
           <ArrowLeftIcon className="size-4" />

--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import {
   useGetTopologyEndpoints,
   useGetTopologyServiceTypes,
@@ -44,10 +44,20 @@ interface FormErrors {
   contacts: string[]
 }
 
-const CreateTopologyEndpoint = () => {
-  const { id, endpointId } = useParams<{ id: string; endpointId?: string }>()
-  const tenantId = id ?? ''
-  const isEditMode = !!endpointId
+interface CreateTopologyEndpointProps {
+  tenantId?: string
+  editingEndpoint?: EndpointTopologyItem
+  onClose?: () => void
+}
+
+const CreateTopologyEndpoint = ({
+  tenantId: tenantIdProp,
+  editingEndpoint,
+  onClose,
+}: CreateTopologyEndpointProps = {}) => {
+  const { id: tenantIdParam } = useParams<{ id?: string }>()
+  const tenantId = tenantIdProp ?? tenantIdParam ?? ''
+  const isEditMode = !!editingEndpoint
   const navigate = useNavigate()
 
   const { data: tenantData } = useGetUserTenantById(tenantId)
@@ -55,22 +65,36 @@ const CreateTopologyEndpoint = () => {
   const { data: todayEndpoints, isLoading: isLoadingToday } =
     useGetTopologyEndpoints(tenantId, today)
 
-  const { data: latestEndpoints, isLoading: isLoadingLatest } =
-    useGetTopologyEndpoints(tenantId, '', isEditMode)
-
   const {
     data: serviceTypes,
     isLoading: isLoadingTypes,
     error: typesError,
   } = useGetTopologyServiceTypes(tenantId)
+
   const createMutation = useCreateTopologyEndpointMutation()
 
-  const [formData, setFormData] = useState<FormData>({
-    service: '',
-    hostname: '',
-    monitored: true,
-    notificationsEnabled: false,
-    contacts: [{ id: crypto.randomUUID(), value: '' }],
+  const [formData, setFormData] = useState<FormData>(() => {
+    if (editingEndpoint) {
+      return {
+        service: editingEndpoint.service,
+        hostname: editingEndpoint.hostname,
+        monitored: editingEndpoint.tags?.monitored === '1',
+        notificationsEnabled: editingEndpoint.notifications?.enabled ?? false,
+        contacts: editingEndpoint.notifications?.contacts?.length
+          ? editingEndpoint.notifications.contacts.map((email) => ({
+              id: crypto.randomUUID(),
+              value: email,
+            }))
+          : [{ id: crypto.randomUUID(), value: '' }],
+      }
+    }
+    return {
+      service: '',
+      hostname: '',
+      monitored: true,
+      notificationsEnabled: false,
+      contacts: [{ id: crypto.randomUUID(), value: '' }],
+    }
   })
 
   const [errors, setErrors] = useState<FormErrors>({
@@ -79,61 +103,19 @@ const CreateTopologyEndpoint = () => {
     contacts: [''],
   })
 
-  const formInitialized = useRef(false)
-
-  useEffect(() => {
-    if (!isEditMode || formInitialized.current || !latestEndpoints) {
-      return
-    }
-    const endpoint = latestEndpoints.find((e) => e.id === endpointId)
-    if (!endpoint) {
-      return
-    }
-    setFormData({
-      service: endpoint.service,
-      hostname: endpoint.hostname,
-      monitored: endpoint.tags?.monitored === '1',
-      notificationsEnabled: endpoint.notifications?.enabled ?? false,
-      contacts: endpoint.notifications?.contacts?.length
-        ? endpoint.notifications.contacts.map((email: string) => ({
-            id: crypto.randomUUID(),
-            value: email,
-          }))
-        : [{ id: crypto.randomUUID(), value: '' }],
-    })
-    formInitialized.current = true
-  }, [isEditMode, endpointId, latestEndpoints])
-
-  if (isEditMode && (isLoadingLatest || isLoadingToday))
-    return (
-      <div className="page-container">
-        <LoadingSpinner size="md" />
-      </div>
-    )
-
-  if (
-    isEditMode &&
-    latestEndpoints &&
-    !latestEndpoints.find((e) => e.id === endpointId)
-  )
-    return (
-      <div className="page-container">
-        <ErrorDisplay
-          error={new Error('Endpoint not found')}
-          context="loading endpoint for editing"
-        />
-      </div>
-    )
-
   const handleServiceChange = (value: string) => {
     setFormData((prev) => ({ ...prev, service: value }))
-    if (value) setErrors((prev) => ({ ...prev, service: '' }))
+    if (value) {
+      setErrors((prev) => ({ ...prev, service: '' }))
+    }
   }
 
   const handleHostnameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
     setFormData((prev) => ({ ...prev, hostname: value }))
-    if (value.trim()) setErrors((prev) => ({ ...prev, hostname: '' }))
+    if (value.trim()) {
+      setErrors((prev) => ({ ...prev, hostname: '' }))
+    }
   }
 
   const handleContactChange = (index: number, value: string) => {
@@ -224,13 +206,11 @@ const CreateTopologyEndpoint = () => {
       },
     }
 
-    const editingEndpoint = latestEndpoints?.find(
-      (e) => e.id === endpointId,
-    ) as EndpointTopologyItem
-
     const payload = isEditMode
       ? [
-          ...(todayEndpoints ?? []).filter((e) => e.id !== endpointId),
+          ...(todayEndpoints ?? []).filter(
+            (e) => e.hostname !== editingEndpoint.hostname,
+          ),
           { ...editingEndpoint, ...updatedFields, date: today },
         ]
       : [
@@ -240,7 +220,7 @@ const CreateTopologyEndpoint = () => {
             group: 'DEFAULT',
             type: 'SERVICEGROUPS',
             ...updatedFields,
-          } as unknown as EndpointTopologyItem,
+          },
         ]
 
     createMutation.mutate(
@@ -252,7 +232,13 @@ const CreateTopologyEndpoint = () => {
               ? 'Topology endpoint updated successfully!'
               : 'Topology endpoint created successfully!',
           )
-          navigate(`/tenants/${tenantId}/topology`)
+          setTimeout(() => {
+            if (onClose) {
+              onClose()
+            } else {
+              navigate(`/tenants/${tenantId}/topology`)
+            }
+          }, 2000)
         },
         onError: (error) => {
           toast.error(
@@ -282,6 +268,7 @@ const CreateTopologyEndpoint = () => {
         navigateTo={{
           label: 'Back to Topology',
           to: `/tenants/${tenantId}/topology`,
+          onClick: onClose,
         }}
       />
 

--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
 import { useGetUserTenantById } from '@/hooks/useTenants'
@@ -23,6 +23,7 @@ import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import SelectDropdown from '@/components/SelectDropdown'
 import type { EndpointTopologyItem } from '@/types/topology'
+import CreateTopologyEndpoint from './CreateTopologyEndpoint'
 type SortColumn = 'service' | 'group' | 'monitored'
 type DateMode = 'latest' | 'custom'
 
@@ -31,7 +32,6 @@ const pageSize = 15
 const TenantTopology = () => {
   const { id } = useParams<{ id: string }>()
   const tenantId = id ?? ''
-  const navigate = useNavigate()
 
   const { data: tenantData } = useGetUserTenantById(tenantId)
 
@@ -41,7 +41,6 @@ const TenantTopology = () => {
   const [sortColumn, setSortColumn] = useState<SortColumn>('monitored')
   const [sortAsc, setSortAsc] = useState(false)
   const [dateMode, setDateMode] = useState<DateMode>('latest')
-  const [customDate, setCustomDate] = useState('')
   const [committedDate, setCommittedDate] = useState('')
   const dateInputRef = useRef<HTMLInputElement>(null)
   const [monitoredFilter, setMonitoredFilter] = useState<
@@ -49,6 +48,8 @@ const TenantTopology = () => {
   >('monitored')
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [endpointToDelete, setEndpointToDelete] =
+    useState<EndpointTopologyItem | null>(null)
+  const [endpointToEdit, setEndpointToEdit] =
     useState<EndpointTopologyItem | null>(null)
 
   const effectiveDate = dateMode === 'latest' ? '' : committedDate
@@ -58,6 +59,8 @@ const TenantTopology = () => {
     isLoading,
     error,
   } = useGetTopologyEndpoints(tenantId, effectiveDate)
+
+  const { data: latestEndpoints } = useGetTopologyEndpoints(tenantId, '')
 
   const deleteMutation = useCreateTopologyEndpointMutation()
 
@@ -115,10 +118,10 @@ const TenantTopology = () => {
     return () => input.removeEventListener('change', handleChange)
   }, [dateMode])
 
-  const latestDate = endpoints?.length
-    ? endpoints.reduce(
+  const latestDate = latestEndpoints?.length
+    ? latestEndpoints.reduce(
         (max, e) => (e.date > max ? e.date : max),
-        endpoints[0].date,
+        latestEndpoints[0].date,
       )
     : ''
 
@@ -129,14 +132,12 @@ const TenantTopology = () => {
   const handleDateModeChange = (mode: string) => {
     setDateMode(mode as DateMode)
     if (mode === 'custom') {
-      setCustomDate(latestDate)
+      if (dateInputRef.current) {
+        dateInputRef.current.value = latestDate
+      }
       setCommittedDate(latestDate)
     }
     setCurrentPage(1)
-  }
-
-  const handleCustomDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setCustomDate(e.target.value)
   }
 
   const handleSortChange = (column: SortColumn) => {
@@ -191,6 +192,16 @@ const TenantTopology = () => {
     currentPage * pageSize,
   )
 
+  if (endpointToEdit) {
+    return (
+      <CreateTopologyEndpoint
+        tenantId={tenantId}
+        editingEndpoint={endpointToEdit}
+        onClose={() => setEndpointToEdit(null)}
+      />
+    )
+  }
+
   return (
     <>
       <div className="page-container">
@@ -243,8 +254,7 @@ const TenantTopology = () => {
               <input
                 ref={dateInputRef}
                 type="date"
-                value={customDate}
-                onChange={handleCustomDateChange}
+                defaultValue={latestDate || undefined}
                 onClick={(e) => e.currentTarget.showPicker?.()}
                 className="text-sm"
               />
@@ -332,7 +342,7 @@ const TenantTopology = () => {
             ) : (
               paginated.map((endpoint) => (
                 <tr
-                  key={endpoint.id}
+                  key={`${endpoint.hostname}_${endpoint.service}`}
                   className="hover:bg-surface-muted transition-colors"
                 >
                   <td className={tdBase}>{endpoint.service}</td>
@@ -365,11 +375,7 @@ const TenantTopology = () => {
                             <PencilSquareIcon className="size-4 md:size-5" />
                           }
                           label="Edit"
-                          onClick={() =>
-                            navigate(
-                              `/tenants/${tenantId}/topology/edit/${endpoint.id}`,
-                            )
-                          }
+                          onClick={() => setEndpointToEdit(endpoint)}
                           className="text-muted hover:bg-surface-strong"
                         />
                         <IconButton

--- a/src/types/topology.ts
+++ b/src/types/topology.ts
@@ -6,7 +6,6 @@ export type TopologyNotifications = {
 }
 
 export type EndpointTopologyItem = {
-  id: string
   date: string
   group: string
   type: string


### PR DESCRIPTION
This PR refactors topology endpoint editing and simplifies the date filter logic in the topology list page.

- Refactored CreateTopologyEndpoint to support edit mode via props, removing the separate edit route
- Updated TenantTopology to render the edit form inline and control visibility with local state
- Updated Actions column visibility to depend on the selected date matching the latest date
- Updated PageHeader to support an onClick handler on the back navigation link