### PR TITLE
[ARGO-5484] - Add labels and groups to topology management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,11 @@ import ManageTenantMembers from './pages/manage-tenant-members'
 import MyInvitations from './pages/MyInvitations'
 import { InvitationReview } from './pages/InvitationReview'
 import { Status } from './pages/Status'
-import { TenantTopology, CreateTopologyEndpoint } from './pages/tenant-topology'
+import {
+  TenantTopology,
+  CreateTopologyEndpoint,
+  CreateTopologyGroup,
+} from './pages/tenant-topology'
 import { AuthProvider } from './auth/AuthProvider'
 import NotFound from './pages/NotFound'
 import { Toaster } from 'sonner'
@@ -197,6 +201,14 @@ function App() {
                   element={
                     <AuthProtected>
                       <TenantTopology />
+                    </AuthProtected>
+                  }
+                />
+                <Route
+                  path="tenants/:id/topology/groups/create"
+                  element={
+                    <AuthProtected>
+                      <CreateTopologyGroup />
                     </AuthProtected>
                   }
                 />

--- a/src/api/topology.ts
+++ b/src/api/topology.ts
@@ -1,5 +1,6 @@
 import type {
   EndpointTopologyItem,
+  GroupTopologyItem,
   ServiceType,
   CreateTopologyEndpointResponse,
 } from '@/types/topology'
@@ -39,6 +40,59 @@ export const fetchCreateTopologyEndpoints = async (
 ): Promise<CreateTopologyEndpointResponse> => {
   const response = await fetch(
     `${BACKEND_API}/v1/tenants/${tenantId}/topology/endpoints?force=${force}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(data),
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchTopologyGroups = async (
+  tenantId: string,
+  date: string,
+  token: string,
+): Promise<GroupTopologyItem[]> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/topology/groups${date ? `?date=${date}` : ''}`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchCreateTopologyGroups = async (
+  tenantId: string,
+  data: GroupTopologyItem[],
+  token: string,
+  force: boolean = true,
+): Promise<CreateTopologyEndpointResponse> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/topology/groups?force=${force}`,
     {
       method: 'POST',
       headers: {

--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -1,6 +1,9 @@
 import { useState, useRef, useEffect, useId } from 'react'
 import { createPortal } from 'react-dom'
-import { ChevronUpDownIcon } from '@heroicons/react/16/solid'
+import {
+  ChevronUpDownIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/16/solid'
 import type { KeyboardEvent } from 'react'
 
 export interface SelectOption {
@@ -14,6 +17,7 @@ interface SelectDropdownProps {
   options: SelectOption[]
   placeholder?: string
   disabled?: boolean
+  searchable?: boolean
   className?: string
 }
 
@@ -23,14 +27,24 @@ const SelectDropdown = ({
   options,
   placeholder = 'Select an option...',
   disabled = false,
+  searchable = false,
   className,
 }: SelectDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
   const [menuPos, setMenuPos] = useState({ top: 0, left: 0, width: 0 })
+  const [searchQuery, setSearchQuery] = useState('')
   const containerRef = useRef<HTMLDivElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const listboxId = useId()
+
+  const filteredOptions =
+    searchable && searchQuery
+      ? options.filter((option) =>
+          option.label.toLowerCase().includes(searchQuery.toLowerCase()),
+        )
+      : options
 
   useEffect(() => {
     if (!isOpen) return
@@ -39,19 +53,18 @@ const SelectDropdown = ({
         !containerRef.current?.contains(e.target as Node) &&
         !menuRef.current?.contains(e.target as Node)
       ) {
-        setIsOpen(false)
-        setActiveIndex(-1)
+        handleClose()
       }
     }
-    document.addEventListener('mousedown', handleMouseDown)
-    return () => document.removeEventListener('mousedown', handleMouseDown)
-  }, [isOpen])
 
-  useEffect(() => {
-    if (!isOpen) return
-    const handleResize = () => setIsOpen(false)
+    const handleResize = () => handleClose()
+
+    document.addEventListener('mousedown', handleMouseDown)
     window.addEventListener('resize', handleResize)
-    return () => window.removeEventListener('resize', handleResize)
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
+      window.removeEventListener('resize', handleResize)
+    }
   }, [isOpen])
 
   useEffect(() => {
@@ -61,55 +74,76 @@ const SelectDropdown = ({
       ?.scrollIntoView({ block: 'nearest' })
   }, [activeIndex, isOpen, listboxId])
 
-  const selectedLabel = options.find((o) => o.value === value)?.label
+  useEffect(() => {
+    if (isOpen && searchable) {
+      searchInputRef.current?.focus()
+    }
+  }, [isOpen, searchable])
+
+  const handleClose = () => {
+    setIsOpen(false)
+    setActiveIndex(-1)
+    setSearchQuery('')
+  }
+
+  const selectedLabel = options.find((option) => option.value === value)?.label
 
   const openMenu = () => {
     if (!containerRef.current) return
     const rect = containerRef.current.getBoundingClientRect()
     setMenuPos({ top: rect.bottom + 4, left: rect.left, width: rect.width })
-    setActiveIndex(options.findIndex((o) => o.value === value))
+    setActiveIndex(filteredOptions.findIndex((o) => o.value === value))
     setIsOpen(true)
   }
 
   const handleSelect = (optionValue: string) => {
     onChange(optionValue)
-    setIsOpen(false)
-    setActiveIndex(-1)
+    handleClose()
   }
 
   const handleToggle = () => {
     if (disabled) return
     if (isOpen) {
-      setIsOpen(false)
-      setActiveIndex(-1)
+      handleClose()
     } else {
       openMenu()
     }
   }
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (
+    e: KeyboardEvent<HTMLInputElement>,
+    allowSpace = false,
+  ) => {
     if (disabled) return
+    const selectOrOpen = () => {
+      if (isOpen && activeIndex >= 0) {
+        handleSelect(filteredOptions[activeIndex].value)
+      } else if (!isOpen) {
+        openMenu()
+      }
+    }
     switch (e.key) {
       case 'Enter':
-      case ' ':
         e.preventDefault()
-        if (isOpen && activeIndex >= 0) {
-          handleSelect(options[activeIndex].value)
-        } else {
-          handleToggle()
-        }
+        selectOrOpen()
+        break
+      case ' ':
+        if (!allowSpace) break
+        e.preventDefault()
+        selectOrOpen()
         break
       case 'Escape':
         e.preventDefault()
-        setIsOpen(false)
-        setActiveIndex(-1)
+        handleClose()
         break
       case 'ArrowDown':
         e.preventDefault()
         if (!isOpen) {
           openMenu()
         } else {
-          setActiveIndex((prev) => Math.min(prev + 1, options.length - 1))
+          setActiveIndex((prev) =>
+            Math.min(prev + 1, filteredOptions.length - 1),
+          )
         }
         break
       case 'ArrowUp':
@@ -137,7 +171,7 @@ const SelectDropdown = ({
         placeholder={placeholder}
         disabled={disabled}
         onClick={handleToggle}
-        onKeyDown={handleKeyDown}
+        onKeyDown={(e) => handleKeyDown(e, true)}
         className="w-full cursor-pointer pr-9 py-1.5"
       />
       <ChevronUpDownIcon className="absolute right-2.5 top-1/2 -translate-y-1/2 size-4 text-muted shrink-0 pointer-events-none" />
@@ -153,27 +187,47 @@ const SelectDropdown = ({
             }}
             className="fixed z-50 bg-white border border-line rounded-md shadow-lg overflow-hidden animate-fade-in"
           >
+            {searchable && (
+              <div className="flex items-center gap-2 px-3 py-2 border-b border-line">
+                <MagnifyingGlassIcon className="size-3.5 text-muted shrink-0" />
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Search..."
+                  className="flex-1 text-sm border-0 outline-none ring-0 focus:ring-0 bg-transparent p-0 placeholder:text-subtle"
+                />
+              </div>
+            )}
             <ul
               id={listboxId}
               className="max-h-60 overflow-y-auto"
               role="listbox"
             >
-              {options.map((option, index) => (
-                <li
-                  id={`${listboxId}-option-${index}`}
-                  key={option.value}
-                  role="option"
-                  aria-selected={option.value === value}
-                  onClick={() => handleSelect(option.value)}
-                  className={`px-4 py-1.5 mb-px last:mb-0 rounded-md text-sm cursor-pointer transition-colors ${
-                    option.value === value || index === activeIndex
-                      ? 'bg-brand-subtle text-brand font-medium'
-                      : 'text-foreground hover:bg-surface-muted'
-                  }`}
-                >
-                  {option.label}
+              {filteredOptions.length === 0 ? (
+                <li className="px-4 py-3 text-sm text-subtle italic text-center">
+                  No results found
                 </li>
-              ))}
+              ) : (
+                filteredOptions.map((option, index) => (
+                  <li
+                    id={`${listboxId}-option-${index}`}
+                    key={option.value}
+                    role="option"
+                    aria-selected={option.value === value}
+                    onClick={() => handleSelect(option.value)}
+                    className={`px-4 py-1.5 mb-px last:mb-0 rounded-md text-sm cursor-pointer transition-colors ${
+                      option.value === value || index === activeIndex
+                        ? 'bg-brand-subtle text-brand font-medium'
+                        : 'text-foreground hover:bg-surface-muted'
+                    }`}
+                  >
+                    {option.label}
+                  </li>
+                ))
+              )}
             </ul>
           </div>,
           document.body,

--- a/src/hooks/useTopology.ts
+++ b/src/hooks/useTopology.ts
@@ -3,10 +3,13 @@ import { useAuth } from '@/auth/useAuth'
 import {
   fetchTopologyEndpoints,
   fetchCreateTopologyEndpoints,
+  fetchTopologyGroups,
+  fetchCreateTopologyGroups,
   fetchTopologyServiceTypes,
 } from '@/api/topology'
 import type {
   EndpointTopologyItem,
+  GroupTopologyItem,
   ServiceType,
   CreateTopologyEndpointResponse,
 } from '@/types/topology'
@@ -45,6 +48,56 @@ export const useGetTopologyServiceTypes = (
     },
     retry: false,
     enabled: enabled && !!token && !!tenantId,
+  })
+}
+
+export const useGetTopologyGroups = (
+  tenantId: string,
+  date: string = '',
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+
+  return useQuery<GroupTopologyItem[], Error>({
+    queryKey: ['topology-groups', tenantId, date],
+    queryFn: () => {
+      if (!token) throw new Error('No authentication token available')
+      if (!tenantId) throw new Error('Tenant ID is required')
+      return fetchTopologyGroups(tenantId, date, token)
+    },
+    retry: false,
+    enabled: enabled && !!token && !!tenantId,
+  })
+}
+
+export const useCreateTopologyGroupsMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<
+    CreateTopologyEndpointResponse,
+    Error,
+    { tenantId: string; data: GroupTopologyItem[] }
+  >({
+    mutationFn: ({
+      tenantId,
+      data,
+    }: {
+      tenantId: string
+      data: GroupTopologyItem[]
+    }) => {
+      if (!token) throw new Error('No authentication token available')
+      if (!tenantId) throw new Error('Tenant ID is required')
+      return fetchCreateTopologyGroups(tenantId, data, token)
+    },
+    onSuccess: (_result, { tenantId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ['topology-groups', tenantId],
+      })
+    },
+    onError: (error) => {
+      console.error('Topology groups create error:', error)
+    },
   })
 }
 

--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -7,17 +7,20 @@ import {
 import { useGetUserTenantById } from '@/hooks/useTenants'
 import { useParams, useNavigate } from 'react-router-dom'
 import type { EndpointTopologyItem } from '@/types/topology'
-import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
 import { toast } from 'sonner'
+import NotificationsSection from './NotificationsSection'
+import GroupSelector from './GroupSelector'
+import KeyValueInput from './KeyValueInput'
+import type { Label } from './KeyValueInput'
+import type { Contact } from './NotificationsSection'
 import PageHeader from '@/components/PageHeader'
 import Button from '@/components/Button'
-import IconButton from '@/components/IconButton'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import SelectDropdown from '@/components/SelectDropdown'
 
 const sectionClass =
-  'grid grid-cols-1 md:grid-cols-[360px_1fr] gap-4 md:gap-8 mb-8 animate-fade-in'
+  'grid grid-cols-1 md:grid-cols-[360px_1fr] gap-4 md:gap-8 mb-7 animate-fade-in'
 const sectionContentClass =
   'bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-2'
 
@@ -25,15 +28,12 @@ const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const today = new Date().toISOString().split('T')[0]
 
-interface Contact {
-  id: string
-  value: string
-}
-
 interface FormData {
   service: string
   hostname: string
+  group: string
   monitored: boolean
+  labels: Label[]
   notificationsEnabled: boolean
   contacts: Contact[]
 }
@@ -41,6 +41,7 @@ interface FormData {
 interface FormErrors {
   service: string
   hostname: string
+  group: string
   contacts: string[]
 }
 
@@ -62,8 +63,8 @@ const CreateTopologyEndpoint = ({
 
   const { data: tenantData } = useGetUserTenantById(tenantId)
 
-  const { data: todayEndpoints, isLoading: isLoadingToday } =
-    useGetTopologyEndpoints(tenantId, today)
+  const { data: latestEndpoints, isLoading: isLoadingLatest } =
+    useGetTopologyEndpoints(tenantId, '')
 
   const {
     data: serviceTypes,
@@ -73,12 +74,18 @@ const CreateTopologyEndpoint = ({
 
   const createMutation = useCreateTopologyEndpointMutation()
 
+  const [isGroupSaving, setIsGroupSaving] = useState(false)
+
   const [formData, setFormData] = useState<FormData>(() => {
     if (editingEndpoint) {
       return {
         service: editingEndpoint.service,
         hostname: editingEndpoint.hostname,
+        group: editingEndpoint.group,
         monitored: editingEndpoint.tags?.monitored === '1',
+        labels: Object.entries(editingEndpoint.tags ?? {})
+          .filter(([key]) => key !== 'monitored')
+          .map(([key, value]) => ({ id: crypto.randomUUID(), key, value })),
         notificationsEnabled: editingEndpoint.notifications?.enabled ?? false,
         contacts: editingEndpoint.notifications?.contacts?.length
           ? editingEndpoint.notifications.contacts.map((email) => ({
@@ -91,7 +98,9 @@ const CreateTopologyEndpoint = ({
     return {
       service: '',
       hostname: '',
+      group: '',
       monitored: true,
+      labels: [],
       notificationsEnabled: false,
       contacts: [{ id: crypto.randomUUID(), value: '' }],
     }
@@ -100,6 +109,7 @@ const CreateTopologyEndpoint = ({
   const [errors, setErrors] = useState<FormErrors>({
     service: '',
     hostname: '',
+    group: '',
     contacts: [''],
   })
 
@@ -158,6 +168,7 @@ const CreateTopologyEndpoint = ({
     const newErrors: FormErrors = {
       service: '',
       hostname: '',
+      group: '',
       contacts: formData.contacts.map(() => ''),
     }
 
@@ -170,6 +181,11 @@ const CreateTopologyEndpoint = ({
 
     if (!formData.hostname.trim()) {
       newErrors.hostname = 'URL is required'
+      hasError = true
+    }
+
+    if (!formData.group) {
+      newErrors.group = 'Group is required'
       hasError = true
     }
 
@@ -197,7 +213,14 @@ const CreateTopologyEndpoint = ({
     const updatedFields = {
       service: formData.service,
       hostname: formData.hostname.trim(),
-      tags: { monitored: formData.monitored ? '1' : '0' },
+      tags: {
+        monitored: formData.monitored ? '1' : '0',
+        ...Object.fromEntries(
+          formData.labels
+            .filter((label) => label.key.trim())
+            .map((label) => [label.key.trim(), label.value.trim()]),
+        ),
+      },
       notifications: {
         enabled: formData.notificationsEnabled,
         contacts: formData.contacts
@@ -208,16 +231,21 @@ const CreateTopologyEndpoint = ({
 
     const payload = isEditMode
       ? [
-          ...(todayEndpoints ?? []).filter(
+          ...(latestEndpoints ?? []).filter(
             (e) => e.hostname !== editingEndpoint.hostname,
           ),
-          { ...editingEndpoint, ...updatedFields, date: today },
+          {
+            ...editingEndpoint,
+            ...updatedFields,
+            group: formData.group,
+            date: today,
+          },
         ]
       : [
-          ...(todayEndpoints ?? []),
+          ...(latestEndpoints ?? []),
           {
             date: today,
-            group: 'DEFAULT',
+            group: formData.group,
             type: 'SERVICEGROUPS',
             ...updatedFields,
           },
@@ -236,7 +264,7 @@ const CreateTopologyEndpoint = ({
             if (onClose) {
               onClose()
             } else {
-              navigate(`/tenants/${tenantId}/topology`)
+              navigate(`/tenants/${tenantId}/topology#endpoints`)
             }
           }, 2000)
         },
@@ -267,7 +295,7 @@ const CreateTopologyEndpoint = ({
         }
         navigateTo={{
           label: 'Back to Topology',
-          to: `/tenants/${tenantId}/topology`,
+          to: `/tenants/${tenantId}/topology#endpoints`,
           onClick: onClose,
         }}
       />
@@ -277,7 +305,9 @@ const CreateTopologyEndpoint = ({
           variant="primary"
           size="md"
           onClick={handleSubmit}
-          disabled={createMutation.isPending || isLoadingToday}
+          disabled={
+            createMutation.isPending || isLoadingLatest || isGroupSaving
+          }
         >
           {createMutation.isPending ? (
             <>
@@ -296,7 +326,7 @@ const CreateTopologyEndpoint = ({
       <div className={sectionClass}>
         <div>
           <p className="section-title">Endpoint Details</p>
-          <p className="section-description mt-1">
+          <p className="section-description">
             Select the service type and provide the endpoint URL
           </p>
         </div>
@@ -365,11 +395,32 @@ const CreateTopologyEndpoint = ({
         </div>
       </div>
 
+      {/* Group */}
+      <div className={sectionClass}>
+        <div>
+          <p className="section-title">Group</p>
+          <p className="section-description">Assign this endpoint to a group</p>
+        </div>
+        <div className={sectionContentClass}>
+          <GroupSelector
+            tenantId={tenantId}
+            tenantName={tenantData?.info.name ?? ''}
+            value={formData.group}
+            onChange={(value) => {
+              setFormData((prev) => ({ ...prev, group: value }))
+              if (value) setErrors((prev) => ({ ...prev, group: '' }))
+            }}
+            error={errors.group}
+            onGroupSaving={setIsGroupSaving}
+          />
+        </div>
+      </div>
+
       {/* Monitoring */}
       <div className={sectionClass}>
         <div>
           <p className="section-title">Monitoring</p>
-          <p className="section-description mt-1">
+          <p className="section-description">
             Configure whether this endpoint is monitored
           </p>
         </div>
@@ -394,83 +445,35 @@ const CreateTopologyEndpoint = ({
 
       {/* Notifications */}
       <div className={sectionClass}>
+        <NotificationsSection
+          subtitle="endpoint"
+          enabled={formData.notificationsEnabled}
+          onEnabledChange={(v) =>
+            setFormData((prev) => ({ ...prev, notificationsEnabled: v }))
+          }
+          contacts={formData.contacts}
+          contactErrors={errors.contacts}
+          onContactChange={handleContactChange}
+          onAddContact={handleAddContact}
+          onRemoveContact={handleRemoveContact}
+        />
+      </div>
+
+      {/* Labels */}
+      <div className={sectionClass}>
         <div>
-          <p className="section-title">Notifications</p>
-          <p className="section-description mt-1">
-            Enable email notifications for this endpoint
+          <p className="section-title">Labels</p>
+          <p className="section-description">
+            Add custom key-value metadata to this endpoint
           </p>
         </div>
         <div className={sectionContentClass}>
-          <label className="flex items-center gap-3 cursor-pointer">
-            <input
-              type="checkbox"
-              className="toggle toggle-brand"
-              checked={formData.notificationsEnabled}
-              onChange={() =>
-                setFormData((prev) => ({
-                  ...prev,
-                  notificationsEnabled: !prev.notificationsEnabled,
-                }))
-              }
-            />
-            <div>
-              <p className="text-sm font-semibold text-body">
-                {formData.notificationsEnabled
-                  ? 'Notifications enabled'
-                  : 'Notifications disabled'}
-              </p>
-            </div>
-          </label>
-
-          {formData.notificationsEnabled && (
-            <div className="flex flex-col gap-2 mt-1 animate-fade-in">
-              <p className="text-sm font-medium text-body">
-                Contact Emails <span className="required">*</span>
-              </p>
-              {formData.contacts.map((contact, index) => (
-                <div key={contact.id} className="flex items-start gap-1">
-                  <div className="flex flex-col flex-1">
-                    <input
-                      type="email"
-                      value={contact.value}
-                      onChange={(e) =>
-                        handleContactChange(index, e.target.value)
-                      }
-                      placeholder="Enter contact email"
-                      className={
-                        errors.contacts[index]
-                          ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
-                          : ''
-                      }
-                    />
-                    {errors.contacts[index] && (
-                      <span className="text-xs text-red-500 mt-1">
-                        {errors.contacts[index]}
-                      </span>
-                    )}
-                  </div>
-                  {formData.contacts.length > 1 && (
-                    <div className="mt-1">
-                      <IconButton
-                        icon={<TrashIcon className="size-4.5" />}
-                        label="Remove contact"
-                        onClick={() => handleRemoveContact(index)}
-                        className="text-red-600 hover:bg-red-50"
-                      />
-                    </div>
-                  )}
-                </div>
-              ))}
-              <button
-                type="button"
-                onClick={handleAddContact}
-                className="flex items-center gap-1.5 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer"
-              >
-                <PlusIcon className="size-4" />
-                Add another email
-              </button>
-            </div>
-          )}
+          <KeyValueInput
+            labels={formData.labels}
+            onLabelsChange={(labels) =>
+              setFormData((prev) => ({ ...prev, labels }))
+            }
+          />
         </div>
       </div>
     </div>

--- a/src/pages/tenant-topology/CreateTopologyGroup.tsx
+++ b/src/pages/tenant-topology/CreateTopologyGroup.tsx
@@ -1,0 +1,336 @@
+import { useState, useRef, useEffect } from 'react'
+import { useGetUserTenantById } from '@/hooks/useTenants'
+import {
+  useGetTopologyGroups,
+  useCreateTopologyGroupsMutation,
+} from '@/hooks/useTopology'
+import { useParams, useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+import PageHeader from '@/components/PageHeader'
+import Button from '@/components/Button'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import NotificationsSection from './NotificationsSection'
+import type { Contact } from './NotificationsSection'
+import type { GroupTopologyItem } from '@/types/topology'
+
+const sectionClass =
+  'grid grid-cols-1 md:grid-cols-[360px_1fr] gap-4 md:gap-8 mb-8 animate-fade-in'
+const sectionContentClass =
+  'bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-2'
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const today = new Date().toISOString().split('T')[0]
+
+interface FormData {
+  subgroup: string
+  notificationsEnabled: boolean
+  contacts: Contact[]
+}
+
+interface FormErrors {
+  subgroup: string
+  contacts: string[]
+}
+
+interface CreateTopologyGroupProps {
+  tenantId?: string
+  editingGroup?: GroupTopologyItem
+  onClose?: () => void
+}
+
+const CreateTopologyGroup = ({
+  tenantId: tenantIdProp,
+  editingGroup,
+  onClose,
+}: CreateTopologyGroupProps = {}) => {
+  const { id: tenantIdParam } = useParams<{ id?: string }>()
+  const tenantId = tenantIdProp ?? tenantIdParam ?? ''
+  const isEditMode = !!editingGroup
+  const navigate = useNavigate()
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const { data: tenantData } = useGetUserTenantById(tenantId)
+
+  const { data: latestGroups, isLoading: isLoadingLatest } =
+    useGetTopologyGroups(tenantId, '')
+
+  const groupsMutation = useCreateTopologyGroupsMutation()
+
+  const [formData, setFormData] = useState<FormData>(() => {
+    if (editingGroup) {
+      return {
+        subgroup: editingGroup.subgroup,
+        notificationsEnabled: editingGroup.notifications?.enabled ?? false,
+        contacts: editingGroup.notifications?.contacts?.length
+          ? editingGroup.notifications.contacts.map((email) => ({
+              id: crypto.randomUUID(),
+              value: email,
+            }))
+          : [{ id: crypto.randomUUID(), value: '' }],
+      }
+    }
+    return {
+      subgroup: '',
+      notificationsEnabled: false,
+      contacts: [{ id: crypto.randomUUID(), value: '' }],
+    }
+  })
+
+  const [errors, setErrors] = useState<FormErrors>({
+    subgroup: '',
+    contacts: [''],
+  })
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [])
+
+  const handleSubgroupChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target
+    setFormData((prev) => ({ ...prev, subgroup: value }))
+    if (value.trim()) {
+      setErrors((prev) => ({ ...prev, subgroup: '' }))
+    }
+  }
+
+  const handleContactChange = (index: number, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      contacts: prev.contacts.map((c, i) =>
+        i === index ? { ...c, value } : c,
+      ),
+    }))
+
+    const updatedErrors = [...errors.contacts]
+    if (!value.trim() || emailRegex.test(value)) {
+      updatedErrors[index] = ''
+    } else {
+      updatedErrors[index] = 'Invalid email'
+    }
+    setErrors((prev) => ({ ...prev, contacts: updatedErrors }))
+  }
+
+  const handleAddContact = () => {
+    setFormData((prev) => ({
+      ...prev,
+      contacts: [...prev.contacts, { id: crypto.randomUUID(), value: '' }],
+    }))
+    setErrors((prev) => ({ ...prev, contacts: [...prev.contacts, ''] }))
+  }
+
+  const handleRemoveContact = (index: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      contacts: prev.contacts.filter((_, i) => i !== index),
+    }))
+    setErrors((prev) => ({
+      ...prev,
+      contacts: prev.contacts.filter((_, i) => i !== index),
+    }))
+  }
+
+  const handleSubmit = () => {
+    const newErrors: FormErrors = {
+      subgroup: '',
+      contacts: formData.contacts.map(() => ''),
+    }
+
+    let hasError = false
+
+    if (!formData.subgroup.trim()) {
+      newErrors.subgroup = 'Subgroup is required'
+      hasError = true
+    }
+
+    if (formData.notificationsEnabled) {
+      const hasValidContact = formData.contacts.some(
+        (c) => c.value.trim() && emailRegex.test(c.value),
+      )
+      if (!hasValidContact) {
+        newErrors.contacts[0] = 'At least one valid email is required'
+        hasError = true
+      }
+      formData.contacts.forEach((c, i) => {
+        if (c.value.trim() && !emailRegex.test(c.value)) {
+          newErrors.contacts[i] = 'Invalid email'
+          hasError = true
+        }
+      })
+    }
+
+    if (hasError) {
+      setErrors(newErrors)
+      return
+    }
+
+    const notifications = {
+      enabled: formData.notificationsEnabled,
+      contacts: formData.contacts
+        .filter((c) => c.value.trim() && emailRegex.test(c.value))
+        .map((c) => c.value),
+    }
+
+    const payload = isEditMode
+      ? [
+          ...(latestGroups ?? []).filter(
+            (g) => g.subgroup !== editingGroup.subgroup,
+          ),
+          {
+            ...editingGroup,
+            subgroup: formData.subgroup,
+            notifications,
+            date: today,
+          },
+        ]
+      : [
+          ...(latestGroups ?? []),
+          {
+            date: today,
+            group: tenantData?.info.name ?? '',
+            type: 'PROJECT',
+            subgroup: formData.subgroup,
+            notifications,
+          },
+        ]
+
+    groupsMutation.mutate(
+      { tenantId, data: payload },
+      {
+        onSuccess: () => {
+          toast.success(
+            isEditMode
+              ? 'Topology group updated successfully!'
+              : 'Topology group created successfully!',
+          )
+          timerRef.current = setTimeout(() => {
+            if (onClose) {
+              onClose()
+            } else {
+              navigate(`/tenants/${tenantId}/topology#groups`)
+            }
+          }, 2000)
+        },
+        onError: (error) => {
+          toast.error(
+            `Failed to ${isEditMode ? 'update' : 'create'} topology group: ${error.message}`,
+          )
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        title={isEditMode ? 'Edit Topology Group' : 'Add Topology Group'}
+        subtitle={
+          <>
+            {isEditMode
+              ? 'Update the topology group for tenant '
+              : 'Configure and register a new topology group for tenant '}
+            <strong>{tenantData?.info.name ?? '...'}</strong>
+          </>
+        }
+        navigateTo={{
+          label: 'Back to Topology',
+          to: `/tenants/${tenantId}/topology#groups`,
+          onClick: onClose,
+        }}
+      />
+
+      <div className="flex justify-end items-center mb-4">
+        <Button
+          variant="primary"
+          size="md"
+          onClick={handleSubmit}
+          disabled={groupsMutation.isPending || isLoadingLatest || !tenantData}
+        >
+          {groupsMutation.isPending ? (
+            <>
+              <LoadingSpinner size="xs" />
+              Saving...
+            </>
+          ) : isEditMode ? (
+            'Update Group'
+          ) : (
+            'Add Group'
+          )}
+        </Button>
+      </div>
+
+      {/* Group details */}
+      <div className={sectionClass}>
+        <div>
+          <p className="section-title">Group Details</p>
+          <p className="section-description">
+            Define the group and subgroup for this topology entry
+          </p>
+        </div>
+        <div className={sectionContentClass}>
+          <div className="flex flex-col">
+            <label className="text-sm font-medium text-body mb-1.5">
+              Group
+            </label>
+            <input
+              type="text"
+              value={tenantData?.info.name ?? ''}
+              disabled
+              readOnly
+            />
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm font-medium text-body mb-1.5">Type</label>
+            <input type="text" value="PROJECT" disabled readOnly />
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm font-medium text-body mb-1.5">
+              Subgroup <span className="required">*</span>
+            </label>
+            <input
+              type="text"
+              name="subgroup"
+              value={formData.subgroup}
+              onChange={handleSubgroupChange}
+              placeholder="Enter subgroup name"
+              className={
+                errors.subgroup
+                  ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
+                  : ''
+              }
+            />
+            {errors.subgroup && (
+              <span className="text-xs text-red-500 mt-1">
+                {errors.subgroup}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Notifications */}
+      <div className={sectionClass}>
+        <NotificationsSection
+          subtitle="group"
+          enabled={formData.notificationsEnabled}
+          onEnabledChange={(v) =>
+            setFormData((prev) => ({ ...prev, notificationsEnabled: v }))
+          }
+          contacts={formData.contacts}
+          contactErrors={errors.contacts}
+          onContactChange={handleContactChange}
+          onAddContact={handleAddContact}
+          onRemoveContact={handleRemoveContact}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default CreateTopologyGroup

--- a/src/pages/tenant-topology/GroupSelector.tsx
+++ b/src/pages/tenant-topology/GroupSelector.tsx
@@ -1,0 +1,321 @@
+import { useState } from 'react'
+import {
+  useGetTopologyGroups,
+  useCreateTopologyGroupsMutation,
+} from '@/hooks/useTopology'
+import {
+  PlusIcon,
+  TrashIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from '@heroicons/react/16/solid'
+import { toast } from 'sonner'
+import Button from '@/components/Button'
+import IconButton from '@/components/IconButton'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import SelectDropdown from '@/components/SelectDropdown'
+import type { Contact } from './NotificationsSection'
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const today = new Date().toISOString().split('T')[0]
+
+interface GroupSelectorProps {
+  tenantId: string
+  tenantName: string
+  value: string
+  onChange: (value: string) => void
+  error?: string
+  onGroupSaving?: (busy: boolean) => void
+}
+
+const GroupSelector = ({
+  tenantId,
+  tenantName,
+  value,
+  onChange,
+  error,
+  onGroupSaving,
+}: GroupSelectorProps) => {
+  const { data: groups, isLoading: isLoadingGroups } =
+    useGetTopologyGroups(tenantId)
+  const groupsMutation = useCreateTopologyGroupsMutation()
+
+  const [showCreateGroup, setShowCreateGroup] = useState(false)
+  const [newGroupSubgroup, setNewGroupSubgroup] = useState('')
+  const [newGroupSubgroupError, setNewGroupSubgroupError] = useState('')
+  const [newGroupNotificationsEnabled, setNewGroupNotificationsEnabled] =
+    useState(false)
+  const [newGroupContacts, setNewGroupContacts] = useState<Contact[]>([
+    { id: crypto.randomUUID(), value: '' },
+  ])
+  const [newGroupContactErrors, setNewGroupContactErrors] = useState<string[]>([
+    '',
+  ])
+
+  const resetCreateGroup = () => {
+    setShowCreateGroup(false)
+    setNewGroupSubgroup('')
+    setNewGroupSubgroupError('')
+    setNewGroupNotificationsEnabled(false)
+    setNewGroupContacts([{ id: crypto.randomUUID(), value: '' }])
+    setNewGroupContactErrors([''])
+  }
+
+  const handleContactChange = (index: number, val: string) => {
+    setNewGroupContacts((prev) =>
+      prev.map((c, i) => (i === index ? { ...c, value: val } : c)),
+    )
+    const updated = [...newGroupContactErrors]
+    updated[index] = !val.trim() || emailRegex.test(val) ? '' : 'Invalid email'
+    setNewGroupContactErrors(updated)
+  }
+
+  const handleCreateGroupSubmit = () => {
+    if (!newGroupSubgroup.trim()) {
+      setNewGroupSubgroupError('Subgroup is required')
+      return
+    }
+
+    if (newGroupNotificationsEnabled) {
+      const nextContactErrors: string[] = newGroupContacts.map((contact) => {
+        if (!contact.value.trim()) {
+          return ''
+        }
+
+        return emailRegex.test(contact.value) ? '' : 'Invalid email'
+      })
+
+      const hasValidContact = newGroupContacts.some(
+        (contact) => contact.value.trim() && emailRegex.test(contact.value),
+      )
+      if (!hasValidContact) {
+        nextContactErrors[0] = 'At least one valid email is required'
+      }
+
+      setNewGroupContactErrors(nextContactErrors)
+
+      const hasContactError = nextContactErrors.some((error) => !!error)
+      if (hasContactError) {
+        return
+      }
+    }
+
+    const notifications = {
+      enabled: newGroupNotificationsEnabled,
+      contacts: newGroupNotificationsEnabled
+        ? newGroupContacts
+            .filter((c) => c.value.trim() && emailRegex.test(c.value))
+            .map((c) => c.value)
+        : [],
+    }
+    const payload = [
+      ...(groups ?? []),
+      {
+        date: today,
+        group: tenantName,
+        type: 'PROJECT',
+        subgroup: newGroupSubgroup.trim(),
+        notifications,
+      },
+    ]
+    onGroupSaving?.(true)
+    groupsMutation.mutate(
+      { tenantId, data: payload },
+      {
+        onSuccess: () => {
+          toast.success('Group created successfully!')
+          onChange(newGroupSubgroup.trim())
+          resetCreateGroup()
+          onGroupSaving?.(false)
+        },
+        onError: (err) => {
+          toast.error(`Failed to create group: ${err.message}`)
+          onGroupSaving?.(false)
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="flex flex-col">
+      <label className="text-sm font-medium text-body mb-1.5">
+        Group <span className="required">*</span>
+      </label>
+
+      {isLoadingGroups ? (
+        <div className="flex items-center gap-2 text-sm text-muted py-2">
+          <LoadingSpinner size="xs" />
+          Loading groups...
+        </div>
+      ) : (
+        <SelectDropdown
+          value={value}
+          onChange={onChange}
+          options={(groups ?? []).map((g) => ({
+            value: g.subgroup,
+            label: g.subgroup,
+          }))}
+          placeholder={groups?.length ? 'Select a group...' : 'No groups yet'}
+          disabled={!groups?.length}
+          searchable
+        />
+      )}
+
+      {error && <span className="text-xs text-red-500 mt-1">{error}</span>}
+
+      <button
+        type="button"
+        onClick={() =>
+          showCreateGroup ? resetCreateGroup() : setShowCreateGroup(true)
+        }
+        className="flex items-center gap-1 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer mt-2"
+      >
+        {showCreateGroup ? (
+          <>
+            <ChevronUpIcon className="size-4" />
+            Cancel new group
+          </>
+        ) : (
+          <>
+            <ChevronDownIcon className="size-4" />
+            Create new group
+          </>
+        )}
+      </button>
+
+      {showCreateGroup && (
+        <div className="border border-line rounded-lg px-4 py-3 flex flex-col gap-3 mt-1 animate-fade-in">
+          <div className="flex flex-col">
+            <label className="text-sm font-medium text-body mb-1.5">
+              Subgroup <span className="required">*</span>
+            </label>
+            <input
+              type="text"
+              value={newGroupSubgroup}
+              onChange={(e) => {
+                setNewGroupSubgroup(e.target.value)
+                if (e.target.value.trim()) setNewGroupSubgroupError('')
+              }}
+              placeholder="Enter subgroup name"
+              className={
+                newGroupSubgroupError
+                  ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
+                  : ''
+              }
+            />
+            {newGroupSubgroupError && (
+              <span className="text-xs text-red-500 mt-1">
+                {newGroupSubgroupError}
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="flex items-center gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                className="toggle toggle-brand"
+                checked={newGroupNotificationsEnabled}
+                onChange={() =>
+                  setNewGroupNotificationsEnabled((prev) => !prev)
+                }
+              />
+              <p className="text-sm font-semibold text-body">
+                {newGroupNotificationsEnabled
+                  ? 'Notifications enabled'
+                  : 'Notifications disabled'}
+              </p>
+            </label>
+
+            {newGroupNotificationsEnabled && (
+              <div className="flex flex-col gap-2 animate-fade-in">
+                <p className="text-sm font-medium text-body">
+                  Contact Emails <span className="required">*</span>
+                </p>
+                {newGroupContacts.map((contact, index) => (
+                  <div key={contact.id} className="flex items-start gap-1">
+                    <div className="flex flex-col flex-1">
+                      <input
+                        type="email"
+                        value={contact.value}
+                        onChange={(e) =>
+                          handleContactChange(index, e.target.value)
+                        }
+                        placeholder="Enter contact email"
+                        className={
+                          newGroupContactErrors[index]
+                            ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
+                            : ''
+                        }
+                      />
+                      {newGroupContactErrors[index] && (
+                        <span className="text-xs text-red-500 mt-1">
+                          {newGroupContactErrors[index]}
+                        </span>
+                      )}
+                    </div>
+                    {newGroupContacts.length > 1 && (
+                      <div className="mt-1">
+                        <IconButton
+                          icon={<TrashIcon className="size-4.5" />}
+                          label="Remove contact"
+                          onClick={() =>
+                            setNewGroupContacts((prev) =>
+                              prev.filter((_, i) => i !== index),
+                            )
+                          }
+                          className="text-red-600 hover:bg-red-50"
+                        />
+                      </div>
+                    )}
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setNewGroupContacts((prev) => [
+                      ...prev,
+                      { id: crypto.randomUUID(), value: '' },
+                    ])
+                    setNewGroupContactErrors((prev) => [...prev, ''])
+                  }}
+                  className="flex items-center gap-1.5 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer"
+                >
+                  <PlusIcon className="size-4" />
+                  Add another email
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleCreateGroupSubmit}
+              disabled={groupsMutation.isPending}
+            >
+              {groupsMutation.isPending ? (
+                <>
+                  <LoadingSpinner size="xs" />
+                  Creating...
+                </>
+              ) : (
+                'Create Group'
+              )}
+            </Button>
+            <button
+              type="button"
+              onClick={resetCreateGroup}
+              className="text-sm text-muted hover:text-body transition-colors cursor-pointer"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default GroupSelector

--- a/src/pages/tenant-topology/KeyValueInput.tsx
+++ b/src/pages/tenant-topology/KeyValueInput.tsx
@@ -1,0 +1,78 @@
+import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
+import IconButton from '@/components/IconButton'
+
+export interface Label {
+  id: string
+  key: string
+  value: string
+}
+
+interface KeyValueInputProps {
+  labels: Label[]
+  onLabelsChange: (labels: Label[]) => void
+}
+
+const KeyValueInput = ({ labels, onLabelsChange }: KeyValueInputProps) => {
+  const handleAdd = () => {
+    onLabelsChange([...labels, { id: crypto.randomUUID(), key: '', value: '' }])
+  }
+
+  const handleChange = (
+    index: number,
+    field: 'key' | 'value',
+    value: string,
+  ) => {
+    onLabelsChange(
+      labels.map((label, i) =>
+        i === index ? { ...label, [field]: value } : label,
+      ),
+    )
+  }
+
+  const handleRemove = (index: number) => {
+    onLabelsChange(labels.filter((_, i) => i !== index))
+  }
+
+  return (
+    <>
+      {labels.length === 0 && (
+        <p className="text-sm text-subtle italic">No labels added</p>
+      )}
+      {labels.map((label, index) => (
+        <div key={label.id} className="flex items-center gap-2">
+          <input
+            type="text"
+            value={label.key}
+            onChange={(e) => handleChange(index, 'key', e.target.value)}
+            placeholder="Key"
+            className="flex-1"
+          />
+          <span className="text-muted text-sm shrink-0">→</span>
+          <input
+            type="text"
+            value={label.value}
+            onChange={(e) => handleChange(index, 'value', e.target.value)}
+            placeholder="Value"
+            className="flex-1"
+          />
+          <IconButton
+            icon={<TrashIcon className="size-4.5" />}
+            label="Remove label"
+            onClick={() => handleRemove(index)}
+            className="text-red-600 hover:bg-red-50 shrink-0"
+          />
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="flex items-center gap-1.5 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer mt-1"
+      >
+        <PlusIcon className="size-4" />
+        Add label
+      </button>
+    </>
+  )
+}
+
+export default KeyValueInput

--- a/src/pages/tenant-topology/NotificationsSection.tsx
+++ b/src/pages/tenant-topology/NotificationsSection.tsx
@@ -1,0 +1,105 @@
+import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
+import IconButton from '@/components/IconButton'
+
+export interface Contact {
+  id: string
+  value: string
+}
+
+interface NotificationsSectionProps {
+  subtitle?: string
+  enabled: boolean
+  onEnabledChange: (enabled: boolean) => void
+  contacts: Contact[]
+  contactErrors: string[]
+  onContactChange: (index: number, value: string) => void
+  onAddContact: () => void
+  onRemoveContact: (index: number) => void
+}
+
+const NotificationsSection = ({
+  subtitle = 'endpoint',
+  enabled,
+  onEnabledChange,
+  contacts,
+  contactErrors,
+  onContactChange,
+  onAddContact,
+  onRemoveContact,
+}: NotificationsSectionProps) => {
+  return (
+    <>
+      <div>
+        <p className="section-title">Notifications</p>
+        <p className="section-description">
+          Enable email notifications for this {subtitle}
+        </p>
+      </div>
+      <div className="bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-2">
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            className="toggle toggle-brand"
+            checked={enabled}
+            onChange={() => onEnabledChange(!enabled)}
+          />
+          <div>
+            <p className="text-sm font-semibold text-body">
+              {enabled ? 'Notifications enabled' : 'Notifications disabled'}
+            </p>
+          </div>
+        </label>
+
+        {enabled && (
+          <div className="flex flex-col gap-2 mt-1 animate-fade-in">
+            <p className="text-sm font-medium text-body">
+              Contact Emails <span className="required">*</span>
+            </p>
+            {contacts.map((contact, index) => (
+              <div key={contact.id} className="flex items-start gap-1">
+                <div className="flex flex-col flex-1">
+                  <input
+                    type="email"
+                    value={contact.value}
+                    onChange={(e) => onContactChange(index, e.target.value)}
+                    placeholder="Enter contact email"
+                    className={
+                      contactErrors[index]
+                        ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
+                        : ''
+                    }
+                  />
+                  {contactErrors[index] && (
+                    <span className="text-xs text-red-500 mt-1">
+                      {contactErrors[index]}
+                    </span>
+                  )}
+                </div>
+                {contacts.length > 1 && (
+                  <div className="mt-1">
+                    <IconButton
+                      icon={<TrashIcon className="size-4.5" />}
+                      label="Remove contact"
+                      onClick={() => onRemoveContact(index)}
+                      className="text-red-600 hover:bg-red-50"
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={onAddContact}
+              className="flex items-center gap-1.5 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer"
+            >
+              <PlusIcon className="size-4" />
+              Add another email
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+export default NotificationsSection

--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -1,33 +1,18 @@
-import { useState, useEffect, useRef } from 'react'
-import { useParams } from 'react-router-dom'
-import { toast } from 'sonner'
-import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
+import { useState, useEffect } from 'react'
+import { useParams, useLocation } from 'react-router-dom'
 import { useGetUserTenantById } from '@/hooks/useTenants'
-import {
-  useGetTopologyEndpoints,
-  useCreateTopologyEndpointMutation,
-} from '@/hooks/useTopology'
 import PageHeader from '@/components/PageHeader'
-import Button from '@/components/Button'
-import IconButton from '@/components/IconButton'
-import ConfirmDialog from '@/components/ConfirmDialog'
-import SearchInput from '@/components/SearchInput'
-import Pagination from '@/components/Pagination'
-import DataTable, {
-  thBase,
-  tdBase,
-  SortableColumnHeader,
-} from '@/components/DataTable'
-import Badge from '@/components/Badge'
-import LoadingSpinner from '@/components/LoadingSpinner'
-import ErrorDisplay from '@/components/ErrorDisplay'
-import SelectDropdown from '@/components/SelectDropdown'
-import type { EndpointTopologyItem } from '@/types/topology'
+import Tabs from '@/components/Tabs'
+import TopologyEndpoints from './TopologyEndpoints'
+import TopologyGroups from './TopologyGroups'
 import CreateTopologyEndpoint from './CreateTopologyEndpoint'
-type SortColumn = 'service' | 'group' | 'monitored'
-type DateMode = 'latest' | 'custom'
+import CreateTopologyGroup from './CreateTopologyGroup'
+import type { EndpointTopologyItem, GroupTopologyItem } from '@/types/topology'
 
-const pageSize = 15
+const tabs = [
+  { id: 'endpoints', label: 'Endpoints' },
+  { id: 'groups', label: 'Groups' },
+]
 
 const TenantTopology = () => {
   const { id } = useParams<{ id: string }>()
@@ -35,395 +20,76 @@ const TenantTopology = () => {
 
   const { data: tenantData } = useGetUserTenantById(tenantId)
 
-  const [searchInput, setSearchInput] = useState('')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [currentPage, setCurrentPage] = useState(1)
-  const [sortColumn, setSortColumn] = useState<SortColumn>('monitored')
-  const [sortAsc, setSortAsc] = useState(false)
-  const [dateMode, setDateMode] = useState<DateMode>('latest')
-  const [committedDate, setCommittedDate] = useState('')
-  const dateInputRef = useRef<HTMLInputElement>(null)
-  const [monitoredFilter, setMonitoredFilter] = useState<
-    'monitored' | 'not_monitored'
-  >('monitored')
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [endpointToDelete, setEndpointToDelete] =
-    useState<EndpointTopologyItem | null>(null)
-  const [endpointToEdit, setEndpointToEdit] =
-    useState<EndpointTopologyItem | null>(null)
-
-  const effectiveDate = dateMode === 'latest' ? '' : committedDate
-
-  const {
-    data: endpoints,
-    isLoading,
-    error,
-  } = useGetTopologyEndpoints(tenantId, effectiveDate)
-
-  const { data: latestEndpoints } = useGetTopologyEndpoints(tenantId, '')
-
-  const deleteMutation = useCreateTopologyEndpointMutation()
-
-  const handleDeleteClick = (endpoint: EndpointTopologyItem) => {
-    setEndpointToDelete(endpoint)
-    setDeleteDialogOpen(true)
-  }
-
-  const handleDeleteConfirm = () => {
-    if (!endpointToDelete) return
-
-    const updatedEndpoints = (endpoints ?? []).filter(
-      (endpoint) => endpoint.hostname !== endpointToDelete.hostname,
-    )
-
-    deleteMutation.mutate(
-      { tenantId, data: updatedEndpoints },
-      {
-        onSuccess: () => {
-          toast.success('Topology endpoint deleted successfully!')
-          setDeleteDialogOpen(false)
-          setEndpointToDelete(null)
-          if (paginated.length === 1 && currentPage > 1) {
-            setCurrentPage((prev) => prev - 1)
-          }
-        },
-        onError: (error) => {
-          toast.error(`Failed to delete endpoint: ${error.message}`)
-        },
-      },
-    )
-  }
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setSearchQuery(searchInput)
-      setCurrentPage(1)
-    }, 500)
-    return () => clearTimeout(timer)
-  }, [searchInput])
-
-  /* Use native DOM `change` (not React's onChange) so the API is called only when the user picks a full date, not on every arrow-key increment in the date input. */
-  useEffect(() => {
-    const input = dateInputRef.current
-    if (!input) return
-
-    const handleChange = (e: Event) => {
-      const value = (e.target as HTMLInputElement).value
-      setCommittedDate(value)
-      setCurrentPage(1)
-    }
-
-    input.addEventListener('change', handleChange)
-
-    return () => input.removeEventListener('change', handleChange)
-  }, [dateMode])
-
-  const latestDate = latestEndpoints?.length
-    ? latestEndpoints.reduce(
-        (max, e) => (e.date > max ? e.date : max),
-        latestEndpoints[0].date,
-      )
-    : ''
-
-  const showActions =
-    dateMode === 'latest' ||
-    (dateMode === 'custom' && committedDate === latestDate && !!latestDate)
-
-  const handleDateModeChange = (mode: string) => {
-    setDateMode(mode as DateMode)
-    if (mode === 'custom') {
-      if (dateInputRef.current) {
-        dateInputRef.current.value = latestDate
-      }
-      setCommittedDate(latestDate)
-    }
-    setCurrentPage(1)
-  }
-
-  const handleSortChange = (column: SortColumn) => {
-    if (sortColumn === column) {
-      setSortAsc((prev) => !prev)
-    } else {
-      setSortColumn(column)
-      setSortAsc(true)
-    }
-    setCurrentPage(1)
-  }
-
-  const handleSearchClear = () => {
-    setSearchInput('')
-    setSearchQuery('')
-    setCurrentPage(1)
-  }
-
-  const filtered = (endpoints ?? []).filter((e) => {
-    if (monitoredFilter === 'monitored' && e.tags?.monitored !== '1')
-      return false
-    if (monitoredFilter === 'not_monitored' && e.tags?.monitored === '1')
-      return false
-    if (!searchQuery) return true
-    const q = searchQuery.toLowerCase()
-    const monitoredLabel =
-      e.tags?.monitored === '1' ? 'monitored' : 'not monitored'
-    return (
-      e.service.toLowerCase().includes(q) ||
-      e.group.toLowerCase().includes(q) ||
-      monitoredLabel.includes(q)
-    )
-  })
-
-  const sorted = [...filtered].sort((a, b) => {
-    let cmp = 0
-    if (sortColumn === 'service') {
-      cmp = a.service.localeCompare(b.service)
-    } else if (sortColumn === 'group') {
-      cmp = a.group.localeCompare(b.group)
-    } else {
-      const aVal = a.tags?.monitored ?? '0'
-      const bVal = b.tags?.monitored ?? '0'
-      cmp = aVal.localeCompare(bVal)
-    }
-    return sortAsc ? cmp : -cmp
-  })
-
-  const totalPages = Math.ceil(sorted.length / pageSize)
-  const paginated = sorted.slice(
-    (currentPage - 1) * pageSize,
-    currentPage * pageSize,
+  const location = useLocation()
+  const [activeTab, setActiveTab] = useState<'endpoints' | 'groups'>(
+    'endpoints',
   )
 
-  if (endpointToEdit) {
+  useEffect(() => {
+    const hash = location.hash
+    if (hash.startsWith('#groups')) {
+      setActiveTab('groups')
+    } else {
+      setActiveTab('endpoints')
+    }
+  }, [location.hash])
+
+  const [editingEndpoint, setEditingEndpoint] =
+    useState<EndpointTopologyItem | null>(null)
+  const [editingGroup, setEditingGroup] = useState<GroupTopologyItem | null>(
+    null,
+  )
+
+  if (editingEndpoint) {
     return (
       <CreateTopologyEndpoint
         tenantId={tenantId}
-        editingEndpoint={endpointToEdit}
-        onClose={() => setEndpointToEdit(null)}
+        editingEndpoint={editingEndpoint}
+        onClose={() => setEditingEndpoint(null)}
+      />
+    )
+  }
+
+  if (editingGroup) {
+    return (
+      <CreateTopologyGroup
+        tenantId={tenantId}
+        editingGroup={editingGroup}
+        onClose={() => setEditingGroup(null)}
       />
     )
   }
 
   return (
-    <>
-      <div className="page-container">
-        <PageHeader
-          title="Topology Endpoints"
-          subtitle={
-            <>
-              Manage topology endpoints for tenant{' '}
-              <strong>{tenantData?.info.name ?? '...'}</strong>
-            </>
-          }
-          className="pb-2 mb-4"
-        >
-          {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
-            <Button
-              variant="primary"
-              size="md"
-              href={`/tenants/${tenantId}/topology/create`}
-            >
-              Add Topology Endpoint
-            </Button>
-          )}
-        </PageHeader>
-
-        <div className="flex items-center justify-between gap-3 mb-3">
-          <div className="flex items-center gap-3 w-full">
-            <SearchInput
-              value={searchInput}
-              onChange={setSearchInput}
-              onClear={handleSearchClear}
-              placeholder="Search by service or group..."
-              className="!mb-0 w-full"
-            />
-            <SelectDropdown
-              value={monitoredFilter}
-              onChange={(value) => {
-                setMonitoredFilter(value as 'monitored' | 'not_monitored')
-                setCurrentPage(1)
-              }}
-              options={[
-                { value: 'monitored', label: 'Monitored' },
-                { value: 'not_monitored', label: 'Not monitored' },
-              ]}
-              className="w-40 shrink-0"
-            />
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <div className="h-8 w-px bg-line-strong me-1" />
-            {dateMode === 'custom' && (
-              <input
-                ref={dateInputRef}
-                type="date"
-                defaultValue={latestDate || undefined}
-                onClick={(e) => e.currentTarget.showPicker?.()}
-                className="text-sm"
-              />
-            )}
-            <SelectDropdown
-              value={dateMode}
-              onChange={handleDateModeChange}
-              options={[
-                { value: 'latest', label: 'Latest' },
-                { value: 'custom', label: 'Select date' },
-              ]}
-              className="w-36"
-            />
-          </div>
-        </div>
-
-        <DataTable>
-          <thead className="bg-surface-strong border-b border-line">
-            <tr>
-              <th className={`${thBase} min-w-28`}>
-                <SortableColumnHeader
-                  isActive={sortColumn === 'service'}
-                  isAscending={sortAsc}
-                  onClick={() => handleSortChange('service')}
-                >
-                  Service
-                </SortableColumnHeader>
-              </th>
-              <th className={`${thBase} min-w-40`}>URL</th>
-              <th className={`${thBase} min-w-24`}>
-                <SortableColumnHeader
-                  isActive={sortColumn === 'group'}
-                  isAscending={sortAsc}
-                  onClick={() => handleSortChange('group')}
-                >
-                  Group
-                </SortableColumnHeader>
-              </th>
-              <th className={`${thBase} min-w-24`}>
-                <SortableColumnHeader
-                  isActive={sortColumn === 'monitored'}
-                  isAscending={sortAsc}
-                  onClick={() => handleSortChange('monitored')}
-                >
-                  Monitored
-                </SortableColumnHeader>
-              </th>
-              <th className={`${thBase} min-w-28`}>Date</th>
-              {showActions && <th className={`${thBase} w-24`}>Actions</th>}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
-            {isLoading ? (
-              <tr>
-                <td colSpan={showActions ? 6 : 5} className="py-12">
-                  <div className="flex justify-center">
-                    <LoadingSpinner size="md" />
-                  </div>
-                </td>
-              </tr>
-            ) : error ? (
-              <tr>
-                <td colSpan={showActions ? 6 : 5} className="py-6 px-12">
-                  <ErrorDisplay error={error} context="topology endpoints" />
-                </td>
-              </tr>
-            ) : !endpoints?.length ? (
-              <tr>
-                <td
-                  colSpan={showActions ? 6 : 5}
-                  className="text-center text-sm text-subtle italic py-6 px-12"
-                >
-                  No topology endpoints found
-                </td>
-              </tr>
-            ) : !paginated.length ? (
-              <tr>
-                <td
-                  colSpan={showActions ? 6 : 5}
-                  className="text-center text-sm text-subtle italic py-6 px-12"
-                >
-                  No endpoints match your filters
-                </td>
-              </tr>
-            ) : (
-              paginated.map((endpoint) => (
-                <tr
-                  key={`${endpoint.hostname}_${endpoint.service}`}
-                  className="hover:bg-surface-muted transition-colors"
-                >
-                  <td className={tdBase}>{endpoint.service}</td>
-                  <td className={`${tdBase} font-mono text-xs break-all`}>
-                    {endpoint.hostname}
-                  </td>
-                  <td className={tdBase}>{endpoint.group}</td>
-                  <td className={tdBase}>
-                    {endpoint.tags?.monitored !== undefined ? (
-                      <Badge
-                        size="sm"
-                        className={
-                          endpoint.tags.monitored === '1'
-                            ? 'bg-emerald-50 text-emerald-600'
-                            : 'bg-surface-strong text-muted'
-                        }
-                      >
-                        {endpoint.tags.monitored === '1'
-                          ? 'Monitored'
-                          : 'Not Monitored'}
-                      </Badge>
-                    ) : null}
-                  </td>
-                  <td className={tdBase}>{endpoint.date}</td>
-                  {showActions && (
-                    <td className={`${tdBase} whitespace-nowrap`}>
-                      <div className="flex items-center gap-1">
-                        <IconButton
-                          icon={
-                            <PencilSquareIcon className="size-4 md:size-5" />
-                          }
-                          label="Edit"
-                          onClick={() => setEndpointToEdit(endpoint)}
-                          className="text-muted hover:bg-surface-strong"
-                        />
-                        <IconButton
-                          icon={<TrashIcon className="size-4 md:size-5" />}
-                          label="Delete"
-                          onClick={() => handleDeleteClick(endpoint)}
-                          className="text-red-600 hover:bg-red-50"
-                        />
-                      </div>
-                    </td>
-                  )}
-                </tr>
-              ))
-            )}
-          </tbody>
-        </DataTable>
-
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          totalElements={sorted.length}
-          itemLabel="endpoints"
-          onPrev={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
-          onNext={() => setCurrentPage((prev) => prev + 1)}
-        />
-      </div>
-      <ConfirmDialog
-        isOpen={deleteDialogOpen}
-        title="Delete Topology Endpoint"
-        message={
+    <div className="page-container">
+      <PageHeader
+        title="Topology"
+        subtitle={
           <>
-            Are you sure you want to delete the endpoint with URL{' '}
-            <strong>{endpointToDelete?.hostname}</strong> ?
-            <br />
-            <span className="text-amber-600 font-medium">
-              This action cannot be undone.
-            </span>
+            Manage topology for tenant{' '}
+            <strong>{tenantData?.info.name ?? '...'}</strong>
           </>
         }
-        confirmLabel="Delete"
-        cancelLabel="Cancel"
-        onConfirm={handleDeleteConfirm}
-        onCancel={() => {
-          setDeleteDialogOpen(false)
-          setEndpointToDelete(null)
-        }}
+        className="pb-1 mb-2"
       />
-    </>
+
+      <Tabs
+        tabs={tabs}
+        activeTab={activeTab}
+        onChange={(id) => {
+          setActiveTab(id as 'endpoints' | 'groups')
+          window.location.hash = id
+        }}
+        className="mb-4"
+      />
+
+      {activeTab === 'endpoints' && (
+        <TopologyEndpoints tenantId={tenantId} onEdit={setEditingEndpoint} />
+      )}
+      {activeTab === 'groups' && (
+        <TopologyGroups tenantId={tenantId} onEdit={setEditingGroup} />
+      )}
+    </div>
   )
 }
 

--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -1,0 +1,402 @@
+import { useState, useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
+import { useGetUserTenantById } from '@/hooks/useTenants'
+import {
+  useGetTopologyEndpoints,
+  useCreateTopologyEndpointMutation,
+} from '@/hooks/useTopology'
+import Button from '@/components/Button'
+import IconButton from '@/components/IconButton'
+import ConfirmDialog from '@/components/ConfirmDialog'
+import SearchInput from '@/components/SearchInput'
+import Pagination from '@/components/Pagination'
+import DataTable, {
+  thBase,
+  tdBase,
+  SortableColumnHeader,
+} from '@/components/DataTable'
+import Badge from '@/components/Badge'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import SelectDropdown from '@/components/SelectDropdown'
+import type { EndpointTopologyItem } from '@/types/topology'
+
+type SortColumn = 'service' | 'group' | 'monitored'
+type DateMode = 'latest' | 'custom'
+
+const pageSize = 15
+
+interface TopologyEndpointsProps {
+  tenantId: string
+  onEdit: (endpoint: EndpointTopologyItem) => void
+}
+
+const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
+  const { data: tenantData } = useGetUserTenantById(tenantId)
+
+  const [searchInput, setSearchInput] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [sortColumn, setSortColumn] = useState<SortColumn>('monitored')
+  const [sortAsc, setSortAsc] = useState(false)
+  const [dateMode, setDateMode] = useState<DateMode>('latest')
+  const [committedDate, setCommittedDate] = useState('')
+  const dateInputRef = useRef<HTMLInputElement>(null)
+  const [monitoredFilter, setMonitoredFilter] = useState<
+    'monitored' | 'not_monitored'
+  >('monitored')
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [endpointToDelete, setEndpointToDelete] =
+    useState<EndpointTopologyItem | null>(null)
+
+  const effectiveDate = dateMode === 'latest' ? '' : committedDate
+
+  const {
+    data: endpoints,
+    isLoading,
+    error,
+  } = useGetTopologyEndpoints(tenantId, effectiveDate)
+
+  const { data: latestEndpoints } = useGetTopologyEndpoints(tenantId, '')
+
+  const deleteMutation = useCreateTopologyEndpointMutation()
+
+  const handleDeleteClick = (endpoint: EndpointTopologyItem) => {
+    setEndpointToDelete(endpoint)
+    setDeleteDialogOpen(true)
+  }
+
+  const handleDeleteConfirm = () => {
+    if (!endpointToDelete) return
+
+    const updatedEndpoints = (endpoints ?? []).filter(
+      (endpoint) => endpoint.hostname !== endpointToDelete.hostname,
+    )
+
+    deleteMutation.mutate(
+      { tenantId, data: updatedEndpoints },
+      {
+        onSuccess: () => {
+          toast.success('Topology endpoint deleted successfully!')
+          setDeleteDialogOpen(false)
+          setEndpointToDelete(null)
+          if (paginated.length === 1 && currentPage > 1) {
+            setCurrentPage((prev) => prev - 1)
+          }
+        },
+        onError: (error) => {
+          toast.error(`Failed to delete endpoint: ${error.message}`)
+        },
+      },
+    )
+  }
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchQuery(searchInput)
+      setCurrentPage(1)
+    }, 500)
+    return () => clearTimeout(timer)
+  }, [searchInput])
+
+  useEffect(() => {
+    const input = dateInputRef.current
+    if (!input) return
+
+    const handleChange = (e: Event) => {
+      const value = (e.target as HTMLInputElement).value
+      setCommittedDate(value)
+      setCurrentPage(1)
+    }
+
+    input.addEventListener('change', handleChange)
+    return () => input.removeEventListener('change', handleChange)
+  }, [dateMode])
+
+  const latestDate = latestEndpoints?.length
+    ? latestEndpoints.reduce(
+        (max, e) => (e.date > max ? e.date : max),
+        latestEndpoints[0].date,
+      )
+    : ''
+
+  const showActions =
+    dateMode === 'latest' ||
+    (dateMode === 'custom' && committedDate === latestDate && !!latestDate)
+
+  const handleDateModeChange = (mode: string) => {
+    setDateMode(mode as DateMode)
+    if (mode === 'custom') {
+      if (dateInputRef.current) {
+        dateInputRef.current.value = latestDate
+      }
+      setCommittedDate(latestDate)
+    }
+    setCurrentPage(1)
+  }
+
+  const handleSortChange = (column: SortColumn) => {
+    if (sortColumn === column) {
+      setSortAsc((prev) => !prev)
+    } else {
+      setSortColumn(column)
+      setSortAsc(true)
+    }
+    setCurrentPage(1)
+  }
+
+  const handleSearchClear = () => {
+    setSearchInput('')
+    setSearchQuery('')
+    setCurrentPage(1)
+  }
+
+  const filtered = (endpoints ?? []).filter((e) => {
+    if (monitoredFilter === 'monitored' && e.tags?.monitored !== '1') {
+      return false
+    }
+    if (monitoredFilter === 'not_monitored' && e.tags?.monitored === '1') {
+      return false
+    }
+    if (!searchQuery) return true
+    const q = searchQuery.toLowerCase()
+    const monitoredLabel =
+      e.tags?.monitored === '1' ? 'monitored' : 'not monitored'
+    return (
+      e.service.toLowerCase().includes(q) ||
+      e.group.toLowerCase().includes(q) ||
+      monitoredLabel.includes(q)
+    )
+  })
+
+  const sorted = [...filtered].sort((a, b) => {
+    let cmp = 0
+    if (sortColumn === 'service') {
+      cmp = a.service.localeCompare(b.service)
+    } else if (sortColumn === 'group') {
+      cmp = a.group.localeCompare(b.group)
+    } else {
+      const aVal = a.tags?.monitored ?? '0'
+      const bVal = b.tags?.monitored ?? '0'
+      cmp = aVal.localeCompare(bVal)
+    }
+    return sortAsc ? cmp : -cmp
+  })
+
+  const totalPages = Math.ceil(sorted.length / pageSize)
+  const paginated = sorted.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize,
+  )
+
+  return (
+    <>
+      <div className="flex flex-wrap xl:flex-nowrap items-center gap-3 mb-3">
+        <SearchInput
+          value={searchInput}
+          onChange={setSearchInput}
+          onClear={handleSearchClear}
+          placeholder="Search by service or group..."
+          className="!mb-0 flex-1 max-w-xs xl:max-w-none"
+        />
+        {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
+          <Button
+            variant="primary"
+            size="md"
+            href={`/tenants/${tenantId}/topology/create`}
+            className="shrink-0 xl:order-last ms-auto xl:ms-2"
+          >
+            Add Endpoint
+          </Button>
+        )}
+        <div className="flex items-center gap-2 w-full xl:w-auto">
+          <div className="hidden xl:block h-8 w-px bg-line-strong me-1" />
+          {dateMode === 'custom' && (
+            <input
+              ref={dateInputRef}
+              type="date"
+              defaultValue={latestDate || undefined}
+              onClick={(e) => e.currentTarget.showPicker?.()}
+              className="text-sm"
+            />
+          )}
+          <SelectDropdown
+            value={dateMode}
+            onChange={handleDateModeChange}
+            options={[
+              { value: 'latest', label: 'Latest' },
+              { value: 'custom', label: 'Select date' },
+            ]}
+            className="w-36"
+          />
+          <SelectDropdown
+            value={monitoredFilter}
+            onChange={(value) => {
+              setMonitoredFilter(value as 'monitored' | 'not_monitored')
+              setCurrentPage(1)
+            }}
+            options={[
+              { value: 'monitored', label: 'Monitored' },
+              { value: 'not_monitored', label: 'Not monitored' },
+            ]}
+            className="w-40 shrink-0 ms-auto xl:ms-0 xl:order-first"
+          />
+        </div>
+      </div>
+
+      <DataTable>
+        <thead className="bg-surface-strong border-b border-line">
+          <tr>
+            <th className={`${thBase} min-w-28`}>
+              <SortableColumnHeader
+                isActive={sortColumn === 'service'}
+                isAscending={sortAsc}
+                onClick={() => handleSortChange('service')}
+              >
+                Service
+              </SortableColumnHeader>
+            </th>
+            <th className={`${thBase} min-w-40`}>URL</th>
+            <th className={`${thBase} min-w-24`}>
+              <SortableColumnHeader
+                isActive={sortColumn === 'group'}
+                isAscending={sortAsc}
+                onClick={() => handleSortChange('group')}
+              >
+                Group
+              </SortableColumnHeader>
+            </th>
+            <th className={`${thBase} min-w-24`}>
+              <SortableColumnHeader
+                isActive={sortColumn === 'monitored'}
+                isAscending={sortAsc}
+                onClick={() => handleSortChange('monitored')}
+              >
+                Monitored
+              </SortableColumnHeader>
+            </th>
+            <th className={`${thBase} min-w-28`}>Date</th>
+            {showActions && <th className={`${thBase} w-24`}>Actions</th>}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {isLoading ? (
+            <tr>
+              <td colSpan={showActions ? 6 : 5} className="py-12">
+                <div className="flex justify-center">
+                  <LoadingSpinner size="md" />
+                </div>
+              </td>
+            </tr>
+          ) : error ? (
+            <tr>
+              <td colSpan={showActions ? 6 : 5} className="py-6 px-12">
+                <ErrorDisplay error={error} context="topology endpoints" />
+              </td>
+            </tr>
+          ) : !endpoints?.length ? (
+            <tr>
+              <td
+                colSpan={showActions ? 6 : 5}
+                className="text-center text-sm text-subtle italic py-6 px-12"
+              >
+                No topology endpoints found
+              </td>
+            </tr>
+          ) : !paginated.length ? (
+            <tr>
+              <td
+                colSpan={showActions ? 6 : 5}
+                className="text-center text-sm text-subtle italic py-6 px-12"
+              >
+                No endpoints match your filters
+              </td>
+            </tr>
+          ) : (
+            paginated.map((endpoint) => (
+              <tr
+                key={`${endpoint.hostname}_${endpoint.service}`}
+                className="hover:bg-surface-muted transition-colors"
+              >
+                <td className={tdBase}>{endpoint.service}</td>
+                <td className={`${tdBase} font-mono text-xs break-all`}>
+                  {endpoint.hostname}
+                </td>
+                <td className={tdBase}>{endpoint.group}</td>
+                <td className={tdBase}>
+                  {endpoint.tags?.monitored !== undefined ? (
+                    <Badge
+                      size="sm"
+                      className={
+                        endpoint.tags.monitored === '1'
+                          ? 'bg-emerald-50 text-emerald-600'
+                          : 'bg-surface-strong text-muted'
+                      }
+                    >
+                      {endpoint.tags.monitored === '1'
+                        ? 'Monitored'
+                        : 'Not Monitored'}
+                    </Badge>
+                  ) : null}
+                </td>
+                <td className={tdBase}>{endpoint.date}</td>
+                {showActions && (
+                  <td className={`${tdBase} whitespace-nowrap`}>
+                    <div className="flex items-center gap-1">
+                      <IconButton
+                        icon={<PencilSquareIcon className="size-4 md:size-5" />}
+                        label="Edit"
+                        onClick={() => onEdit(endpoint)}
+                        className="text-muted hover:bg-surface-strong !p-1"
+                      />
+                      <IconButton
+                        icon={<TrashIcon className="size-4 md:size-5" />}
+                        label="Delete"
+                        onClick={() => handleDeleteClick(endpoint)}
+                        className="text-red-600 hover:bg-red-50 !p-1"
+                      />
+                    </div>
+                  </td>
+                )}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </DataTable>
+
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalElements={sorted.length}
+        itemLabel="endpoints"
+        onPrev={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+        onNext={() => setCurrentPage((prev) => prev + 1)}
+      />
+
+      <ConfirmDialog
+        isOpen={deleteDialogOpen}
+        title="Delete Topology Endpoint"
+        message={
+          <>
+            Are you sure you want to delete the endpoint with URL{' '}
+            <strong>{endpointToDelete?.hostname}</strong> ?
+            <br />
+            <span className="text-amber-600 font-medium">
+              This action cannot be undone.
+            </span>
+          </>
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => {
+          setDeleteDialogOpen(false)
+          setEndpointToDelete(null)
+        }}
+      />
+    </>
+  )
+}
+
+export default TopologyEndpoints

--- a/src/pages/tenant-topology/TopologyGroups.tsx
+++ b/src/pages/tenant-topology/TopologyGroups.tsx
@@ -1,0 +1,342 @@
+import { useState, useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
+import { useGetUserTenantById } from '@/hooks/useTenants'
+import {
+  useGetTopologyGroups,
+  useCreateTopologyGroupsMutation,
+} from '@/hooks/useTopology'
+import Button from '@/components/Button'
+import IconButton from '@/components/IconButton'
+import ConfirmDialog from '@/components/ConfirmDialog'
+import SearchInput from '@/components/SearchInput'
+import Pagination from '@/components/Pagination'
+import DataTable, {
+  thBase,
+  tdBase,
+  SortableColumnHeader,
+} from '@/components/DataTable'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import SelectDropdown from '@/components/SelectDropdown'
+import type { GroupTopologyItem } from '@/types/topology'
+
+type SortColumn = 'subgroup'
+type DateMode = 'latest' | 'custom'
+
+const pageSize = 15
+
+interface TopologyGroupsProps {
+  tenantId: string
+  onEdit: (group: GroupTopologyItem) => void
+}
+
+const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
+  const { data: tenantData } = useGetUserTenantById(tenantId)
+
+  const [searchInput, setSearchInput] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [sortColumn, setSortColumn] = useState<SortColumn>('subgroup')
+  const [sortAsc, setSortAsc] = useState(true)
+  const [dateMode, setDateMode] = useState<DateMode>('latest')
+  const [committedDate, setCommittedDate] = useState('')
+  const dateInputRef = useRef<HTMLInputElement>(null)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [groupToDelete, setGroupToDelete] = useState<GroupTopologyItem | null>(
+    null,
+  )
+
+  const effectiveDate = dateMode === 'latest' ? '' : committedDate
+
+  const {
+    data: groups,
+    isLoading,
+    error,
+  } = useGetTopologyGroups(tenantId, effectiveDate)
+
+  const { data: latestGroups } = useGetTopologyGroups(tenantId, '')
+
+  const deleteMutation = useCreateTopologyGroupsMutation()
+
+  const handleDeleteClick = (group: GroupTopologyItem) => {
+    setGroupToDelete(group)
+    setDeleteDialogOpen(true)
+  }
+
+  const handleDeleteConfirm = () => {
+    if (!groupToDelete) return
+
+    const updatedGroups = (groups ?? []).filter(
+      (g) => g.subgroup !== groupToDelete.subgroup,
+    )
+
+    deleteMutation.mutate(
+      { tenantId, data: updatedGroups },
+      {
+        onSuccess: () => {
+          toast.success('Topology group deleted successfully!')
+          setDeleteDialogOpen(false)
+          setGroupToDelete(null)
+          if (paginated.length === 1 && currentPage > 1) {
+            setCurrentPage((prev) => prev - 1)
+          }
+        },
+        onError: (error) => {
+          toast.error(`Failed to delete group: ${error.message}`)
+        },
+      },
+    )
+  }
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchQuery(searchInput)
+      setCurrentPage(1)
+    }, 500)
+    return () => clearTimeout(timer)
+  }, [searchInput])
+
+  useEffect(() => {
+    const input = dateInputRef.current
+    if (!input) return
+
+    const handleChange = (e: Event) => {
+      const value = (e.target as HTMLInputElement).value
+      setCommittedDate(value)
+      setCurrentPage(1)
+    }
+
+    input.addEventListener('change', handleChange)
+    return () => input.removeEventListener('change', handleChange)
+  }, [dateMode])
+
+  const latestDate = latestGroups?.length
+    ? latestGroups.reduce(
+        (max, g) => (g.date > max ? g.date : max),
+        latestGroups[0].date,
+      )
+    : ''
+
+  const showActions =
+    dateMode === 'latest' ||
+    (dateMode === 'custom' && committedDate === latestDate && !!latestDate)
+
+  const handleDateModeChange = (mode: string) => {
+    setDateMode(mode as DateMode)
+    if (mode === 'custom') {
+      if (dateInputRef.current) {
+        dateInputRef.current.value = latestDate
+      }
+      setCommittedDate(latestDate)
+    }
+    setCurrentPage(1)
+  }
+
+  const handleSortChange = (column: SortColumn) => {
+    if (sortColumn === column) {
+      setSortAsc((prev) => !prev)
+    } else {
+      setSortColumn(column)
+      setSortAsc(true)
+    }
+    setCurrentPage(1)
+  }
+
+  const handleSearchClear = () => {
+    setSearchInput('')
+    setSearchQuery('')
+    setCurrentPage(1)
+  }
+
+  const filtered = (groups ?? []).filter((g) => {
+    if (!searchQuery) return true
+    return g.subgroup.toLowerCase().includes(searchQuery.toLowerCase())
+  })
+
+  const sorted = [...filtered].sort((a, b) => {
+    const cmp = a.subgroup.localeCompare(b.subgroup)
+    return sortAsc ? cmp : -cmp
+  })
+
+  const totalPages = Math.ceil(sorted.length / pageSize)
+  const paginated = sorted.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize,
+  )
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <div className="flex items-center gap-3 w-full">
+          <SearchInput
+            value={searchInput}
+            onChange={setSearchInput}
+            onClear={handleSearchClear}
+            placeholder="Search by subgroup..."
+            className="!mb-0 w-full"
+          />
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          {dateMode === 'custom' && (
+            <input
+              ref={dateInputRef}
+              type="date"
+              defaultValue={latestDate || undefined}
+              onClick={(e) => e.currentTarget.showPicker?.()}
+              className="text-sm"
+            />
+          )}
+          <SelectDropdown
+            value={dateMode}
+            onChange={handleDateModeChange}
+            options={[
+              { value: 'latest', label: 'Latest' },
+              { value: 'custom', label: 'Select date' },
+            ]}
+            className="w-36"
+          />
+          {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
+            <Button
+              size="md"
+              variant="primary"
+              href={`/tenants/${tenantId}/topology/groups/create`}
+              className="ms-2"
+            >
+              Add Group
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <DataTable tableClassName="table-fixed">
+        <thead className="bg-surface-strong border-b border-line">
+          <tr>
+            <th className={`${thBase} w-[30%]`}>
+              <SortableColumnHeader
+                isActive={sortColumn === 'subgroup'}
+                isAscending={sortAsc}
+                onClick={() => handleSortChange('subgroup')}
+              >
+                Subgroup
+              </SortableColumnHeader>
+            </th>
+            <th className={`${thBase} w-[40%]`}>Contacts</th>
+            <th className={`${thBase} w-[15%]`}>Date</th>
+            {showActions && <th className={`${thBase} w-[8%]`}>Actions</th>}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {isLoading ? (
+            <tr>
+              <td colSpan={showActions ? 4 : 3} className="py-12">
+                <div className="flex justify-center">
+                  <LoadingSpinner size="md" />
+                </div>
+              </td>
+            </tr>
+          ) : error ? (
+            <tr>
+              <td colSpan={showActions ? 4 : 3} className="py-6 px-12">
+                <ErrorDisplay error={error} context="topology groups" />
+              </td>
+            </tr>
+          ) : !groups?.length ? (
+            <tr>
+              <td
+                colSpan={showActions ? 4 : 3}
+                className="text-center text-sm text-subtle italic py-6 px-12"
+              >
+                No topology groups found
+              </td>
+            </tr>
+          ) : !paginated.length ? (
+            <tr>
+              <td
+                colSpan={showActions ? 4 : 3}
+                className="text-center text-sm text-subtle italic py-6 px-12"
+              >
+                No groups match your filters
+              </td>
+            </tr>
+          ) : (
+            paginated.map((group) => (
+              <tr
+                key={group.subgroup}
+                className="hover:bg-surface-muted transition-colors"
+              >
+                <td className={tdBase}>{group.subgroup}</td>
+                <td className={`${tdBase} text-sm text-muted`}>
+                  {group.notifications?.contacts?.length ? (
+                    <div className="flex flex-wrap gap-x-2 gap-y-0.5">
+                      {group.notifications.contacts.map((contact, i, arr) => (
+                        <span key={contact}>
+                          {contact}
+                          {i < arr.length - 1 ? ',' : ''}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="ms-7">-</span>
+                  )}
+                </td>
+                <td className={tdBase}>{group.date}</td>
+                {showActions && (
+                  <td className={`${tdBase} whitespace-nowrap`}>
+                    <div className="flex items-center gap-1">
+                      <IconButton
+                        icon={<PencilSquareIcon className="size-4 md:size-5" />}
+                        label="Edit"
+                        onClick={() => onEdit(group)}
+                        className="text-muted hover:bg-surface-strong !p-1"
+                      />
+                      <IconButton
+                        icon={<TrashIcon className="size-4 md:size-5" />}
+                        label="Delete"
+                        onClick={() => handleDeleteClick(group)}
+                        className="text-red-600 hover:bg-red-50 !p-1"
+                      />
+                    </div>
+                  </td>
+                )}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </DataTable>
+
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalElements={sorted.length}
+        itemLabel="groups"
+        onPrev={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+        onNext={() => setCurrentPage((prev) => prev + 1)}
+      />
+
+      <ConfirmDialog
+        isOpen={deleteDialogOpen}
+        title="Delete Topology Group"
+        message={
+          <>
+            Are you sure you want to delete the group{' '}
+            <strong>{groupToDelete?.subgroup}</strong> ?
+            <br />
+            <span className="text-amber-600 font-medium">
+              This action cannot be undone.
+            </span>
+          </>
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => {
+          setDeleteDialogOpen(false)
+          setGroupToDelete(null)
+        }}
+      />
+    </>
+  )
+}
+
+export default TopologyGroups

--- a/src/pages/tenant-topology/index.ts
+++ b/src/pages/tenant-topology/index.ts
@@ -1,2 +1,3 @@
 export { default as TenantTopology } from './TenantTopology'
 export { default as CreateTopologyEndpoint } from './CreateTopologyEndpoint'
+export { default as CreateTopologyGroup } from './CreateTopologyGroup'

--- a/src/types/topology.ts
+++ b/src/types/topology.ts
@@ -15,6 +15,15 @@ export type EndpointTopologyItem = {
   notifications?: TopologyNotifications
 }
 
+export type GroupTopologyItem = {
+  date: string
+  group: string
+  type: string
+  subgroup: string
+  tags?: TopologyTags
+  notifications?: TopologyNotifications
+}
+
 export type ServiceType = {
   name: string
   title: string


### PR DESCRIPTION
This PR adds Labels and Groups to topology management and uses separate tabs for Endpoints and Groups.

- Added Labels and Groups sections in topology management pages
- Implemented tab navigation for Endpoints and Groups in the main topology page
- Split topology components into smaller, dedicated components for list, create, and edit actions
- Added topology groups API endpoint declaration and React Query integration for groups data handling
- Updated the topology forms for Endpoints and Groups in both Add and Edit actions
- Added search support in SelectDropdown for option filtering in selection lists