### PR TITLE
[ARGO-5486] - Refactor topology components with shared hooks and utilities

### DIFF
--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -214,7 +214,7 @@ const SelectDropdown = ({
                 filteredOptions.map((option, index) => (
                   <li
                     id={`${listboxId}-option-${index}`}
-                    key={option.value}
+                    key={`${option.value}-${index}`}
                     role="option"
                     aria-selected={option.value === value}
                     onClick={() => handleSelect(option.value)}

--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -1,31 +1,34 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
 import {
   useGetTopologyEndpoints,
   useGetTopologyServiceTypes,
   useCreateTopologyEndpointMutation,
 } from '@/hooks/useTopology'
 import { useGetUserTenantById } from '@/hooks/useTenants'
-import { useParams, useNavigate } from 'react-router-dom'
-import type { EndpointTopologyItem } from '@/types/topology'
 import { toast } from 'sonner'
-import NotificationsSection from './NotificationsSection'
-import GroupSelector from './GroupSelector'
-import KeyValueInput from './KeyValueInput'
-import LabelsInput from './LabelsInput'
-import type { Label } from './KeyValueInput'
-import type { Contact } from './NotificationsSection'
 import PageHeader from '@/components/PageHeader'
 import Button from '@/components/Button'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import SelectDropdown from '@/components/SelectDropdown'
+import {
+  getContactValidationErrors,
+  getValidContactEmails,
+  isValidEmail,
+} from './utils/topologyValidation'
+import NotificationsSection from './NotificationsSection'
+import GroupSelector from './GroupSelector'
+import LabelsInput from './LabelsInput'
+import KeyValueInput from './KeyValueInput'
+import type { Label } from './KeyValueInput'
+import type { Contact } from './NotificationsSection'
+import type { EndpointTopologyItem } from '@/types/topology'
 
 const sectionClass =
   'grid grid-cols-1 lg:grid-cols-[360px_1fr] gap-2 lg:gap-8 mb-6 animate-fade-in'
 const sectionContentClass =
   'bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-2'
-
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const today = new Date().toISOString().split('T')[0]
 
@@ -62,6 +65,7 @@ const CreateTopologyEndpoint = ({
   const tenantId = tenantIdProp ?? tenantIdParam ?? ''
   const isEditMode = !!editingEndpoint
   const navigate = useNavigate()
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { data: tenantData } = useGetUserTenantById(tenantId)
 
@@ -123,6 +127,14 @@ const CreateTopologyEndpoint = ({
     contacts: [''],
   })
 
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [])
+
   const handleServiceChange = (value: string) => {
     setFormData((prev) => ({ ...prev, service: value }))
     if (value) {
@@ -147,7 +159,7 @@ const CreateTopologyEndpoint = ({
     }))
 
     const updatedErrors = [...errors.contacts]
-    if (!value.trim() || emailRegex.test(value)) {
+    if (!value.trim() || isValidEmail(value)) {
       updatedErrors[index] = ''
     } else {
       updatedErrors[index] = 'Invalid email'
@@ -208,19 +220,11 @@ const CreateTopologyEndpoint = ({
     }
 
     if (formData.notificationsEnabled) {
-      const hasValidContact = formData.contacts.some(
-        (c) => c.value.trim() && emailRegex.test(c.value),
-      )
-      if (!hasValidContact) {
-        newErrors.contacts[0] = 'At least one valid email is required'
+      const contactErrors = getContactValidationErrors(formData.contacts, true)
+      if (contactErrors.some((error) => !!error)) {
+        newErrors.contacts = contactErrors
         hasError = true
       }
-      formData.contacts.forEach((c, i) => {
-        if (c.value.trim() && !emailRegex.test(c.value)) {
-          newErrors.contacts[i] = 'Invalid email'
-          hasError = true
-        }
-      })
     }
 
     if (hasError) {
@@ -244,9 +248,7 @@ const CreateTopologyEndpoint = ({
       },
       notifications: {
         enabled: formData.notificationsEnabled,
-        contacts: formData.contacts
-          .filter((c) => c.value.trim() && emailRegex.test(c.value))
-          .map((c) => c.value),
+        contacts: getValidContactEmails(formData.contacts),
       },
     }
 
@@ -281,7 +283,10 @@ const CreateTopologyEndpoint = ({
               ? 'Topology endpoint updated successfully!'
               : 'Topology endpoint created successfully!',
           )
-          setTimeout(() => {
+          if (timerRef.current) {
+            clearTimeout(timerRef.current)
+          }
+          timerRef.current = setTimeout(() => {
             if (onClose) {
               onClose()
             } else {

--- a/src/pages/tenant-topology/CreateTopologyGroup.tsx
+++ b/src/pages/tenant-topology/CreateTopologyGroup.tsx
@@ -1,14 +1,19 @@
 import { useState, useRef, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
 import { useGetUserTenantById } from '@/hooks/useTenants'
 import {
   useGetTopologyGroups,
   useCreateTopologyGroupsMutation,
 } from '@/hooks/useTopology'
-import { useParams, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import PageHeader from '@/components/PageHeader'
 import Button from '@/components/Button'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import {
+  getContactValidationErrors,
+  getValidContactEmails,
+  isValidEmail,
+} from './utils/topologyValidation'
 import NotificationsSection from './NotificationsSection'
 import type { Contact } from './NotificationsSection'
 import type { GroupTopologyItem } from '@/types/topology'
@@ -17,8 +22,6 @@ const sectionClass =
   'grid grid-cols-1 md:grid-cols-[360px_1fr] gap-4 md:gap-8 mb-8 animate-fade-in'
 const sectionContentClass =
   'bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-2'
-
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const today = new Date().toISOString().split('T')[0]
 
@@ -107,7 +110,7 @@ const CreateTopologyGroup = ({
     }))
 
     const updatedErrors = [...errors.contacts]
-    if (!value.trim() || emailRegex.test(value)) {
+    if (!value.trim() || isValidEmail(value)) {
       updatedErrors[index] = ''
     } else {
       updatedErrors[index] = 'Invalid email'
@@ -148,19 +151,11 @@ const CreateTopologyGroup = ({
     }
 
     if (formData.notificationsEnabled) {
-      const hasValidContact = formData.contacts.some(
-        (c) => c.value.trim() && emailRegex.test(c.value),
-      )
-      if (!hasValidContact) {
-        newErrors.contacts[0] = 'At least one valid email is required'
+      const contactErrors = getContactValidationErrors(formData.contacts, true)
+      if (contactErrors.some((error) => !!error)) {
+        newErrors.contacts = contactErrors
         hasError = true
       }
-      formData.contacts.forEach((c, i) => {
-        if (c.value.trim() && !emailRegex.test(c.value)) {
-          newErrors.contacts[i] = 'Invalid email'
-          hasError = true
-        }
-      })
     }
 
     if (hasError) {
@@ -170,9 +165,7 @@ const CreateTopologyGroup = ({
 
     const notifications = {
       enabled: formData.notificationsEnabled,
-      contacts: formData.contacts
-        .filter((c) => c.value.trim() && emailRegex.test(c.value))
-        .map((c) => c.value),
+      contacts: getValidContactEmails(formData.contacts),
     }
 
     const payload = isEditMode
@@ -207,6 +200,9 @@ const CreateTopologyGroup = ({
               ? 'Topology group updated successfully!'
               : 'Topology group created successfully!',
           )
+          if (timerRef.current) {
+            clearTimeout(timerRef.current)
+          }
           timerRef.current = setTimeout(() => {
             if (onClose) {
               onClose()

--- a/src/pages/tenant-topology/GroupCreationPanel.tsx
+++ b/src/pages/tenant-topology/GroupCreationPanel.tsx
@@ -1,0 +1,288 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
+import {
+  useCreateTopologyGroupsMutation,
+  useGetTopologyGroups,
+} from '@/hooks/useTopology'
+import Button from '@/components/Button'
+import IconButton from '@/components/IconButton'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import {
+  getContactValidationErrors,
+  getValidContactEmails,
+  isValidEmail,
+} from './utils/topologyValidation'
+import type { Contact } from './NotificationsSection'
+
+const today = new Date().toISOString().split('T')[0]
+
+interface GroupCreationPanelProps {
+  tenantId: string
+  tenantName: string
+  onSuccess: (subgroup: string) => void
+  onCancel: () => void
+  onGroupSaving?: (busy: boolean) => void
+}
+
+interface GroupCreationState {
+  subgroup: string
+  subgroupError: string
+  notificationsEnabled: boolean
+  contacts: Contact[]
+  contactErrors: string[]
+}
+
+const GroupCreationPanel = ({
+  tenantId,
+  tenantName,
+  onSuccess,
+  onCancel,
+  onGroupSaving,
+}: GroupCreationPanelProps) => {
+  const { data: groups } = useGetTopologyGroups(tenantId)
+  const groupsMutation = useCreateTopologyGroupsMutation()
+
+  const [groupForm, setGroupForm] = useState<GroupCreationState>({
+    subgroup: '',
+    subgroupError: '',
+    notificationsEnabled: false,
+    contacts: [{ id: crypto.randomUUID(), value: '' }],
+    contactErrors: [''],
+  })
+
+  const resetForm = () => {
+    setGroupForm({
+      subgroup: '',
+      subgroupError: '',
+      notificationsEnabled: false,
+      contacts: [{ id: crypto.randomUUID(), value: '' }],
+      contactErrors: [''],
+    })
+  }
+
+  const handleCancel = () => {
+    resetForm()
+    onCancel()
+  }
+
+  const handleContactChange = (index: number, value: string) => {
+    const updatedContacts = groupForm.contacts.map((contact, i) =>
+      i === index ? { ...contact, value } : contact,
+    )
+
+    const updatedErrors = [...groupForm.contactErrors]
+    updatedErrors[index] =
+      !value.trim() || isValidEmail(value) ? '' : 'Invalid email'
+
+    setGroupForm((prev) => ({
+      ...prev,
+      contacts: updatedContacts,
+      contactErrors: updatedErrors,
+    }))
+  }
+
+  const handleCreateGroupSubmit = () => {
+    if (!groupForm.subgroup.trim()) {
+      setGroupForm((prev) => ({
+        ...prev,
+        subgroupError: 'Group is required',
+      }))
+      return
+    }
+
+    if (groupForm.notificationsEnabled) {
+      const nextContactErrors = getContactValidationErrors(
+        groupForm.contacts,
+        true,
+      )
+      setGroupForm((prev) => ({ ...prev, contactErrors: nextContactErrors }))
+
+      if (nextContactErrors.some((error) => !!error)) {
+        return
+      }
+    }
+
+    const notifications = {
+      enabled: groupForm.notificationsEnabled,
+      contacts: groupForm.notificationsEnabled
+        ? getValidContactEmails(groupForm.contacts)
+        : [],
+    }
+
+    const payload = [
+      ...(groups ?? []),
+      {
+        date: today,
+        group: tenantName,
+        type: 'PROJECT',
+        subgroup: groupForm.subgroup.trim(),
+        notifications,
+      },
+    ]
+
+    onGroupSaving?.(true)
+
+    groupsMutation.mutate(
+      { tenantId, data: payload },
+      {
+        onSuccess: () => {
+          toast.success('Group created successfully!')
+          onSuccess(groupForm.subgroup.trim())
+          resetForm()
+          onGroupSaving?.(false)
+        },
+        onError: (error) => {
+          toast.error(`Failed to create group: ${error.message}`)
+          onGroupSaving?.(false)
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="border border-line rounded-lg px-4 py-3 flex flex-col gap-3 mt-1 animate-fade-in">
+      <div className="flex flex-col">
+        <label className="text-sm font-medium text-body mb-1.5">
+          Group <span className="required">*</span>
+        </label>
+        <input
+          type="text"
+          value={groupForm.subgroup}
+          onChange={(e) => {
+            const value = e.target.value
+            setGroupForm((prev) => ({
+              ...prev,
+              subgroup: value,
+              subgroupError: value.trim() ? '' : prev.subgroupError,
+            }))
+          }}
+          placeholder="Enter group name"
+          className={
+            groupForm.subgroupError
+              ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
+              : ''
+          }
+        />
+        {groupForm.subgroupError && (
+          <span className="text-xs text-red-500 mt-1">
+            {groupForm.subgroupError}
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            className="toggle toggle-brand"
+            checked={groupForm.notificationsEnabled}
+            onChange={() =>
+              setGroupForm((prev) => ({
+                ...prev,
+                notificationsEnabled: !prev.notificationsEnabled,
+              }))
+            }
+          />
+          <p className="text-sm font-semibold text-body">
+            {groupForm.notificationsEnabled
+              ? 'Notifications enabled'
+              : 'Notifications disabled'}
+          </p>
+        </label>
+
+        {groupForm.notificationsEnabled && (
+          <div className="flex flex-col gap-2 animate-fade-in">
+            <p className="text-sm font-medium text-body">
+              Contact Emails <span className="required">*</span>
+            </p>
+            {groupForm.contacts.map((contact, index) => (
+              <div key={contact.id} className="flex items-start gap-1">
+                <div className="flex flex-col flex-1">
+                  <input
+                    type="email"
+                    value={contact.value}
+                    onChange={(e) => handleContactChange(index, e.target.value)}
+                    placeholder="Enter contact email"
+                    className={
+                      groupForm.contactErrors[index]
+                        ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
+                        : ''
+                    }
+                  />
+                  {groupForm.contactErrors[index] && (
+                    <span className="text-xs text-red-500 mt-1">
+                      {groupForm.contactErrors[index]}
+                    </span>
+                  )}
+                </div>
+                {groupForm.contacts.length > 1 && (
+                  <div className="mt-1">
+                    <IconButton
+                      icon={<TrashIcon className="size-4.5" />}
+                      label="Remove contact"
+                      onClick={() => {
+                        setGroupForm((prev) => ({
+                          ...prev,
+                          contacts: prev.contacts.filter((_, i) => i !== index),
+                          contactErrors: prev.contactErrors.filter(
+                            (_, i) => i !== index,
+                          ),
+                        }))
+                      }}
+                      className="text-red-600 hover:bg-red-50"
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                setGroupForm((prev) => ({
+                  ...prev,
+                  contacts: [
+                    ...prev.contacts,
+                    { id: crypto.randomUUID(), value: '' },
+                  ],
+                  contactErrors: [...prev.contactErrors, ''],
+                }))
+              }}
+              className="flex items-center gap-1.5 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer"
+            >
+              <PlusIcon className="size-4" />
+              Add another email
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={handleCreateGroupSubmit}
+          disabled={groupsMutation.isPending}
+        >
+          {groupsMutation.isPending ? (
+            <>
+              <LoadingSpinner size="xs" />
+              Creating...
+            </>
+          ) : (
+            'Create Group'
+          )}
+        </Button>
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="text-sm text-muted hover:text-body transition-colors cursor-pointer"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default GroupCreationPanel

--- a/src/pages/tenant-topology/GroupSelector.tsx
+++ b/src/pages/tenant-topology/GroupSelector.tsx
@@ -1,23 +1,9 @@
 import { useState } from 'react'
-import {
-  useGetTopologyGroups,
-  useCreateTopologyGroupsMutation,
-} from '@/hooks/useTopology'
-import {
-  PlusIcon,
-  TrashIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-} from '@heroicons/react/16/solid'
-import { toast } from 'sonner'
-import Button from '@/components/Button'
-import IconButton from '@/components/IconButton'
+import { useGetTopologyGroups } from '@/hooks/useTopology'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/16/solid'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import SelectDropdown from '@/components/SelectDropdown'
-import type { Contact } from './NotificationsSection'
-
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-const today = new Date().toISOString().split('T')[0]
+import GroupCreationPanel from './GroupCreationPanel'
 
 interface GroupSelectorProps {
   tenantId: string
@@ -38,102 +24,15 @@ const GroupSelector = ({
 }: GroupSelectorProps) => {
   const { data: groups, isLoading: isLoadingGroups } =
     useGetTopologyGroups(tenantId)
-  const groupsMutation = useCreateTopologyGroupsMutation()
-
   const [showCreateGroup, setShowCreateGroup] = useState(false)
-  const [newGroupSubgroup, setNewGroupSubgroup] = useState('')
-  const [newGroupSubgroupError, setNewGroupSubgroupError] = useState('')
-  const [newGroupNotificationsEnabled, setNewGroupNotificationsEnabled] =
-    useState(false)
-  const [newGroupContacts, setNewGroupContacts] = useState<Contact[]>([
-    { id: crypto.randomUUID(), value: '' },
-  ])
-  const [newGroupContactErrors, setNewGroupContactErrors] = useState<string[]>([
-    '',
-  ])
 
-  const resetCreateGroup = () => {
+  const handleToggleCreateGroup = () => {
+    setShowCreateGroup((prev) => !prev)
+  }
+
+  const handleCreateGroupSuccess = (subgroup: string) => {
+    onChange(subgroup)
     setShowCreateGroup(false)
-    setNewGroupSubgroup('')
-    setNewGroupSubgroupError('')
-    setNewGroupNotificationsEnabled(false)
-    setNewGroupContacts([{ id: crypto.randomUUID(), value: '' }])
-    setNewGroupContactErrors([''])
-  }
-
-  const handleContactChange = (index: number, val: string) => {
-    setNewGroupContacts((prev) =>
-      prev.map((c, i) => (i === index ? { ...c, value: val } : c)),
-    )
-    const updated = [...newGroupContactErrors]
-    updated[index] = !val.trim() || emailRegex.test(val) ? '' : 'Invalid email'
-    setNewGroupContactErrors(updated)
-  }
-
-  const handleCreateGroupSubmit = () => {
-    if (!newGroupSubgroup.trim()) {
-      setNewGroupSubgroupError('Group is required')
-      return
-    }
-
-    if (newGroupNotificationsEnabled) {
-      const nextContactErrors: string[] = newGroupContacts.map((contact) => {
-        if (!contact.value.trim()) {
-          return ''
-        }
-
-        return emailRegex.test(contact.value) ? '' : 'Invalid email'
-      })
-
-      const hasValidContact = newGroupContacts.some(
-        (contact) => contact.value.trim() && emailRegex.test(contact.value),
-      )
-      if (!hasValidContact) {
-        nextContactErrors[0] = 'At least one valid email is required'
-      }
-
-      setNewGroupContactErrors(nextContactErrors)
-
-      const hasContactError = nextContactErrors.some((error) => !!error)
-      if (hasContactError) {
-        return
-      }
-    }
-
-    const notifications = {
-      enabled: newGroupNotificationsEnabled,
-      contacts: newGroupNotificationsEnabled
-        ? newGroupContacts
-            .filter((c) => c.value.trim() && emailRegex.test(c.value))
-            .map((c) => c.value)
-        : [],
-    }
-    const payload = [
-      ...(groups ?? []),
-      {
-        date: today,
-        group: tenantName,
-        type: 'PROJECT',
-        subgroup: newGroupSubgroup.trim(),
-        notifications,
-      },
-    ]
-    onGroupSaving?.(true)
-    groupsMutation.mutate(
-      { tenantId, data: payload },
-      {
-        onSuccess: () => {
-          toast.success('Group created successfully!')
-          onChange(newGroupSubgroup.trim())
-          resetCreateGroup()
-          onGroupSaving?.(false)
-        },
-        onError: (err) => {
-          toast.error(`Failed to create group: ${err.message}`)
-          onGroupSaving?.(false)
-        },
-      },
-    )
   }
 
   return (
@@ -165,9 +64,7 @@ const GroupSelector = ({
 
       <button
         type="button"
-        onClick={() =>
-          showCreateGroup ? resetCreateGroup() : setShowCreateGroup(true)
-        }
+        onClick={handleToggleCreateGroup}
         className="flex items-center gap-1 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer mt-2"
       >
         {showCreateGroup ? (
@@ -184,135 +81,13 @@ const GroupSelector = ({
       </button>
 
       {showCreateGroup && (
-        <div className="border border-line rounded-lg px-4 py-3 flex flex-col gap-3 mt-1 animate-fade-in">
-          <div className="flex flex-col">
-            <label className="text-sm font-medium text-body mb-1.5">
-              Group <span className="required">*</span>
-            </label>
-            <input
-              type="text"
-              value={newGroupSubgroup}
-              onChange={(e) => {
-                setNewGroupSubgroup(e.target.value)
-                if (e.target.value.trim()) setNewGroupSubgroupError('')
-              }}
-              placeholder="Enter group name"
-              className={
-                newGroupSubgroupError
-                  ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
-                  : ''
-              }
-            />
-            {newGroupSubgroupError && (
-              <span className="text-xs text-red-500 mt-1">
-                {newGroupSubgroupError}
-              </span>
-            )}
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <label className="flex items-center gap-3 cursor-pointer">
-              <input
-                type="checkbox"
-                className="toggle toggle-brand"
-                checked={newGroupNotificationsEnabled}
-                onChange={() =>
-                  setNewGroupNotificationsEnabled((prev) => !prev)
-                }
-              />
-              <p className="text-sm font-semibold text-body">
-                {newGroupNotificationsEnabled
-                  ? 'Notifications enabled'
-                  : 'Notifications disabled'}
-              </p>
-            </label>
-
-            {newGroupNotificationsEnabled && (
-              <div className="flex flex-col gap-2 animate-fade-in">
-                <p className="text-sm font-medium text-body">
-                  Contact Emails <span className="required">*</span>
-                </p>
-                {newGroupContacts.map((contact, index) => (
-                  <div key={contact.id} className="flex items-start gap-1">
-                    <div className="flex flex-col flex-1">
-                      <input
-                        type="email"
-                        value={contact.value}
-                        onChange={(e) =>
-                          handleContactChange(index, e.target.value)
-                        }
-                        placeholder="Enter contact email"
-                        className={
-                          newGroupContactErrors[index]
-                            ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
-                            : ''
-                        }
-                      />
-                      {newGroupContactErrors[index] && (
-                        <span className="text-xs text-red-500 mt-1">
-                          {newGroupContactErrors[index]}
-                        </span>
-                      )}
-                    </div>
-                    {newGroupContacts.length > 1 && (
-                      <div className="mt-1">
-                        <IconButton
-                          icon={<TrashIcon className="size-4.5" />}
-                          label="Remove contact"
-                          onClick={() =>
-                            setNewGroupContacts((prev) =>
-                              prev.filter((_, i) => i !== index),
-                            )
-                          }
-                          className="text-red-600 hover:bg-red-50"
-                        />
-                      </div>
-                    )}
-                  </div>
-                ))}
-                <button
-                  type="button"
-                  onClick={() => {
-                    setNewGroupContacts((prev) => [
-                      ...prev,
-                      { id: crypto.randomUUID(), value: '' },
-                    ])
-                    setNewGroupContactErrors((prev) => [...prev, ''])
-                  }}
-                  className="flex items-center gap-1.5 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer"
-                >
-                  <PlusIcon className="size-4" />
-                  Add another email
-                </button>
-              </div>
-            )}
-          </div>
-
-          <div className="flex items-center gap-3">
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={handleCreateGroupSubmit}
-              disabled={groupsMutation.isPending}
-            >
-              {groupsMutation.isPending ? (
-                <>
-                  <LoadingSpinner size="xs" />
-                  Creating...
-                </>
-              ) : (
-                'Create Group'
-              )}
-            </Button>
-            <button
-              type="button"
-              onClick={resetCreateGroup}
-              className="text-sm text-muted hover:text-body transition-colors cursor-pointer"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        <GroupCreationPanel
+          tenantId={tenantId}
+          tenantName={tenantName}
+          onSuccess={handleCreateGroupSuccess}
+          onCancel={() => setShowCreateGroup(false)}
+          onGroupSaving={onGroupSaving}
+        />
       )}
     </div>
   )

--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -83,12 +83,13 @@ const TenantTopology = () => {
         className="mb-4"
       />
 
-      {activeTab === 'endpoints' && (
+      <div className={activeTab === 'endpoints' ? 'block' : 'hidden'}>
         <TopologyEndpoints tenantId={tenantId} onEdit={setEditingEndpoint} />
-      )}
-      {activeTab === 'groups' && (
+      </div>
+
+      <div className={activeTab === 'groups' ? 'block' : 'hidden'}>
         <TopologyGroups tenantId={tenantId} onEdit={setEditingGroup} />
-      )}
+      </div>
     </div>
   )
 }

--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
 import { useGetUserTenantById } from '@/hooks/useTenants'
@@ -7,6 +7,9 @@ import {
   useCreateTopologyEndpointMutation,
 } from '@/hooks/useTopology'
 import Button from '@/components/Button'
+import { getLatestTopologyDate } from './utils/topologyDateHelpers'
+import { sortByField } from './utils/topologySortHelpers'
+import { useTopologyListState } from './hooks/useTopologyListState'
 import IconButton from '@/components/IconButton'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import SearchInput from '@/components/SearchInput'
@@ -22,8 +25,7 @@ import ErrorDisplay from '@/components/ErrorDisplay'
 import SelectDropdown from '@/components/SelectDropdown'
 import type { EndpointTopologyItem } from '@/types/topology'
 
-type SortColumn = 'service' | 'group' | 'monitored'
-type DateMode = 'latest' | 'custom'
+type SortColumn = 'service' | 'group' | 'tags.monitored'
 
 const pageSize = 15
 
@@ -34,34 +36,43 @@ interface TopologyEndpointsProps {
 
 const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
   const { data: tenantData } = useGetUserTenantById(tenantId)
-
-  const [searchInput, setSearchInput] = useState('')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [currentPage, setCurrentPage] = useState(1)
-  const [sortColumn, setSortColumn] = useState<SortColumn>('monitored')
-  const [sortAsc, setSortAsc] = useState(false)
-  const [dateMode, setDateMode] = useState<DateMode>('latest')
-  const [committedDate, setCommittedDate] = useState('')
-  const dateInputRef = useRef<HTMLInputElement>(null)
   const [monitoredFilter, setMonitoredFilter] = useState<
-    'monitored' | 'not_monitored'
-  >('monitored')
+    'all' | 'monitored' | 'not_monitored'
+  >('all')
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [endpointToDelete, setEndpointToDelete] = useState<{
     endpoint: EndpointTopologyItem
     index: number
   } | null>(null)
 
-  const effectiveDate = dateMode === 'latest' ? '' : committedDate
+  const { data: latestEndpoints } = useGetTopologyEndpoints(tenantId, '')
+  const latestDate = getLatestTopologyDate(latestEndpoints)
+
+  const {
+    searchInput,
+    setSearchInput,
+    currentPage,
+    setCurrentPage,
+    sortColumn,
+    sortAsc,
+    dateMode,
+    dateInput,
+    committedDate,
+    showActions,
+    handleDateInputChange,
+    handleDateModeChange,
+    handleSortChange,
+    handleSearchClear,
+  } = useTopologyListState<SortColumn>({
+    latestDate,
+  })
 
   const {
     data: endpoints,
     isLoading,
     isFetching,
     error,
-  } = useGetTopologyEndpoints(tenantId, effectiveDate)
-
-  const { data: latestEndpoints } = useGetTopologyEndpoints(tenantId, '')
+  } = useGetTopologyEndpoints(tenantId, committedDate)
 
   const deleteMutation = useCreateTopologyEndpointMutation()
 
@@ -99,66 +110,6 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
     )
   }
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setSearchQuery(searchInput)
-      setCurrentPage(1)
-    }, 500)
-    return () => clearTimeout(timer)
-  }, [searchInput])
-
-  useEffect(() => {
-    const input = dateInputRef.current
-    if (!input) return
-
-    const handleChange = (e: Event) => {
-      const value = (e.target as HTMLInputElement).value
-      setCommittedDate(value)
-      setCurrentPage(1)
-    }
-
-    input.addEventListener('change', handleChange)
-    return () => input.removeEventListener('change', handleChange)
-  }, [dateMode])
-
-  const latestDate = latestEndpoints?.length
-    ? latestEndpoints.reduce(
-        (max, e) => (e.date > max ? e.date : max),
-        latestEndpoints[0].date,
-      )
-    : ''
-
-  const showActions =
-    dateMode === 'latest' ||
-    (dateMode === 'custom' && committedDate === latestDate && !!latestDate)
-
-  const handleDateModeChange = (mode: string) => {
-    setDateMode(mode as DateMode)
-    if (mode === 'custom') {
-      if (dateInputRef.current) {
-        dateInputRef.current.value = latestDate
-      }
-      setCommittedDate(latestDate)
-    }
-    setCurrentPage(1)
-  }
-
-  const handleSortChange = (column: SortColumn) => {
-    if (sortColumn === column) {
-      setSortAsc((prev) => !prev)
-    } else {
-      setSortColumn(column)
-      setSortAsc(true)
-    }
-    setCurrentPage(1)
-  }
-
-  const handleSearchClear = () => {
-    setSearchInput('')
-    setSearchQuery('')
-    setCurrentPage(1)
-  }
-
   const filtered = (endpoints ?? []).filter((e) => {
     if (monitoredFilter === 'monitored' && e.tags?.monitored !== '1') {
       return false
@@ -166,30 +117,19 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
     if (monitoredFilter === 'not_monitored' && e.tags?.monitored === '1') {
       return false
     }
-    if (!searchQuery) return true
-    const q = searchQuery.toLowerCase()
+    if (!searchInput) return true
+    const q = searchInput.toLowerCase()
     const monitoredLabel =
       e.tags?.monitored === '1' ? 'monitored' : 'not monitored'
     return (
       e.service.toLowerCase().includes(q) ||
       e.group.toLowerCase().includes(q) ||
+      e.hostname.toLowerCase().includes(q) ||
       monitoredLabel.includes(q)
     )
   })
 
-  const sorted = [...filtered].sort((a, b) => {
-    let cmp = 0
-    if (sortColumn === 'service') {
-      cmp = a.service.localeCompare(b.service)
-    } else if (sortColumn === 'group') {
-      cmp = a.group.localeCompare(b.group)
-    } else {
-      const aVal = a.tags?.monitored ?? '0'
-      const bVal = b.tags?.monitored ?? '0'
-      cmp = aVal.localeCompare(bVal)
-    }
-    return sortAsc ? cmp : -cmp
-  })
+  const sorted = sortByField(filtered, sortColumn, sortAsc)
 
   const totalPages = Math.ceil(sorted.length / pageSize)
   const paginated = sorted.slice(
@@ -204,7 +144,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           value={searchInput}
           onChange={setSearchInput}
           onClear={handleSearchClear}
-          placeholder="Search by service or group..."
+          placeholder="Search by service, URL or group..."
           className="!mb-0 flex-1 max-w-xs xl:max-w-none"
         />
         {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
@@ -221,9 +161,9 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           <div className="hidden xl:block h-8 w-px bg-line-strong me-1" />
           {dateMode === 'custom' && (
             <input
-              ref={dateInputRef}
               type="date"
-              defaultValue={latestDate || undefined}
+              value={dateInput}
+              onChange={handleDateInputChange}
               onClick={(e) => e.currentTarget.showPicker?.()}
               className="text-sm"
             />
@@ -240,10 +180,11 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           <SelectDropdown
             value={monitoredFilter}
             onChange={(value) => {
-              setMonitoredFilter(value as 'monitored' | 'not_monitored')
+              setMonitoredFilter(value as 'all' | 'monitored' | 'not_monitored')
               setCurrentPage(1)
             }}
             options={[
+              { value: 'all', label: 'All' },
               { value: 'monitored', label: 'Monitored' },
               { value: 'not_monitored', label: 'Not monitored' },
             ]}
@@ -276,9 +217,9 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
             </th>
             <th className={`${thBase} min-w-24`}>
               <SortableColumnHeader
-                isActive={sortColumn === 'monitored'}
+                isActive={sortColumn === 'tags.monitored'}
                 isAscending={sortAsc}
-                onClick={() => handleSortChange('monitored')}
+                onClick={() => handleSortChange('tags.monitored')}
               >
                 Monitored
               </SortableColumnHeader>

--- a/src/pages/tenant-topology/TopologyGroups.tsx
+++ b/src/pages/tenant-topology/TopologyGroups.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
 import { useGetUserTenantById } from '@/hooks/useTenants'
@@ -7,6 +7,9 @@ import {
   useCreateTopologyGroupsMutation,
 } from '@/hooks/useTopology'
 import Button from '@/components/Button'
+import { getLatestTopologyDate } from './utils/topologyDateHelpers'
+import { sortByField } from './utils/topologySortHelpers'
+import { useTopologyListState } from './hooks/useTopologyListState'
 import IconButton from '@/components/IconButton'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import SearchInput from '@/components/SearchInput'
@@ -22,7 +25,6 @@ import SelectDropdown from '@/components/SelectDropdown'
 import type { GroupTopologyItem } from '@/types/topology'
 
 type SortColumn = 'subgroup'
-type DateMode = 'latest' | 'custom'
 
 const pageSize = 15
 
@@ -33,31 +35,40 @@ interface TopologyGroupsProps {
 
 const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
   const { data: tenantData } = useGetUserTenantById(tenantId)
-
-  const [searchInput, setSearchInput] = useState('')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [currentPage, setCurrentPage] = useState(1)
-  const [sortColumn, setSortColumn] = useState<SortColumn>('subgroup')
-  const [sortAsc, setSortAsc] = useState(true)
-  const [dateMode, setDateMode] = useState<DateMode>('latest')
-  const [committedDate, setCommittedDate] = useState('')
-  const dateInputRef = useRef<HTMLInputElement>(null)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [groupToDelete, setGroupToDelete] = useState<{
     group: GroupTopologyItem
     index: number
   } | null>(null)
 
-  const effectiveDate = dateMode === 'latest' ? '' : committedDate
+  const { data: latestGroups } = useGetTopologyGroups(tenantId, '')
+  const latestDate = getLatestTopologyDate(latestGroups)
+
+  const {
+    searchInput,
+    setSearchInput,
+    currentPage,
+    setCurrentPage,
+    sortColumn,
+    sortAsc,
+    dateMode,
+    dateInput,
+    committedDate,
+    showActions,
+    handleDateInputChange,
+    handleDateModeChange,
+    handleSortChange,
+    handleSearchClear,
+  } = useTopologyListState<SortColumn>({
+    latestDate,
+  })
 
   const {
     data: groups,
     isLoading,
     isFetching,
     error,
-  } = useGetTopologyGroups(tenantId, effectiveDate)
-
-  const { data: latestGroups } = useGetTopologyGroups(tenantId, '')
+  } = useGetTopologyGroups(tenantId, committedDate)
 
   const deleteMutation = useCreateTopologyGroupsMutation()
 
@@ -95,75 +106,12 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
     )
   }
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setSearchQuery(searchInput)
-      setCurrentPage(1)
-    }, 500)
-    return () => clearTimeout(timer)
-  }, [searchInput])
-
-  useEffect(() => {
-    const input = dateInputRef.current
-    if (!input) return
-
-    const handleChange = (e: Event) => {
-      const value = (e.target as HTMLInputElement).value
-      setCommittedDate(value)
-      setCurrentPage(1)
-    }
-
-    input.addEventListener('change', handleChange)
-    return () => input.removeEventListener('change', handleChange)
-  }, [dateMode])
-
-  const latestDate = latestGroups?.length
-    ? latestGroups.reduce(
-        (max, g) => (g.date > max ? g.date : max),
-        latestGroups[0].date,
-      )
-    : ''
-
-  const showActions =
-    dateMode === 'latest' ||
-    (dateMode === 'custom' && committedDate === latestDate && !!latestDate)
-
-  const handleDateModeChange = (mode: string) => {
-    setDateMode(mode as DateMode)
-    if (mode === 'custom') {
-      if (dateInputRef.current) {
-        dateInputRef.current.value = latestDate
-      }
-      setCommittedDate(latestDate)
-    }
-    setCurrentPage(1)
-  }
-
-  const handleSortChange = (column: SortColumn) => {
-    if (sortColumn === column) {
-      setSortAsc((prev) => !prev)
-    } else {
-      setSortColumn(column)
-      setSortAsc(true)
-    }
-    setCurrentPage(1)
-  }
-
-  const handleSearchClear = () => {
-    setSearchInput('')
-    setSearchQuery('')
-    setCurrentPage(1)
-  }
-
   const filtered = (groups ?? []).filter((g) => {
-    if (!searchQuery) return true
-    return g.subgroup.toLowerCase().includes(searchQuery.toLowerCase())
+    if (!searchInput) return true
+    return g.subgroup.toLowerCase().includes(searchInput.toLowerCase())
   })
 
-  const sorted = [...filtered].sort((a, b) => {
-    const cmp = a.subgroup.localeCompare(b.subgroup)
-    return sortAsc ? cmp : -cmp
-  })
+  const sorted = sortByField(filtered, sortColumn, sortAsc)
 
   const totalPages = Math.ceil(sorted.length / pageSize)
   const paginated = sorted.slice(
@@ -186,9 +134,9 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
         <div className="flex items-center gap-3 shrink-0">
           {dateMode === 'custom' && (
             <input
-              ref={dateInputRef}
               type="date"
-              defaultValue={latestDate || undefined}
+              value={dateInput}
+              onChange={handleDateInputChange}
               onClick={(e) => e.currentTarget.showPicker?.()}
               className="text-sm"
             />
@@ -266,9 +214,9 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
               </td>
             </tr>
           ) : (
-            paginated.map((group) => (
+            paginated.map((group, index) => (
               <tr
-                key={group.subgroup}
+                key={`${group.subgroup}-${group.date}-${index}`}
                 className="hover:bg-surface-muted transition-colors"
               >
                 <td className={tdBase}>{group.subgroup}</td>

--- a/src/pages/tenant-topology/hooks/useTopologyListState.ts
+++ b/src/pages/tenant-topology/hooks/useTopologyListState.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react'
+
+type DateMode = 'latest' | 'custom'
+
+interface UseTopologyListStateOptions {
+  latestDate: string
+}
+
+export const useTopologyListState = <TSort extends string>({
+  latestDate,
+}: UseTopologyListStateOptions) => {
+  const [searchInput, setSearchInput] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [sortColumn, setSortColumn] = useState<TSort | null>(null)
+  const [sortAsc, setSortAsc] = useState(true)
+  const [dateMode, setDateMode] = useState<DateMode>('latest')
+  const [dateInput, setDateInput] = useState('')
+  const [committedDate, setCommittedDate] = useState('')
+
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [searchInput])
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setCommittedDate(dateInput)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [dateInput])
+
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [committedDate])
+
+  const showActions =
+    dateMode === 'latest' ||
+    (dateMode === 'custom' && committedDate === latestDate && !!latestDate)
+
+  const handleDateInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDateInput(e.target.value)
+  }
+
+  const handleDateModeChange = (mode: string) => {
+    setDateMode(mode as DateMode)
+    if (mode === 'custom') {
+      setDateInput(latestDate)
+      setCommittedDate(latestDate)
+    } else {
+      setCommittedDate('')
+    }
+    setCurrentPage(1)
+  }
+
+  const handleSortChange = (column: TSort) => {
+    if (sortColumn === column) {
+      setSortAsc((prev) => !prev)
+    } else {
+      setSortColumn(column)
+      setSortAsc(true)
+    }
+    setCurrentPage(1)
+  }
+
+  const handleSearchClear = () => {
+    setSearchInput('')
+    setCurrentPage(1)
+  }
+
+  return {
+    searchInput,
+    setSearchInput,
+    currentPage,
+    setCurrentPage,
+    sortColumn,
+    sortAsc,
+    dateMode,
+    dateInput,
+    committedDate,
+    showActions,
+    handleDateInputChange,
+    handleDateModeChange,
+    handleSortChange,
+    handleSearchClear,
+  }
+}

--- a/src/pages/tenant-topology/utils/topologyDateHelpers.ts
+++ b/src/pages/tenant-topology/utils/topologyDateHelpers.ts
@@ -1,0 +1,14 @@
+type DateItem = {
+  date: string
+}
+
+export const getLatestTopologyDate = (items?: DateItem[]): string => {
+  if (!items?.length) {
+    return ''
+  }
+
+  return items.reduce(
+    (max, item) => (item.date > max ? item.date : max),
+    items[0].date,
+  )
+}

--- a/src/pages/tenant-topology/utils/topologySortHelpers.ts
+++ b/src/pages/tenant-topology/utils/topologySortHelpers.ts
@@ -1,0 +1,32 @@
+const getFieldValue = (item: unknown, propertyPath: string): string => {
+  const value = propertyPath.split('.').reduce<unknown>((acc, propertyKey) => {
+    if (!acc || typeof acc !== 'object') {
+      return undefined
+    }
+
+    return (acc as Record<string, unknown>)[propertyKey]
+  }, item)
+
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  return String(value)
+}
+
+export const sortByField = <T>(
+  items: T[],
+  sortField: string | null,
+  sortAsc: boolean,
+): T[] => {
+  if (!sortField) {
+    return items
+  }
+
+  return [...items].sort((a, b) => {
+    const comparisonResult = getFieldValue(a, sortField).localeCompare(
+      getFieldValue(b, sortField),
+    )
+    return sortAsc ? comparisonResult : -comparisonResult
+  })
+}

--- a/src/pages/tenant-topology/utils/topologyValidation.ts
+++ b/src/pages/tenant-topology/utils/topologyValidation.ts
@@ -1,0 +1,40 @@
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+type ContactValue = {
+  value: string
+}
+
+export const isValidEmail = (email: string): boolean => {
+  return emailRegex.test(email)
+}
+
+export const getValidContactEmails = (contacts: ContactValue[]): string[] => {
+  return contacts
+    .filter((contact) => contact.value.trim() && isValidEmail(contact.value))
+    .map((contact) => contact.value)
+}
+
+export const getContactValidationErrors = (
+  contacts: ContactValue[],
+  requireAtLeastOneValid: boolean = false,
+): string[] => {
+  const errors: string[] = contacts.map((contact) => {
+    if (!contact.value.trim()) {
+      return ''
+    }
+
+    return isValidEmail(contact.value) ? '' : 'Invalid email'
+  })
+
+  if (requireAtLeastOneValid) {
+    const hasValidContact = contacts.some(
+      (contact) => contact.value.trim() && isValidEmail(contact.value),
+    )
+
+    if (!hasValidContact && errors.length > 0) {
+      errors[0] = 'At least one valid email is required'
+    }
+  }
+
+  return errors
+}


### PR DESCRIPTION
This PR refactors the topology components into smaller components and extract shared logic into reusable hooks and utility functions.

- Extracted shared topology logic into reusable hooks and utility helpers
- Refactored tenant-topology components into smaller, clearer ones
- Updated topology tabs to stay mounted between panels to preserve tab state
- Changed sorting to use API order by default and apply  after the user selects a sort column
- Updated the monitored filter in TopologyEndpoints to include an All option as the default
