### PR TITLE
[ARGO-5488] - Add labels input to topology endpoint form

### DIFF
--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -11,6 +11,7 @@ import { toast } from 'sonner'
 import NotificationsSection from './NotificationsSection'
 import GroupSelector from './GroupSelector'
 import KeyValueInput from './KeyValueInput'
+import LabelsInput from './LabelsInput'
 import type { Label } from './KeyValueInput'
 import type { Contact } from './NotificationsSection'
 import PageHeader from '@/components/PageHeader'
@@ -20,7 +21,7 @@ import ErrorDisplay from '@/components/ErrorDisplay'
 import SelectDropdown from '@/components/SelectDropdown'
 
 const sectionClass =
-  'grid grid-cols-1 md:grid-cols-[360px_1fr] gap-4 md:gap-8 mb-7 animate-fade-in'
+  'grid grid-cols-1 lg:grid-cols-[360px_1fr] gap-2 lg:gap-8 mb-6 animate-fade-in'
 const sectionContentClass =
   'bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-2'
 
@@ -31,9 +32,10 @@ const today = new Date().toISOString().split('T')[0]
 interface FormData {
   service: string
   hostname: string
+  tags: string[]
   group: string
   monitored: boolean
-  labels: Label[]
+  metadata: Label[]
   notificationsEnabled: boolean
   contacts: Contact[]
 }
@@ -78,13 +80,20 @@ const CreateTopologyEndpoint = ({
 
   const [formData, setFormData] = useState<FormData>(() => {
     if (editingEndpoint) {
+      const labelsTag = editingEndpoint.tags?.labels ?? ''
       return {
         service: editingEndpoint.service,
         hostname: editingEndpoint.hostname,
+        tags: labelsTag
+          ? labelsTag
+              .split(',')
+              .map((t) => t.trim())
+              .filter(Boolean)
+          : [],
         group: editingEndpoint.group,
         monitored: editingEndpoint.tags?.monitored === '1',
-        labels: Object.entries(editingEndpoint.tags ?? {})
-          .filter(([key]) => key !== 'monitored')
+        metadata: Object.entries(editingEndpoint.tags ?? {})
+          .filter(([key]) => key !== 'monitored' && key !== 'labels')
           .map(([key, value]) => ({ id: crypto.randomUUID(), key, value })),
         notificationsEnabled: editingEndpoint.notifications?.enabled ?? false,
         contacts: editingEndpoint.notifications?.contacts?.length
@@ -98,9 +107,10 @@ const CreateTopologyEndpoint = ({
     return {
       service: '',
       hostname: '',
+      tags: [],
       group: '',
       monitored: true,
-      labels: [],
+      metadata: [],
       notificationsEnabled: false,
       contacts: [{ id: crypto.randomUUID(), value: '' }],
     }
@@ -189,6 +199,14 @@ const CreateTopologyEndpoint = ({
       hasError = true
     }
 
+    if (
+      formData.metadata.some(
+        (label) => label.key.trim().toLowerCase() === 'labels',
+      )
+    ) {
+      hasError = true
+    }
+
     if (formData.notificationsEnabled) {
       const hasValidContact = formData.contacts.some(
         (c) => c.value.trim() && emailRegex.test(c.value),
@@ -215,8 +233,11 @@ const CreateTopologyEndpoint = ({
       hostname: formData.hostname.trim(),
       tags: {
         monitored: formData.monitored ? '1' : '0',
+        ...(formData.tags.length > 0
+          ? { labels: formData.tags.join(',') }
+          : {}),
         ...Object.fromEntries(
-          formData.labels
+          formData.metadata
             .filter((label) => label.key.trim())
             .map((label) => [label.key.trim(), label.value.trim()]),
         ),
@@ -333,7 +354,7 @@ const CreateTopologyEndpoint = ({
         <div className={sectionContentClass}>
           {/* Service type */}
           <div className="flex flex-col">
-            <label className="text-sm font-medium text-body mb-1.5">
+            <label className="text-sm font-medium text-body mb-1">
               Service Type <span className="required">*</span>
             </label>
             {isLoadingTypes ? (
@@ -371,7 +392,7 @@ const CreateTopologyEndpoint = ({
 
           {/* Hostname / URL */}
           <div className="flex flex-col">
-            <label className="text-sm font-medium text-body mb-1.5">
+            <label className="text-sm font-medium text-body mb-1">
               URL <span className="required">*</span>
             </label>
             <input
@@ -391,6 +412,18 @@ const CreateTopologyEndpoint = ({
                 {errors.hostname}
               </span>
             )}
+          </div>
+
+          {/* Labels */}
+          <div className="flex flex-col">
+            <label className="text-sm font-medium text-body mb-1">Labels</label>
+            <LabelsInput
+              tags={formData.tags}
+              onChange={(tags) => setFormData((prev) => ({ ...prev, tags }))}
+            />
+            <p className="text-xs text-muted mt-1">
+              Press 'Enter' or 'Space' to add a label
+            </p>
           </div>
         </div>
       </div>
@@ -459,20 +492,26 @@ const CreateTopologyEndpoint = ({
         />
       </div>
 
-      {/* Labels */}
+      {/* Metadata */}
       <div className={sectionClass}>
         <div>
-          <p className="section-title">Labels</p>
+          <p className="section-title">Metadata</p>
           <p className="section-description">
             Add custom key-value metadata to this endpoint
           </p>
         </div>
         <div className={sectionContentClass}>
           <KeyValueInput
-            labels={formData.labels}
-            onLabelsChange={(labels) =>
-              setFormData((prev) => ({ ...prev, labels }))
+            labels={formData.metadata}
+            onLabelsChange={(metadata) =>
+              setFormData((prev) => ({ ...prev, metadata }))
             }
+            disallowedKeys={[
+              {
+                key: 'labels',
+                message: '"labels" cannot be used as a key',
+              },
+            ]}
           />
         </div>
       </div>

--- a/src/pages/tenant-topology/CreateTopologyGroup.tsx
+++ b/src/pages/tenant-topology/CreateTopologyGroup.tsx
@@ -143,7 +143,7 @@ const CreateTopologyGroup = ({
     let hasError = false
 
     if (!formData.subgroup.trim()) {
-      newErrors.subgroup = 'Subgroup is required'
+      newErrors.subgroup = 'Group is required'
       hasError = true
     }
 
@@ -268,37 +268,20 @@ const CreateTopologyGroup = ({
         <div>
           <p className="section-title">Group Details</p>
           <p className="section-description">
-            Define the group and subgroup for this topology entry
+            Define the details for this topology entry
           </p>
         </div>
         <div className={sectionContentClass}>
           <div className="flex flex-col">
-            <label className="text-sm font-medium text-body mb-1.5">
-              Group
-            </label>
-            <input
-              type="text"
-              value={tenantData?.info.name ?? ''}
-              disabled
-              readOnly
-            />
-          </div>
-
-          <div className="flex flex-col">
-            <label className="text-sm font-medium text-body mb-1.5">Type</label>
-            <input type="text" value="PROJECT" disabled readOnly />
-          </div>
-
-          <div className="flex flex-col">
-            <label className="text-sm font-medium text-body mb-1.5">
-              Subgroup <span className="required">*</span>
+            <label className="text-sm font-medium text-body mb-1">
+              Group <span className="required">*</span>
             </label>
             <input
               type="text"
               name="subgroup"
               value={formData.subgroup}
               onChange={handleSubgroupChange}
-              placeholder="Enter subgroup name"
+              placeholder="Enter group name"
               className={
                 errors.subgroup
                   ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'

--- a/src/pages/tenant-topology/GroupSelector.tsx
+++ b/src/pages/tenant-topology/GroupSelector.tsx
@@ -72,7 +72,7 @@ const GroupSelector = ({
 
   const handleCreateGroupSubmit = () => {
     if (!newGroupSubgroup.trim()) {
-      setNewGroupSubgroupError('Subgroup is required')
+      setNewGroupSubgroupError('Group is required')
       return
     }
 
@@ -138,7 +138,7 @@ const GroupSelector = ({
 
   return (
     <div className="flex flex-col">
-      <label className="text-sm font-medium text-body mb-1.5">
+      <label className="text-sm font-medium text-body mb-1">
         Group <span className="required">*</span>
       </label>
 
@@ -187,7 +187,7 @@ const GroupSelector = ({
         <div className="border border-line rounded-lg px-4 py-3 flex flex-col gap-3 mt-1 animate-fade-in">
           <div className="flex flex-col">
             <label className="text-sm font-medium text-body mb-1.5">
-              Subgroup <span className="required">*</span>
+              Group <span className="required">*</span>
             </label>
             <input
               type="text"
@@ -196,7 +196,7 @@ const GroupSelector = ({
                 setNewGroupSubgroup(e.target.value)
                 if (e.target.value.trim()) setNewGroupSubgroupError('')
               }}
-              placeholder="Enter subgroup name"
+              placeholder="Enter group name"
               className={
                 newGroupSubgroupError
                   ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'

--- a/src/pages/tenant-topology/KeyValueInput.tsx
+++ b/src/pages/tenant-topology/KeyValueInput.tsx
@@ -7,12 +7,22 @@ export interface Label {
   value: string
 }
 
+interface DisallowedKey {
+  key: string
+  message: string
+}
+
 interface KeyValueInputProps {
   labels: Label[]
   onLabelsChange: (labels: Label[]) => void
+  disallowedKeys?: DisallowedKey[]
 }
 
-const KeyValueInput = ({ labels, onLabelsChange }: KeyValueInputProps) => {
+const KeyValueInput = ({
+  labels,
+  onLabelsChange,
+  disallowedKeys,
+}: KeyValueInputProps) => {
   const handleAdd = () => {
     onLabelsChange([...labels, { id: crypto.randomUUID(), key: '', value: '' }])
   }
@@ -33,43 +43,69 @@ const KeyValueInput = ({ labels, onLabelsChange }: KeyValueInputProps) => {
     onLabelsChange(labels.filter((_, i) => i !== index))
   }
 
+  const getKeyError = (key: string): string => {
+    if (!disallowedKeys || !key.trim()) {
+      return ''
+    }
+    const match = disallowedKeys.find(
+      (dk) => dk.key.toLowerCase() === key.trim().toLowerCase(),
+    )
+    return match?.message ?? ''
+  }
+
   return (
     <>
       {labels.length === 0 && (
-        <p className="text-sm text-subtle italic">No labels added</p>
+        <p className="text-sm text-subtle italic">No metadata added</p>
       )}
-      {labels.map((label, index) => (
-        <div key={label.id} className="flex items-center gap-2">
-          <input
-            type="text"
-            value={label.key}
-            onChange={(e) => handleChange(index, 'key', e.target.value)}
-            placeholder="Key"
-            className="flex-1"
-          />
-          <span className="text-muted text-sm shrink-0">→</span>
-          <input
-            type="text"
-            value={label.value}
-            onChange={(e) => handleChange(index, 'value', e.target.value)}
-            placeholder="Value"
-            className="flex-1"
-          />
-          <IconButton
-            icon={<TrashIcon className="size-4.5" />}
-            label="Remove label"
-            onClick={() => handleRemove(index)}
-            className="text-red-600 hover:bg-red-50 shrink-0"
-          />
-        </div>
-      ))}
+      {labels.map((label, index) => {
+        const keyError = getKeyError(label.key)
+        return (
+          <div key={label.id} className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <div className="flex-1 flex flex-col gap-1">
+                <input
+                  type="text"
+                  value={label.key}
+                  onChange={(e) => handleChange(index, 'key', e.target.value)}
+                  placeholder="Key"
+                  className={
+                    keyError
+                      ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
+                      : ''
+                  }
+                />
+                {keyError && (
+                  <span className="text-xs text-red-500">{keyError}</span>
+                )}
+              </div>
+              <span className="text-muted text-sm shrink-0 self-start mt-2">
+                →
+              </span>
+              <input
+                type="text"
+                value={label.value}
+                onChange={(e) => handleChange(index, 'value', e.target.value)}
+                placeholder="Value"
+                className="flex-1 self-start"
+              />
+              <IconButton
+                icon={<TrashIcon className="size-4.5" />}
+                label="Remove metadata"
+                onClick={() => handleRemove(index)}
+                className="text-red-600 hover:bg-red-50 shrink-0 self-start mt-0.5"
+              />
+            </div>
+          </div>
+        )
+      })}
       <button
         type="button"
         onClick={handleAdd}
         className="flex items-center gap-1.5 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer mt-1"
       >
         <PlusIcon className="size-4" />
-        Add label
+        Add metadata
       </button>
     </>
   )

--- a/src/pages/tenant-topology/LabelsInput.tsx
+++ b/src/pages/tenant-topology/LabelsInput.tsx
@@ -1,0 +1,85 @@
+import { useState, type KeyboardEvent } from 'react'
+import { XMarkIcon } from '@heroicons/react/16/solid'
+
+interface LabelsInputProps {
+  tags: string[]
+  onChange: (tags: string[]) => void
+}
+
+const LabelsInput = ({ tags, onChange }: LabelsInputProps) => {
+  const [inputValue, setInputValue] = useState('')
+  const [inputError, setInputError] = useState('')
+
+  const addTag = (value: string) => {
+    const trimmed = value.trim()
+    if (!trimmed || tags.includes(trimmed)) {
+      setInputValue('')
+      setInputError('')
+      return
+    }
+    onChange([...tags, trimmed])
+    setInputValue('')
+    setInputError('')
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      addTag(inputValue)
+    } else if (e.key === 'Backspace' && !inputValue && tags.length > 0) {
+      onChange(tags.slice(0, -1))
+    }
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    if (value.includes(',')) {
+      setInputError('Commas are not allowed in labels')
+      return
+    }
+    setInputError('')
+    setInputValue(value)
+  }
+
+  const handleRemove = (index: number) => {
+    onChange(tags.filter((_, i) => i !== index))
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex flex-wrap gap-1.5 items-center border border-line-strong rounded-md px-3 py-1.5 bg-white focus-within:ring-2 focus-within:ring-brand/10 focus-within:border-brand cursor-text">
+        {tags.map((tag, index) => (
+          <span
+            key={`${tag}-${index}`}
+            className="inline-flex items-center gap-1 bg-brand-muted text-brand text-xs font-medium px-2 py-0.5 rounded-full"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => handleRemove(index)}
+              className="text-brand/70 hover:text-brand-strong hover:bg-brand/20 rounded-full p-px transition-colors cursor-pointer"
+              aria-label={`Remove ${tag}`}
+            >
+              <XMarkIcon className="size-4" />
+            </button>
+          </span>
+        ))}
+        <input
+          type="text"
+          value={inputValue}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={
+            tags.length === 0
+              ? `Type and press 'Enter' or 'Space' to add...`
+              : ''
+          }
+          className="flex-1 min-w-[120px] !border-transparent !ring-0 p-0 text-sm bg-transparent"
+        />
+      </div>
+      {inputError && <span className="text-xs text-red-500">{inputError}</span>}
+    </div>
+  )
+}
+
+export default LabelsInput

--- a/src/pages/tenant-topology/NotificationsSection.tsx
+++ b/src/pages/tenant-topology/NotificationsSection.tsx
@@ -35,7 +35,7 @@ const NotificationsSection = ({
           Enable email notifications for this {subtitle}
         </p>
       </div>
-      <div className="bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-2">
+      <div className="bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-1">
         <label className="flex items-center gap-3 cursor-pointer">
           <input
             type="checkbox"
@@ -51,50 +51,52 @@ const NotificationsSection = ({
         </label>
 
         {enabled && (
-          <div className="flex flex-col gap-2 mt-1 animate-fade-in">
-            <p className="text-sm font-medium text-body">
+          <div className="mt-2">
+            <p className="text-sm font-medium text-body mb-1">
               Contact Emails <span className="required">*</span>
             </p>
-            {contacts.map((contact, index) => (
-              <div key={contact.id} className="flex items-start gap-1">
-                <div className="flex flex-col flex-1">
-                  <input
-                    type="email"
-                    value={contact.value}
-                    onChange={(e) => onContactChange(index, e.target.value)}
-                    placeholder="Enter contact email"
-                    className={
-                      contactErrors[index]
-                        ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
-                        : ''
-                    }
-                  />
-                  {contactErrors[index] && (
-                    <span className="text-xs text-red-500 mt-1">
-                      {contactErrors[index]}
-                    </span>
+            <div className="flex flex-col gap-2 animate-fade-in">
+              {contacts.map((contact, index) => (
+                <div key={contact.id} className="flex items-start gap-1">
+                  <div className="flex flex-col flex-1">
+                    <input
+                      type="email"
+                      value={contact.value}
+                      onChange={(e) => onContactChange(index, e.target.value)}
+                      placeholder="Enter contact email"
+                      className={
+                        contactErrors[index]
+                          ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
+                          : ''
+                      }
+                    />
+                    {contactErrors[index] && (
+                      <span className="text-xs text-red-500 mt-1">
+                        {contactErrors[index]}
+                      </span>
+                    )}
+                  </div>
+                  {contacts.length > 1 && (
+                    <div className="mt-1">
+                      <IconButton
+                        icon={<TrashIcon className="size-4.5" />}
+                        label="Remove contact"
+                        onClick={() => onRemoveContact(index)}
+                        className="text-red-600 hover:bg-red-50"
+                      />
+                    </div>
                   )}
                 </div>
-                {contacts.length > 1 && (
-                  <div className="mt-1">
-                    <IconButton
-                      icon={<TrashIcon className="size-4.5" />}
-                      label="Remove contact"
-                      onClick={() => onRemoveContact(index)}
-                      className="text-red-600 hover:bg-red-50"
-                    />
-                  </div>
-                )}
-              </div>
-            ))}
-            <button
-              type="button"
-              onClick={onAddContact}
-              className="flex items-center gap-1.5 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer"
-            >
-              <PlusIcon className="size-4" />
-              Add another email
-            </button>
+              ))}
+              <button
+                type="button"
+                onClick={onAddContact}
+                className="flex items-center gap-1.5 text-sm text-brand hover:text-brand-strong transition-colors w-fit cursor-pointer"
+              >
+                <PlusIcon className="size-4" />
+                Add another email
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -47,14 +47,17 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
     'monitored' | 'not_monitored'
   >('monitored')
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [endpointToDelete, setEndpointToDelete] =
-    useState<EndpointTopologyItem | null>(null)
+  const [endpointToDelete, setEndpointToDelete] = useState<{
+    endpoint: EndpointTopologyItem
+    index: number
+  } | null>(null)
 
   const effectiveDate = dateMode === 'latest' ? '' : committedDate
 
   const {
     data: endpoints,
     isLoading,
+    isFetching,
     error,
   } = useGetTopologyEndpoints(tenantId, effectiveDate)
 
@@ -62,8 +65,8 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
 
   const deleteMutation = useCreateTopologyEndpointMutation()
 
-  const handleDeleteClick = (endpoint: EndpointTopologyItem) => {
-    setEndpointToDelete(endpoint)
+  const handleDeleteClick = (endpoint: EndpointTopologyItem, index: number) => {
+    setEndpointToDelete({ endpoint, index })
     setDeleteDialogOpen(true)
   }
 
@@ -71,7 +74,11 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
     if (!endpointToDelete) return
 
     const updatedEndpoints = (endpoints ?? []).filter(
-      (endpoint) => endpoint.hostname !== endpointToDelete.hostname,
+      (endpoint, index) =>
+        !(
+          index === endpointToDelete.index &&
+          endpoint.hostname === endpointToDelete.endpoint.hostname
+        ),
     )
 
     deleteMutation.mutate(
@@ -281,7 +288,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
-          {isLoading ? (
+          {isLoading || isFetching ? (
             <tr>
               <td colSpan={showActions ? 6 : 5} className="py-12">
                 <div className="flex justify-center">
@@ -353,7 +360,12 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
                       <IconButton
                         icon={<TrashIcon className="size-4 md:size-5" />}
                         label="Delete"
-                        onClick={() => handleDeleteClick(endpoint)}
+                        onClick={() => {
+                          const indexToDelete = (endpoints ?? []).indexOf(
+                            endpoint,
+                          )
+                          handleDeleteClick(endpoint, indexToDelete)
+                        }}
                         className="text-red-600 hover:bg-red-50 !p-1"
                       />
                     </div>
@@ -380,7 +392,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
         message={
           <>
             Are you sure you want to delete the endpoint with URL{' '}
-            <strong>{endpointToDelete?.hostname}</strong> ?
+            <strong>{endpointToDelete?.endpoint.hostname}</strong> ?
             <br />
             <span className="text-amber-600 font-medium">
               This action cannot be undone.

--- a/src/pages/tenant-topology/TopologyGroups.tsx
+++ b/src/pages/tenant-topology/TopologyGroups.tsx
@@ -43,15 +43,17 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
   const [committedDate, setCommittedDate] = useState('')
   const dateInputRef = useRef<HTMLInputElement>(null)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [groupToDelete, setGroupToDelete] = useState<GroupTopologyItem | null>(
-    null,
-  )
+  const [groupToDelete, setGroupToDelete] = useState<{
+    group: GroupTopologyItem
+    index: number
+  } | null>(null)
 
   const effectiveDate = dateMode === 'latest' ? '' : committedDate
 
   const {
     data: groups,
     isLoading,
+    isFetching,
     error,
   } = useGetTopologyGroups(tenantId, effectiveDate)
 
@@ -59,8 +61,8 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
 
   const deleteMutation = useCreateTopologyGroupsMutation()
 
-  const handleDeleteClick = (group: GroupTopologyItem) => {
-    setGroupToDelete(group)
+  const handleDeleteClick = (group: GroupTopologyItem, index: number) => {
+    setGroupToDelete({ group, index })
     setDeleteDialogOpen(true)
   }
 
@@ -68,7 +70,11 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
     if (!groupToDelete) return
 
     const updatedGroups = (groups ?? []).filter(
-      (g) => g.subgroup !== groupToDelete.subgroup,
+      (group, index) =>
+        !(
+          index === groupToDelete.index &&
+          group.subgroup === groupToDelete.group.subgroup
+        ),
     )
 
     deleteMutation.mutate(
@@ -173,7 +179,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
             value={searchInput}
             onChange={setSearchInput}
             onClear={handleSearchClear}
-            placeholder="Search by subgroup..."
+            placeholder="Search by group..."
             className="!mb-0 w-full"
           />
         </div>
@@ -218,7 +224,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
                 isAscending={sortAsc}
                 onClick={() => handleSortChange('subgroup')}
               >
-                Subgroup
+                Group
               </SortableColumnHeader>
             </th>
             <th className={`${thBase} w-[40%]`}>Contacts</th>
@@ -227,7 +233,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
-          {isLoading ? (
+          {isLoading || isFetching ? (
             <tr>
               <td colSpan={showActions ? 4 : 3} className="py-12">
                 <div className="flex justify-center">
@@ -293,7 +299,10 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
                       <IconButton
                         icon={<TrashIcon className="size-4 md:size-5" />}
                         label="Delete"
-                        onClick={() => handleDeleteClick(group)}
+                        onClick={() => {
+                          const indexToDelete = (groups ?? []).indexOf(group)
+                          handleDeleteClick(group, indexToDelete)
+                        }}
                         className="text-red-600 hover:bg-red-50 !p-1"
                       />
                     </div>
@@ -320,7 +329,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
         message={
           <>
             Are you sure you want to delete the group{' '}
-            <strong>{groupToDelete?.subgroup}</strong> ?
+            <strong>{groupToDelete?.group.subgroup}</strong> ?
             <br />
             <span className="text-amber-600 font-medium">
               This action cannot be undone.


### PR DESCRIPTION
This PR adds a labels field to the topology endpoint form and improves topology group and endpoint management.

- Added labels chip input to CreateTopologyEndpoint, stored as comma separated values in endpoint tags
- Renamed "Labels" section to "Metadata" and added disallowedKeys validation to KeyValueInput
- Refactored delete logic in TopologyGroups and TopologyEndpoints to use index and field matching
- Removed read-only Group and Type fields from CreateTopologyGroup
