### PR TITLE
[ARGO-5497] - Implement theme selection for status pages

### DIFF
--- a/src/pages/Status.tsx
+++ b/src/pages/Status.tsx
@@ -43,7 +43,9 @@ export const Status = () => {
                 />
               </div>
 
-              {statusData.theming?.logo ? (
+              {(statusData.theming?.option === 'theme_1' ||
+                !statusData.theming?.option) &&
+              statusData.theming?.logo ? (
                 <div className="relative flex justify-center -mt-20">
                   <div className="bg-white rounded-full p-2 shadow-xl">
                     <img
@@ -66,7 +68,13 @@ export const Status = () => {
               ) : null}
 
               <div
-                className={`text-center pt-2 pb-3 px-24 ${statusData.theming?.logo ? 'mt-4' : 'mt-8'}`}
+                className={`text-center pt-2 pb-3 px-24 ${
+                  (statusData.theming?.option === 'theme_1' ||
+                    !statusData.theming?.option) &&
+                  statusData.theming?.logo
+                    ? 'mt-4'
+                    : 'mt-8'
+                }`}
                 style={{
                   backgroundColor: statusData.theming?.color || '#FFFFFF',
                 }}

--- a/src/pages/build-status-page/BuildPagePreview.tsx
+++ b/src/pages/build-status-page/BuildPagePreview.tsx
@@ -17,6 +17,7 @@ interface BuildPagePreviewProps {
   selectIcon: string
   selectText: string
   report: string
+  themeOption: 'theme_1' | 'theme_2'
   groupsMutationIsPending: boolean
   onTitleChange: (value: string) => void
   onDescChange: (value: string) => void
@@ -42,6 +43,7 @@ const BuildPagePreview = ({
   selectIcon,
   selectText,
   report,
+  themeOption,
   groupsMutationIsPending,
   onTitleChange,
   onDescChange,
@@ -54,7 +56,7 @@ const BuildPagePreview = ({
   <div className="border border-line rounded-lg p-4 shadow-md w-full max-w-3xl self-start">
     <header style={{ backgroundColor: color }} className="p-3 mb-2 rounded-lg">
       <div className="flex flex-col items-center">
-        {logo && (
+        {logo && themeOption === 'theme_1' && (
           <img
             src={
               logo?.startsWith('http') || logo?.startsWith('data:')

--- a/src/pages/build-status-page/BuildStatusPage.tsx
+++ b/src/pages/build-status-page/BuildStatusPage.tsx
@@ -52,6 +52,9 @@ const BuildStatusPage = () => {
   const [saved, setSaved] = useState(false)
   const [selectIcon, setSelectIcon] = useState('led')
   const [selectText, setSelectText] = useState('none')
+  const [themeOption, setThemeOption] = useState<'theme_1' | 'theme_2'>(
+    'theme_1',
+  )
   const [color, setColor] = useState('#FFFFFF')
   const [logo, setLogo] = useState('')
   const [logoUrl, setLogoUrl] = useState('')
@@ -109,6 +112,7 @@ const BuildStatusPage = () => {
       setSaved(true)
       setSelectIcon(pageData.config?.theming?.status.icon || 'led')
       setSelectText(pageData.config?.theming?.status.text || 'none')
+      setThemeOption(pageData.config?.theming?.option || 'theme_1')
       setColor(pageData.config?.theming?.color || '')
       setLogo(pageData.config?.theming?.logo || '')
       if (pageData.config?.theming?.logo) {
@@ -157,6 +161,7 @@ const BuildStatusPage = () => {
         title,
         description: desc,
         theming: {
+          option: themeOption,
           status: { icon: selectIcon, text: selectText },
           logo:
             logo &&
@@ -477,6 +482,7 @@ const BuildStatusPage = () => {
                   selectIcon={selectIcon}
                   selectText={selectText}
                   columns={columns}
+                  themeOption={themeOption}
                   onColorChange={setColor}
                   onLogoUrlChange={handleLogoUrlChange}
                   onRemoveLogo={handleRemoveLogo}
@@ -484,6 +490,7 @@ const BuildStatusPage = () => {
                   onIconChange={setSelectIcon}
                   onTextChange={setSelectText}
                   onColumnsChange={setColumns}
+                  onThemeOptionChange={setThemeOption}
                 />
               </div>
             </div>
@@ -500,6 +507,7 @@ const BuildStatusPage = () => {
                 selectIcon={selectIcon}
                 selectText={selectText}
                 report={report}
+                themeOption={themeOption}
                 groupsMutationIsPending={groupsMutation.isPending}
                 onTitleChange={setTitle}
                 onDescChange={setDesc}

--- a/src/pages/build-status-page/BuildThemingTab.tsx
+++ b/src/pages/build-status-page/BuildThemingTab.tsx
@@ -3,6 +3,7 @@ import {
   XMarkIcon,
   PhotoIcon,
   CheckCircleIcon,
+  QuestionMarkCircleIcon,
 } from '@heroicons/react/16/solid'
 import { BanIcon, Columns2Icon, SquareIcon } from 'lucide-react'
 import { useDropzone } from 'react-dropzone'
@@ -11,6 +12,8 @@ import SelectGroup from './SelectGroup'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 
+const labelClass = 'block text-sm font-medium text-body mb-1'
+
 interface BuildThemingTabProps {
   color: string
   logoUrl: string
@@ -18,6 +21,7 @@ interface BuildThemingTabProps {
   selectIcon: string
   selectText: string
   columns: string
+  themeOption: 'theme_1' | 'theme_2'
   onColorChange: (value: string) => void
   onLogoUrlChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onRemoveLogo: (e: React.MouseEvent) => void
@@ -25,6 +29,7 @@ interface BuildThemingTabProps {
   onIconChange: (value: string) => void
   onTextChange: (value: string) => void
   onColumnsChange: (value: string) => void
+  onThemeOptionChange: (value: 'theme_1' | 'theme_2') => void
 }
 
 const BuildThemingTab = ({
@@ -34,6 +39,7 @@ const BuildThemingTab = ({
   selectIcon,
   selectText,
   columns,
+  themeOption,
   onColorChange,
   onLogoUrlChange,
   onRemoveLogo,
@@ -41,6 +47,7 @@ const BuildThemingTab = ({
   onIconChange,
   onTextChange,
   onColumnsChange,
+  onThemeOptionChange,
 }: BuildThemingTabProps) => {
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
@@ -86,9 +93,7 @@ const BuildThemingTab = ({
           </p>
           <div className="bg-white rounded-lg py-2 space-y-3 mt-1">
             <div>
-              <label className="block text-sm font-medium text-body mb-2">
-                Color:
-              </label>
+              <label className={labelClass}>Color:</label>
               <div className="flex items-center gap-3">
                 <input
                   type="color"
@@ -107,75 +112,103 @@ const BuildThemingTab = ({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-body mb-2">
-                Logo:
+              <label className="flex items-center gap-1 text-sm font-medium text-body mb-1">
+                Theme:
+                <div
+                  className="tooltip tooltip-right"
+                  data-tip="Select whether the public status page will feature a logo at the top."
+                >
+                  <QuestionMarkCircleIcon className="w-4.5 h-4.5 text-muted cursor-help" />
+                </div>
               </label>
-              <div
-                {...getRootProps()}
-                className={`border-2 border-dashed rounded-lg p-4 text-center cursor-pointer transition-colors flex flex-col items-center justify-center ${
-                  isDragActive
-                    ? 'border-blue-400 bg-brand-subtle'
-                    : 'border-line-strong bg-surface-muted hover:border-gray-400'
-                }`}
+              <SelectGroup
+                selected={themeOption}
+                onChange={(val) =>
+                  onThemeOptionChange(val as 'theme_1' | 'theme_2')
+                }
               >
-                <input {...getInputProps()} />
-                {logoPreview ? (
-                  <div className="relative flex flex-col items-center gap-2 w-full">
-                    <button
-                      type="button"
-                      onClick={onRemoveLogo}
-                      className="absolute -top-2 -right-2 bg-gray-600 hover:bg-gray-700 border-2 border-white rounded-full w-7 h-7 flex items-center justify-center z-10 shadow-md"
-                      aria-label="Remove logo"
-                    >
-                      <XMarkIcon className="w-5 h-5 text-white" />
-                    </button>
-                    <img
-                      alt="Logo"
-                      className="h-20 w-20 object-contain rounded"
-                      src={
-                        logoPreview?.startsWith('http') ||
-                        logoPreview?.startsWith('data:')
-                          ? logoPreview
-                          : `${BACKEND_API}${logoPreview}`
-                      }
-                    />
-                    <p className="text-sm text-muted">
-                      Click or drag to change
-                    </p>
-                  </div>
-                ) : (
-                  <>
-                    <div className="text-subtle mb-1">
-                      <PhotoIcon className="mx-auto h-10 w-10" />
-                    </div>
-                    <p className="text-sm text-muted">
-                      {isDragActive
-                        ? 'Drop logo here'
-                        : 'Drop logo here or click to upload'}
-                    </p>
-                  </>
-                )}
-              </div>
-              <div className="flex items-center my-2">
-                <div className="flex-1 border-b border-line-strong"></div>
-                <span className="px-3 text-xs text-muted font-medium uppercase">
-                  OR
-                </span>
-                <div className="flex-1 border-b border-line-strong"></div>
-              </div>
-              <input
-                type="url"
-                value={logoUrl}
-                onChange={onLogoUrlChange}
-                className="w-full"
-                placeholder="Enter logo URL"
-              />
+                <SelectGroup.Item value="theme_1">
+                  <PhotoIcon className="w-4" />
+                  <div>With Logo</div>
+                </SelectGroup.Item>
+                <SelectGroup.Item value="theme_2">
+                  <BanIcon className="w-4" />
+                  <div>No Logo</div>
+                </SelectGroup.Item>
+              </SelectGroup>
             </div>
 
+            {themeOption === 'theme_1' && (
+              <div>
+                <label className={labelClass}>Logo:</label>
+                <div
+                  {...getRootProps()}
+                  className={`border-2 border-dashed rounded-lg p-3 text-center cursor-pointer transition-colors flex flex-col items-center justify-center ${
+                    isDragActive
+                      ? 'border-blue-400 bg-brand-subtle'
+                      : 'border-line-strong bg-surface-muted hover:border-gray-400'
+                  }`}
+                >
+                  <input {...getInputProps()} />
+                  {logoPreview ? (
+                    <div className="relative flex flex-col items-center gap-1 w-full">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onRemoveLogo(e)
+                        }}
+                        className="absolute -top-1 -right-1 bg-gray-600 hover:bg-gray-700 rounded-full w-6 h-6 flex items-center justify-center z-10 shadow-md cursor-pointer"
+                        aria-label="Remove logo"
+                      >
+                        <XMarkIcon className="w-4 h-4 text-white" />
+                      </button>
+                      <img
+                        alt="Logo"
+                        className="w-24 w-h-24 object-contain rounded"
+                        src={
+                          logoPreview?.startsWith('http') ||
+                          logoPreview?.startsWith('data:')
+                            ? logoPreview
+                            : `${BACKEND_API}${logoPreview}`
+                        }
+                      />
+                      <p className="text-sm text-muted">
+                        Click or drag to change
+                      </p>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="text-subtle mb-1">
+                        <PhotoIcon className="mx-auto h-10 w-10" />
+                      </div>
+                      <p className="text-sm text-muted">
+                        {isDragActive
+                          ? 'Drop logo here'
+                          : 'Drop logo here or click to upload'}
+                      </p>
+                    </>
+                  )}
+                </div>
+                <div className="flex items-center my-2">
+                  <div className="flex-1 border-b border-line-strong"></div>
+                  <span className="px-3 text-xs text-muted font-medium uppercase">
+                    OR
+                  </span>
+                  <div className="flex-1 border-b border-line-strong"></div>
+                </div>
+                <input
+                  type="url"
+                  value={logoUrl}
+                  onChange={onLogoUrlChange}
+                  className="w-full"
+                  placeholder="Enter logo URL"
+                />
+              </div>
+            )}
+
             <div>
-              <label className="block text-sm font-medium text-body mb-2">
-                Status Icon:
-              </label>
+              <label className={labelClass}>Status Icon:</label>
               <SelectGroup selected={selectIcon} onChange={onIconChange}>
                 <SelectGroup.Item value="led">
                   <div
@@ -192,9 +225,7 @@ const BuildThemingTab = ({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-body mb-2">
-                Status Text:
-              </label>
+              <label className={labelClass}>Status Text:</label>
               <SelectGroup selected={selectText} onChange={onTextChange}>
                 <SelectGroup.Item value="text">
                   <div className="text-green-500">
@@ -203,7 +234,7 @@ const BuildThemingTab = ({
                   <div>Text</div>
                 </SelectGroup.Item>
                 <SelectGroup.Item value="badge">
-                  <div className="badge badge-success text-white">
+                  <div className="badge badge-success text-white px-2 py-1">
                     <small>OK</small>
                   </div>
                   <div>Badge</div>
@@ -216,9 +247,7 @@ const BuildThemingTab = ({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-body mb-2">
-                Status Columns:
-              </label>
+              <label className={labelClass}>Status Columns:</label>
               <SelectGroup selected={columns} onChange={onColumnsChange}>
                 <SelectGroup.Item value="one">
                   <SquareIcon className="w-4" />

--- a/src/pages/build-status-page/SelectGroup.tsx
+++ b/src/pages/build-status-page/SelectGroup.tsx
@@ -47,10 +47,10 @@ const SelectGroup = ({ children, selected, onChange }: SelectGroupProps) => {
           <button
             key={item.value}
             onClick={() => handleClick(item.value)}
-            className={`btn ${
+            className={`btn h-9 px-3 text-sm ${
               isSelected
-                ? 'bg-gray-200 border-gray-400 hover:bg-gray-300'
-                : 'btn'
+                ? 'bg-brand-subtle border-brand text-brand hover:bg-brand-muted hover:border-brand font-medium'
+                : 'bg-surface-muted border-line text-body hover:bg-surface-strong hover:border-line-strong font-normal'
             }`}
           >
             {item.children}

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -57,6 +57,7 @@ export type PageThemingStatus = {
 }
 
 export type PageTheming = {
+  option?: 'theme_1' | 'theme_2'
   status: PageThemingStatus
   color?: string
   logo?: string


### PR DESCRIPTION
This PR introduces a configuration option that allows users to select between different themes for their status pages.

- Implemented a theme selection UI in BuildThemingTab to choose the preferred visual theme
- Updated BuildStatusPage to track the selected theme and include it in the API payload
- Added a fallback to the first theme as default for backwards compatibility
- Refactored SelectGroup styling to use brand colors and updated dimensions