### PR TITLE
[ARGO-5498] - Add documentation tab to topology page

### DIFF
--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -5,6 +5,7 @@ import PageHeader from '@/components/PageHeader'
 import Tabs from '@/components/Tabs'
 import TopologyEndpoints from './TopologyEndpoints'
 import TopologyGroups from './TopologyGroups'
+import TopologyDocumentation from './TopologyDocumentation'
 import CreateTopologyEndpoint from './CreateTopologyEndpoint'
 import CreateTopologyGroup from './CreateTopologyGroup'
 import type { EndpointTopologyItem, GroupTopologyItem } from '@/types/topology'
@@ -12,6 +13,7 @@ import type { EndpointTopologyItem, GroupTopologyItem } from '@/types/topology'
 const tabs = [
   { id: 'endpoints', label: 'Endpoints' },
   { id: 'groups', label: 'Groups' },
+  { id: 'documentation', label: 'Documentation' },
 ]
 
 const TenantTopology = () => {
@@ -21,14 +23,16 @@ const TenantTopology = () => {
   const { data: tenantData } = useGetUserTenantById(tenantId)
 
   const location = useLocation()
-  const [activeTab, setActiveTab] = useState<'endpoints' | 'groups'>(
-    'endpoints',
-  )
+  const [activeTab, setActiveTab] = useState<
+    'endpoints' | 'groups' | 'documentation'
+  >('endpoints')
 
   useEffect(() => {
     const hash = location.hash
     if (hash.startsWith('#groups')) {
       setActiveTab('groups')
+    } else if (hash.startsWith('#documentation')) {
+      setActiveTab('documentation')
     } else {
       setActiveTab('endpoints')
     }
@@ -77,7 +81,7 @@ const TenantTopology = () => {
         tabs={tabs}
         activeTab={activeTab}
         onChange={(id) => {
-          setActiveTab(id as 'endpoints' | 'groups')
+          setActiveTab(id as 'endpoints' | 'groups' | 'documentation')
           window.location.hash = id
         }}
         className="mb-4"
@@ -89,6 +93,10 @@ const TenantTopology = () => {
 
       <div className={activeTab === 'groups' ? 'block' : 'hidden'}>
         <TopologyGroups tenantId={tenantId} onEdit={setEditingGroup} />
+      </div>
+
+      <div className={activeTab === 'documentation' ? 'block' : 'hidden'}>
+        <TopologyDocumentation />
       </div>
     </div>
   )

--- a/src/pages/tenant-topology/TopologyDocumentation.tsx
+++ b/src/pages/tenant-topology/TopologyDocumentation.tsx
@@ -1,0 +1,5 @@
+const TopologyDocumentation = () => {
+  return <div className="px-2 pb-4"></div>
+}
+
+export default TopologyDocumentation


### PR DESCRIPTION
This PR adds a documentation tab to the tenant topology page