### PR TITLE
[ARGO-5502] - Add notify action for tenant status jobs

### DIFF
--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -524,6 +524,39 @@ export const notifyAmsCheckReadiness = async (
   return response.json()
 }
 
+export const notifyAms = async (
+  tenantId: string,
+  tenantName: string,
+  jobName: string,
+  token: string,
+): Promise<{ jobs: Job[] }> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/admin/tenants/${tenantId}/notify-ams`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        name: jobName,
+        properties: {
+          tenant_name: tenantName,
+        },
+      }),
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
 export const setTenantNode = async (
   id: string,
   node: boolean,

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -26,6 +26,7 @@ import {
   fetchTenantMetricProfile,
   fetchTenantReadiness,
   notifyAmsCheckReadiness,
+  notifyAms,
   setTenantNode,
   setNodeReport,
 } from '@/api/tenants'
@@ -523,6 +524,35 @@ export const useCheckReadinessMutation = () => {
     },
     onError: (error) => {
       console.error('Failed to notify AMS check readiness:', error)
+    },
+  })
+}
+
+export const useNotifyAmsMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<
+    { jobs: Job[] },
+    Error,
+    { tenantId: string; tenantName: string; jobName: string }
+  >({
+    mutationFn: ({ tenantId, tenantName, jobName }) => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      return notifyAms(tenantId, tenantName, jobName, token)
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['user-tenant-status', variables.tenantId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['user-tenants'],
+      })
+    },
+    onError: (error) => {
+      console.error('Failed to rerun AMS job:', error)
     },
   })
 }

--- a/src/pages/tenant-details/TenantStatusTab.tsx
+++ b/src/pages/tenant-details/TenantStatusTab.tsx
@@ -2,6 +2,7 @@ import { useState, Fragment } from 'react'
 import {
   useGetUserTenantStatus,
   useUpdateTenantStatusMutation,
+  useNotifyAmsMutation,
 } from '@/hooks/useTenants'
 import { useAuth } from '@/auth/useAuth'
 import {
@@ -82,6 +83,7 @@ const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
   } = useGetUserTenantStatus(tenantId, 10000) // Refetch every 10 seconds to keep status updated
 
   const updateStatusMutation = useUpdateTenantStatusMutation()
+  const notifyAmsMutation = useNotifyAmsMutation()
 
   const jobs = statusData && statusData.status.jobs
 
@@ -90,6 +92,31 @@ const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
       ...prev,
       [jobName]: !prev[jobName],
     }))
+  }
+
+  const handleRerunJob = (e: React.MouseEvent, job: Job) => {
+    e.stopPropagation()
+    if (!tenantId || !statusData?.name) return
+
+    toast.loading(`Notifying AMS to rerun ${job.name.toLowerCase()}...`)
+
+    notifyAmsMutation.mutate(
+      {
+        tenantId,
+        tenantName: statusData.name,
+        jobName: job.name,
+      },
+      {
+        onSuccess: () => {
+          toast.dismiss()
+          toast.success('Job execution triggered successfully')
+        },
+        onError: (error) => {
+          toast.dismiss()
+          toast.error(`Failed to rerun job: ${error.message}`)
+        },
+      },
+    )
   }
 
   const handleEditClick = (job: Job) => {
@@ -371,6 +398,25 @@ const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
                   )}
 
                   <div className="flex flex-col gap-2">
+                    {isSuperAdmin && job.mode !== 'MANUAL' && (
+                      <div className="flex flex-col items-start gap-1.5 border-b border-gray-50 pb-3 pt-1">
+                        <label className="text-sm font-medium text-body">
+                          Trigger manual notification to AMS
+                        </label>
+                        <Button
+                          size="sm"
+                          variant="outline-primary"
+                          onClick={(e) => handleRerunJob(e, job)}
+                          disabled={notifyAmsMutation.isPending}
+                        >
+                          {notifyAmsMutation.isPending ? (
+                            <LoadingSpinner size="xs" />
+                          ) : (
+                            'Rerun'
+                          )}
+                        </Button>
+                      </div>
+                    )}
                     <div className="flex justify-between items-center gap-4 py-1.5 pb-2 border-b border-gray-50 last:border-b-0">
                       <div className="grid grid-cols-1 gap-1 md:grid-cols-[120px_1fr] md:gap-3">
                         <span className="text-sm font-semibold text-muted px-1">


### PR DESCRIPTION
This PR adds a manual action for administrators to re-trigger automated initialization jobs in the tenant status panel.

- Implemented a "Rerun" manual action button with a status tooltip for administrators in the TenantStatusTab
- Added notify ams API function to support triggering manual initialization jobs for tenants
- Added a mutation hook with cache invalidation to update tenant status automatically
