### PR TITLE
[ARGO-5499] - Refactor Data Source selection for tenant status pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,6 +181,14 @@ function App() {
                   }
                 />
                 <Route
+                  path="status-pages/tenants/:tenantId/build"
+                  element={
+                    <AuthProtected>
+                      <BuildStatusPage />
+                    </AuthProtected>
+                  }
+                />
+                <Route
                   path="status-pages/build"
                   element={
                     <AuthProtected>

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -109,7 +109,7 @@ function Layout() {
       {/* Page content */}
       <main className="flex-1 bg-white overflow-auto">
         <div
-          className={`${tDetsRoute ? '' : 'container mx-2 md:mx-auto p-4 md:px-6'}`}
+          className={`${tDetsRoute ? '' : 'container mx-2 md:mx-auto py-2 px-4 md:px-6'}`}
         >
           {!authenticated ? (
             <LoginPrompt

--- a/src/pages/build-status-page/BuildConfigTab.tsx
+++ b/src/pages/build-status-page/BuildConfigTab.tsx
@@ -2,11 +2,14 @@ import { CheckBadgeIcon } from '@heroicons/react/24/solid'
 import type { TenantList, ReportListItem } from '@/types/tenants'
 import SelectDropdown from '@/components/SelectDropdown'
 
+const labelClass = 'block text-sm font-medium text-body mb-1'
+
 interface BuildConfigTabProps {
   name: string
   slug: string
   tenantId: string
   isEditMode: boolean
+  isTenantSelectionDisabled: boolean
   tenantsData: TenantList | undefined
   reportsData: ReportListItem[] | undefined
   onNameChange: (value: string) => void
@@ -19,6 +22,7 @@ const BuildConfigTab = ({
   slug,
   tenantId,
   isEditMode,
+  isTenantSelectionDisabled,
   tenantsData,
   reportsData,
   onNameChange,
@@ -36,7 +40,7 @@ const BuildConfigTab = ({
 
       <div className="bg-white border border-line rounded-lg p-6 space-y-4">
         <div>
-          <label className="block text-sm font-medium text-body mb-2">
+          <label className={labelClass}>
             Name <span className="required">*</span>
           </label>
           <input
@@ -49,7 +53,7 @@ const BuildConfigTab = ({
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-body mb-2">
+          <label className={labelClass}>
             Path <span className="required">*</span>
           </label>
           <input
@@ -71,9 +75,9 @@ const BuildConfigTab = ({
         </p>
       </div>
 
-      <div className="bg-white border border-line rounded-lg p-6 space-y-4">
+      <div className="bg-white border border-line rounded-lg p-6 space-y-2">
         <div>
-          <label className="block text-sm font-medium text-body mb-2">
+          <label className={labelClass}>
             Tenant: <span className="required">*</span>
           </label>
           <SelectDropdown
@@ -88,17 +92,19 @@ const BuildConfigTab = ({
                 })) ?? []
             }
             placeholder="Select a tenant"
-            disabled={isEditMode}
+            disabled={isTenantSelectionDisabled}
           />
-          {isEditMode && (
+          {isTenantSelectionDisabled && (
             <p className="text-xs text-muted mt-1">
-              Tenant cannot be changed when editing a page
+              {isEditMode
+                ? 'Tenant cannot be changed when editing a status page'
+                : 'You are currently creating a status page for this specific tenant'}
             </p>
           )}
         </div>
 
         {!isEditMode && tenantId && reportsData && reportsData.length > 0 && (
-          <div className="p-3 bg-green-50 border border-green-200 rounded text-sm text-green-700 flex items-center">
+          <div className="p-2 bg-green-50 border border-green-200 rounded text-sm text-green-700 flex items-center">
             <CheckBadgeIcon className="size-5 inline-block me-2" />
             {reportsData.length} report{reportsData.length !== 1 ? 's' : ''}{' '}
             available

--- a/src/pages/build-status-page/BuildItemsTab.tsx
+++ b/src/pages/build-status-page/BuildItemsTab.tsx
@@ -5,6 +5,8 @@ import { StatusItem } from './StatusItem'
 import type { StatusItemType, StatusGroupType } from '@/types/common'
 import type { ReportListItem } from '@/types/tenants'
 
+const labelClass = 'block text-sm font-medium text-body mb-1'
+
 interface BuildItemsTabProps {
   tenantId: string
   report: string
@@ -73,9 +75,7 @@ const BuildItemsTab = ({
           {tenantId && reportsData && reportsData.length > 0 && (
             <>
               <div>
-                <label className="block text-sm font-medium text-body mb-1">
-                  Report:
-                </label>
+                <label className={labelClass}>Report:</label>
                 <SelectDropdown
                   value={report}
                   onChange={onReportChange}
@@ -102,9 +102,7 @@ const BuildItemsTab = ({
                 ) : (
                   <>
                     <div className="mb-2">
-                      <label className="block text-sm font-medium text-body mb-1">
-                        Search Items:
-                      </label>
+                      <label className={labelClass}>Search Items:</label>
                       <input
                         type="text"
                         className="w-full"

--- a/src/pages/build-status-page/BuildStatusPage.tsx
+++ b/src/pages/build-status-page/BuildStatusPage.tsx
@@ -154,7 +154,6 @@ const BuildStatusPage = () => {
     const data = {
       name,
       slug,
-      tenant_id: tenantId,
       'report-id': report,
       config: {
         groups: statusGroups,
@@ -404,15 +403,16 @@ const BuildStatusPage = () => {
             className="pb-1 mb-3"
           />
 
-          <div className="flex flex-row justify-between items-center mb-4">
+          <div className="flex flex-col md:flex-row justify-between md:items-center gap-3 md:gap-6 mb-1 md:mb-4">
             <Tabs
               tabs={buildTabs}
               activeTab={activeTab}
               onChange={(id) =>
                 setActiveTab(id as 'config' | 'items' | 'theming')
               }
+              className="flex-1 w-full"
             />
-            <div className="flex justify-end gap-4">
+            <div className="flex justify-end gap-4 w-full md:w-auto 2xl:mr-25">
               {saved && (
                 <Button
                   variant="outline-primary"
@@ -420,7 +420,7 @@ const BuildStatusPage = () => {
                   onClick={() => window.open(`/status/${slug}`, '_blank')}
                 >
                   View Page
-                  <ArrowTopRightOnSquareIcon className="size-4" />
+                  <ArrowTopRightOnSquareIcon className="size-4 flex-shrink-0" />
                 </Button>
               )}
               {activeTab !== 'config' && (
@@ -435,7 +435,7 @@ const BuildStatusPage = () => {
             className={
               activeTab === 'config'
                 ? ''
-                : 'flex flex-col xl:grid xl:grid-cols-[500px_1fr] 2xl:grid-cols-[720px_1fr] gap-8'
+                : 'flex flex-col xl:grid xl:grid-cols-[2fr_3fr] gap-8'
             }
           >
             <div
@@ -447,6 +447,9 @@ const BuildStatusPage = () => {
                   slug={slug}
                   tenantId={tenantId}
                   isEditMode={isEditMode}
+                  isTenantSelectionDisabled={
+                    isEditMode || Boolean(tenantIdParam)
+                  }
                   tenantsData={tenantsData}
                   reportsData={reportsData}
                   onNameChange={handleNameChange}

--- a/src/pages/status-pages/TenantStatusPages.tsx
+++ b/src/pages/status-pages/TenantStatusPages.tsx
@@ -120,7 +120,11 @@ const TenantStatusPages = () => {
           }
           className="pb-1 mb-2 md:mb-4 px-2 md:px-0"
         >
-          <Button variant="primary" size="md" href="/status-pages/build">
+          <Button
+            variant="primary"
+            size="md"
+            href={`/status-pages/tenants/${tenantId}/build`}
+          >
             Create Status Page
           </Button>
         </PageHeader>

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -34,13 +34,9 @@ export type UserPages = {
 }
 
 export type PageCreateRequest = {
-  id?: string
   name: string
   slug: string
-  tenant_id: string
   'report-id': string
-  created_at?: string
-  updated_at?: string
   config?: PageConfig
 }
 


### PR DESCRIPTION
This PR refactors the Data Source selection so the tenant is pre-selected, when creating a status page for a specific tenant.

- Refactored tenant selection handling in BuildConfigTab to support both edit and pre-selection cases
- Added a new route for creating status pages scoped to a specific tenant
- Updated TenantStatusPages to navigate to the new scoped route
