### PR TITLE
[ARGO-5509] - Implement a shared context for the selected tenant

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,128 +1,71 @@
-import { useState, useEffect, useMemo } from 'react'
-import { Outlet, useLocation, useMatch } from 'react-router'
-import { useGetUserTenants } from '@/hooks/useTenants'
+import { useState } from 'react'
+import { Outlet, useMatch } from 'react-router'
 import { useAuth } from './auth/useAuth'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
+import { SelectedTenantProvider } from '@/contexts/selected-tenant'
 import LoginPrompt from './components/LoginPrompt'
 import Sidebar from '@/components/sidebar/Sidebar'
 import MobileMenuToggle from '@/components/sidebar/MobileMenuToggle'
 
-const LAST_TENANT_KEY = 'lastActiveTenantId'
-
-function Layout() {
-  const { authenticated, profile, login, logout } = useAuth()
+function LayoutContent() {
+  const { authenticated, isSuperAdmin, profile, logout } = useAuth()
+  const { effectiveTenantId, tenants, isTenantAdmin } = useSelectedTenant()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const location = useLocation()
-
-  const isSuperAdmin = !!profile?.roles?.includes('super_admin')
-
-  // check to see if we are on tenant details route
   const tDetsRoute = useMatch('/tenants/:id/details')
-
-  // Per-user storage key
-  const storageKey = profile?.id ? `${LAST_TENANT_KEY}_${profile.id}` : null
-
-  const [lastActiveTenantId, setLastActiveTenantId] = useState<string | null>(
-    null,
-  )
-
-  const openMobileMenu = () => setIsMobileMenuOpen(true)
-  const closeMobileMenu = () => setIsMobileMenuOpen(false)
-
-  // Detect active tenant ID from current URL path
-  const tenantMatch = location.pathname.match(/\/tenants\/([^/]+)/)
-  const rawTenantId = tenantMatch?.[1] ?? null
-  const activeTenantId =
-    rawTenantId && !['create', 'edit'].includes(rawTenantId)
-      ? rawTenantId
-      : null
-
-  // Load persisted tenant when storage key is available
-  useEffect(() => {
-    if (!storageKey) return
-    setLastActiveTenantId(localStorage.getItem(storageKey))
-  }, [storageKey])
-
-  // Sync lastActiveTenantId to localStorage whenever it changes
-  useEffect(() => {
-    if (!storageKey || !lastActiveTenantId) return
-    localStorage.setItem(storageKey, lastActiveTenantId)
-  }, [lastActiveTenantId, storageKey])
-
-  // Persist the last tenant the user navigated into
-  useEffect(() => {
-    if (activeTenantId) {
-      setLastActiveTenantId(activeTenantId)
-    }
-  }, [activeTenantId])
-
-  const { data: tenantsData } = useGetUserTenants(
-    1,
-    50,
-    undefined,
-    authenticated,
-  )
-  const userTenants = useMemo(() => tenantsData?.content ?? [], [tenantsData])
-
-  // Validate stored ID on load, fall back to first tenant if missing or invalid
-  useEffect(() => {
-    if (!storageKey || userTenants.length === 0) return
-
-    setLastActiveTenantId((current) => {
-      if (current && userTenants.some((t) => t.id === current)) return current
-      return userTenants[0]?.id ?? null
-    })
-  }, [userTenants, storageKey])
-
-  const effectiveTenantId = activeTenantId ?? lastActiveTenantId ?? null
-
-  const activeTenantInfo = effectiveTenantId
-    ? userTenants.find((t) => t.id === effectiveTenantId)
-    : null
-  const activeTenantName = activeTenantInfo?.info?.name ?? ''
-
-  const isAdminOfTenant =
-    isSuperAdmin ||
-    !!profile?.groups?.find(
-      (group) => group.name === activeTenantName && group.role === 'admin',
-    )
 
   return (
     <div className="h-screen flex overflow-hidden">
       <MobileMenuToggle
         isOpen={isMobileMenuOpen}
-        onOpen={openMobileMenu}
-        onClose={closeMobileMenu}
+        onOpen={() => setIsMobileMenuOpen(true)}
+        onClose={() => setIsMobileMenuOpen(false)}
       />
 
       <Sidebar
         isMobileMenuOpen={isMobileMenuOpen}
-        onCloseMobileMenu={closeMobileMenu}
+        onCloseMobileMenu={() => setIsMobileMenuOpen(false)}
         authenticated={authenticated}
         isSuperAdmin={isSuperAdmin}
-        userTenants={userTenants}
+        userTenants={tenants}
         effectiveTenantId={effectiveTenantId}
-        isAdminOfTenant={isAdminOfTenant}
+        isAdminOfTenant={isTenantAdmin}
         profile={profile}
         onLogout={logout}
       />
 
-      {/* Page content */}
       <main className="flex-1 bg-white overflow-auto">
         <div
           className={`${tDetsRoute ? '' : 'container mx-2 md:mx-auto py-2 px-4 md:px-6'}`}
         >
-          {!authenticated ? (
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function Layout() {
+  const { authenticated, login } = useAuth()
+
+  if (!authenticated)
+    return (
+      <div className="h-screen flex overflow-hidden">
+        <main className="flex-1 bg-white overflow-auto">
+          <div className="container mx-2 md:mx-auto p-4 md:px-6">
             <LoginPrompt
               title="Authentication Required"
               description="Please login to access the status pages management"
               onLogin={login}
             />
-          ) : (
-            <Outlet />
-          )}
-        </div>
-      </main>
-    </div>
+          </div>
+        </main>
+      </div>
+    )
+
+  return (
+    <SelectedTenantProvider>
+      <LayoutContent />
+    </SelectedTenantProvider>
   )
 }
 

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -135,6 +135,8 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
       redirectUri: import.meta.env.VITE_REDIRECT_URI || window.location.origin,
     })
 
+  const isSuperAdmin = !!profile?.roles?.includes('super_admin')
+
   return (
     <AuthContext.Provider
       value={{
@@ -143,6 +145,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
         registered,
         token,
         profile,
+        isSuperAdmin,
         login,
         logout,
       }}

--- a/src/auth/context.ts
+++ b/src/auth/context.ts
@@ -17,6 +17,7 @@ export type AuthContextType = {
       role: string
     }>
   }
+  isSuperAdmin: boolean
   login: (redirectUri?: string) => void
   logout: () => void
 }
@@ -25,6 +26,7 @@ export const AuthContext = createContext<AuthContextType>({
   initialized: false,
   authenticated: false,
   registered: false,
+  isSuperAdmin: false,
   login: () => {},
   logout: () => {},
 })

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -86,7 +86,7 @@ function Sidebar({
                   <HomeIcon className="size-4" aria-hidden />
                   Overview
                 </SidebarNavItem>
-                {isAdminOfTenant && (
+                {(isSuperAdmin || isAdminOfTenant) && (
                   <SidebarNavItem
                     to={`/tenants/${effectiveTenantId}/topology`}
                     onClick={onCloseMobileMenu}
@@ -116,7 +116,7 @@ function Sidebar({
                   <ShieldCheckIcon className="size-4" aria-hidden />
                   Capabilities
                 </SidebarNavItem>
-                {isAdminOfTenant && (
+                {(isSuperAdmin || isAdminOfTenant) && (
                   <SidebarNavItem
                     to={`/tenants/${effectiveTenantId}/members`}
                     onClick={onCloseMobileMenu}

--- a/src/contexts/selected-tenant/SelectedTenantContext.ts
+++ b/src/contexts/selected-tenant/SelectedTenantContext.ts
@@ -1,0 +1,15 @@
+import { createContext } from 'react'
+import type { Tenant } from '@/types/tenants'
+
+export interface SelectedTenantContextValue {
+  tenant: Tenant | undefined
+  isTenantLoading: boolean
+  tenantError: Error | null
+  isTenantAdmin: boolean
+  effectiveTenantId: string | null
+  tenants: Tenant[]
+}
+
+export const SelectedTenantContext = createContext<
+  SelectedTenantContextValue | undefined
+>(undefined)

--- a/src/contexts/selected-tenant/SelectedTenantProvider.tsx
+++ b/src/contexts/selected-tenant/SelectedTenantProvider.tsx
@@ -1,0 +1,112 @@
+import { useState, useEffect, useMemo } from 'react'
+import type { ReactNode } from 'react'
+import { useLocation } from 'react-router'
+import { useAuth } from '@/auth/useAuth'
+import { useGetAllTenants } from '@/hooks/useTenants'
+import { SelectedTenantContext } from './SelectedTenantContext'
+
+const LAST_TENANT_KEY = 'lastActiveTenantId'
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+interface SelectedTenantProviderProps {
+  children: ReactNode
+}
+
+const SelectedTenantProvider = ({ children }: SelectedTenantProviderProps) => {
+  const { profile, authenticated } = useAuth()
+  const location = useLocation()
+
+  // Per-user storage key
+  const storageKey = profile?.id ? `${LAST_TENANT_KEY}_${profile.id}` : null
+
+  const [lastActiveTenantId, setLastActiveTenantId] = useState<string | null>(
+    null,
+  )
+
+  const {
+    data: tenantsData,
+    isLoading: isTenantLoading,
+    error: tenantError,
+    fetchNextPage,
+    hasNextPage,
+  } = useGetAllTenants(authenticated)
+
+  useEffect(() => {
+    if (hasNextPage) {
+      fetchNextPage()
+    }
+  }, [tenantsData, hasNextPage, fetchNextPage])
+
+  const tenants = useMemo(
+    () => tenantsData?.pages.flatMap((page) => page.content) ?? [],
+    [tenantsData],
+  )
+
+  // Detect active tenant ID from current URL path
+  const tenantMatch = location.pathname.match(/\/tenants\/([^/]+)/)
+  const rawTenantId = tenantMatch?.[1] ?? null
+  const activeTenantId =
+    rawTenantId && UUID_REGEX.test(rawTenantId) ? rawTenantId : null
+
+  // Load persisted tenant when storage key is available
+  useEffect(() => {
+    if (!storageKey) return
+    setLastActiveTenantId(localStorage.getItem(storageKey))
+  }, [storageKey])
+
+  // Sync lastActiveTenantId to localStorage whenever it changes
+  useEffect(() => {
+    if (!storageKey || !lastActiveTenantId) return
+    localStorage.setItem(storageKey, lastActiveTenantId)
+  }, [lastActiveTenantId, storageKey])
+
+  // Persist the last tenant the user navigated into
+  useEffect(() => {
+    if (activeTenantId) {
+      setLastActiveTenantId(activeTenantId)
+    }
+  }, [activeTenantId])
+
+  // Validate stored ID on load, fall back to first tenant if missing or invalid
+  useEffect(() => {
+    if (!storageKey || tenants.length === 0) return
+    setLastActiveTenantId((current) => {
+      if (current && tenants.some((t) => t.id === current)) return current
+      return tenants[0]?.id ?? null
+    })
+  }, [tenants, storageKey])
+
+  const effectiveTenantId = activeTenantId ?? lastActiveTenantId ?? null
+
+  const selectedTenant = useMemo(
+    () => tenants.find((t) => t.id === effectiveTenantId),
+    [tenants, effectiveTenantId],
+  )
+
+  const isTenantAdmin = useMemo(
+    () =>
+      !!profile?.groups?.find(
+        (group) =>
+          group.name === selectedTenant?.info.name && group.role === 'admin',
+      ),
+    [profile, selectedTenant],
+  )
+
+  return (
+    <SelectedTenantContext.Provider
+      value={{
+        tenant: selectedTenant,
+        isTenantLoading,
+        tenantError,
+        isTenantAdmin,
+        effectiveTenantId,
+        tenants,
+      }}
+    >
+      {children}
+    </SelectedTenantContext.Provider>
+  )
+}
+
+export default SelectedTenantProvider

--- a/src/contexts/selected-tenant/index.ts
+++ b/src/contexts/selected-tenant/index.ts
@@ -1,0 +1,3 @@
+export { default as SelectedTenantProvider } from './SelectedTenantProvider'
+export { useSelectedTenant } from './useSelectedTenant'
+export type { SelectedTenantContextValue } from './SelectedTenantContext'

--- a/src/contexts/selected-tenant/useSelectedTenant.ts
+++ b/src/contexts/selected-tenant/useSelectedTenant.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react'
+import { SelectedTenantContext } from './SelectedTenantContext'
+import type { SelectedTenantContextValue } from './SelectedTenantContext'
+
+export const useSelectedTenant = (): SelectedTenantContextValue => {
+  const context = useContext(SelectedTenantContext)
+  if (!context)
+    throw new Error(
+      'useSelectedTenant must be used within SelectedTenantProvider',
+    )
+  return context
+}

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -127,6 +127,28 @@ export const useGetUserTenants = (
   })
 }
 
+export const useGetAllTenants = (enabled: boolean = true) => {
+  const { token } = useAuth()
+
+  return useInfiniteQuery<TenantList, Error>({
+    queryKey: ['user-tenants', 'all'],
+    queryFn: ({ pageParam = 1 }) => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      return fetchUserTenants(token, pageParam as number, 10)
+    },
+    getNextPageParam: (lastPage) => {
+      const currentPage = lastPage.number_of_page
+      const totalPages = lastPage.total_pages
+      return currentPage < totalPages ? currentPage + 1 : undefined
+    },
+    initialPageParam: 1,
+    retry: false,
+    enabled: enabled && !!token,
+  })
+}
+
 export const useGetUserTenantById = (id: string, enabled: boolean = true) => {
   const { token } = useAuth()
 

--- a/src/pages/AssignProjects.tsx
+++ b/src/pages/AssignProjects.tsx
@@ -34,9 +34,8 @@ const listContainerClass =
   'bg-surface-muted min-h-[300px] max-h-[400px] md:min-h-[400px] md:max-h-[500px] overflow-y-auto'
 
 const AssignProjects = () => {
-  const { profile } = useAuth()
+  const { isSuperAdmin } = useAuth()
   const { id: tenantId } = useParams<{ id: string }>()
-  const isSuperAdmin = profile?.roles?.includes('super_admin')
 
   const [allProjects, setAllProjects] = useState<ProjectItem[]>([])
   const [tenantProjectIds, setTenantProjectIds] = useState<string[]>([])

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -25,8 +25,7 @@ const profileGridClass = 'grid grid-cols-[200px_1fr] gap-6'
 export const Profile = () => {
   const { username } = useParams<{ username: string }>()
 
-  const { profile } = useAuth()
-  const isSuperAdmin = profile?.roles?.includes('super_admin')
+  const { isSuperAdmin, profile } = useAuth()
 
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false)
   const [tenantToRemove, setTenantToRemove] = useState<{

--- a/src/pages/administration/Administration.tsx
+++ b/src/pages/administration/Administration.tsx
@@ -20,7 +20,7 @@ const Administration = () => {
   const location = useLocation()
   const [activeTab, setActiveTab] = useState<ActiveTab>('tenants')
 
-  const { profile } = useAuth()
+  const { isSuperAdmin } = useAuth()
 
   useEffect(() => {
     const hash = location.hash
@@ -36,8 +36,6 @@ const Administration = () => {
       setActiveTab('tenants')
     }
   }, [location.hash])
-  const isSuperAdmin = profile?.roles?.includes('super_admin')
-
   if (!isSuperAdmin) {
     return (
       <div className="page-container">

--- a/src/pages/administration/StatusPagesManagementTab.tsx
+++ b/src/pages/administration/StatusPagesManagementTab.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGetTenantPages, useDeletePageMutation } from '@/hooks/usePages'
 import { useGetUserPages } from '@/hooks/useUsers'
-import { useGetUserTenants } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import { toast } from 'sonner'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import Pagination from '@/components/Pagination'
@@ -18,7 +18,7 @@ const StatusPagesManagementTab = () => {
   const [tenantId, setTenantId] = useState<string>('')
   const [isAllSelected, setIsAllSelected] = useState<boolean>(true)
 
-  const { data: tenantsData } = useGetUserTenants(1, 100, undefined, true)
+  const { tenants } = useSelectedTenant()
 
   const {
     data: allUserPagesData,
@@ -145,10 +145,10 @@ const StatusPagesManagementTab = () => {
             options={
               [
                 { value: 'all', label: 'All' },
-                ...(tenantsData?.content.map((tenant) => ({
+                ...tenants.map((tenant) => ({
                   value: tenant.id ?? '',
                   label: tenant.info.name,
-                })) ?? []),
+                })),
               ] satisfies SelectOption[]
             }
             onChange={(value) => {

--- a/src/pages/administration/TenantManagementTab.tsx
+++ b/src/pages/administration/TenantManagementTab.tsx
@@ -39,10 +39,8 @@ const TenantManagementTab = () => {
     name: string
   } | null>(null)
 
-  const { profile } = useAuth()
+  const { isSuperAdmin } = useAuth()
   const { data: userProfileData } = useGetUserProfile()
-
-  const isSuperAdmin = profile?.roles?.includes('super_admin')
 
   const { data, isLoading, error } = useGetUserTenants(
     currentPage,

--- a/src/pages/administration/UsersTab.tsx
+++ b/src/pages/administration/UsersTab.tsx
@@ -25,8 +25,7 @@ const UsersTab = () => {
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [currentPage, setCurrentPage] = useState(1)
 
-  const { profile } = useAuth()
-  const isSuperAdmin = profile?.roles?.includes('super_admin')
+  const { isSuperAdmin } = useAuth()
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/src/pages/build-status-page/BuildConfigTab.tsx
+++ b/src/pages/build-status-page/BuildConfigTab.tsx
@@ -1,5 +1,5 @@
 import { CheckBadgeIcon } from '@heroicons/react/24/solid'
-import type { TenantList, ReportListItem } from '@/types/tenants'
+import type { ReportListItem, Tenant } from '@/types/tenants'
 import SelectDropdown from '@/components/SelectDropdown'
 
 const labelClass = 'block text-sm font-medium text-body mb-1'
@@ -10,7 +10,7 @@ interface BuildConfigTabProps {
   tenantId: string
   isEditMode: boolean
   isTenantSelectionDisabled: boolean
-  tenantsData: TenantList | undefined
+  tenantsData: Tenant[]
   reportsData: ReportListItem[] | undefined
   onNameChange: (value: string) => void
   onSlugChange: (value: string) => void
@@ -83,14 +83,12 @@ const BuildConfigTab = ({
           <SelectDropdown
             value={tenantId}
             onChange={onTenantChange}
-            options={
-              tenantsData?.content
-                .filter((tenant) => tenant.id)
-                .map((tenant) => ({
-                  value: tenant.id as string,
-                  label: tenant.info.name,
-                })) ?? []
-            }
+            options={tenantsData
+              .filter((tenant) => tenant.id)
+              .map((tenant) => ({
+                value: tenant.id as string,
+                label: tenant.info.name,
+              }))}
             placeholder="Select a tenant"
             disabled={isTenantSelectionDisabled}
           />

--- a/src/pages/build-status-page/BuildStatusPage.tsx
+++ b/src/pages/build-status-page/BuildStatusPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useGroupsMutation } from '@/hooks/useGroups'
-import { useGetUserTenants, useGetTenantReports } from '@/hooks/useTenants'
+import { useGetTenantReports } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import {
   useSavePageMutation,
   useGetPageQuery,
@@ -73,7 +74,7 @@ const BuildStatusPage = () => {
   } = useGetPageQuery(tenantId || '', pageId || '')
   const groupsMutation = useGroupsMutation()
 
-  const { data: tenantsData } = useGetUserTenants(1, 100, undefined, true)
+  const { tenants: tenantsData } = useSelectedTenant()
   const { data: reportsData, isLoading: reportsLoading } = useGetTenantReports(
     tenantId,
     undefined,

--- a/src/pages/manage-tenant-members/ManageTenantMembers.tsx
+++ b/src/pages/manage-tenant-members/ManageTenantMembers.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { useParams } from 'react-router-dom'
-import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import { useAuth } from '@/auth/useAuth'
+import { useParams } from 'react-router-dom'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import PageHeader from '@/components/PageHeader'
 import Tabs from '@/components/Tabs'
@@ -12,12 +12,8 @@ import AddDirectTab from './AddDirectTab'
 
 const ManageTenantMembers = () => {
   const { id: tenantId } = useParams<{ id: string }>()
-  const { profile } = useAuth()
-  const { data: tenantData, error: tenantError } = useGetUserTenantById(
-    tenantId || '',
-  )
-
-  const isSuperAdmin = profile?.roles?.includes('super_admin')
+  const { isSuperAdmin } = useAuth()
+  const { tenant: tenantData, tenantError } = useSelectedTenant()
 
   const [activeTab, setActiveTab] = useState<
     'members' | 'invite' | 'add-direct' | 'invitations'

--- a/src/pages/status-pages/TenantStatusPages.tsx
+++ b/src/pages/status-pages/TenantStatusPages.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import { useGetTenantPages, useDeletePageMutation } from '@/hooks/usePages'
-import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import PageHeader from '@/components/PageHeader'
@@ -15,7 +15,7 @@ const TenantStatusPages = () => {
   const { id: tenantId } = useParams<{ id: string }>()
   const [currentPage, setCurrentPage] = useState(1)
 
-  const { data: tenantData } = useGetUserTenantById(tenantId ?? '')
+  const { tenant: tenantData } = useSelectedTenant()
 
   const { data, isLoading, error } = useGetTenantPages(
     tenantId ?? '',

--- a/src/pages/tenant-capabilities/TenantCapabilities.tsx
+++ b/src/pages/tenant-capabilities/TenantCapabilities.tsx
@@ -1,18 +1,14 @@
 import { useParams } from 'react-router-dom'
-import { useGetUserTenantById } from '@/hooks/useTenants'
 import { useAuth } from '@/auth/useAuth'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import PageHeader from '@/components/PageHeader'
 import TenantCapabilitiesTab from './TenantCapabilitiesTab'
 import NodeConfigPanel from './NodeConfigPanel'
 
 const TenantCapabilities = () => {
   const { id } = useParams<{ id: string }>()
-  const { profile } = useAuth()
-  const { data: tenantData } = useGetUserTenantById(id || '')
-  const isSuperAdmin = profile?.roles?.includes('super_admin')
-  const isTenantAdmin = profile?.groups?.some(
-    (g) => g.name === tenantData?.info.name && g.role === 'admin',
-  )
+  const { isSuperAdmin } = useAuth()
+  const { tenant, isTenantAdmin } = useSelectedTenant()
   const canConfigureNode = isSuperAdmin || isTenantAdmin
 
   return (
@@ -22,20 +18,18 @@ const TenantCapabilities = () => {
         subtitle={
           <>
             Explore capabilities for tenant{' '}
-            <strong>
-              {tenantData?.info.name ? tenantData.info.name : '...'}
-            </strong>
+            <strong>{tenant?.info.name ? tenant.info.name : '...'}</strong>
           </>
         }
         className="pb-2 mb-2"
       />
-      {canConfigureNode && tenantData !== undefined && (
+      {canConfigureNode && tenant !== undefined && (
         <NodeConfigPanel
           tenantId={id || ''}
-          currentNode={tenantData.node ?? false}
+          currentNode={tenant.node ?? false}
         />
       )}
-      <TenantCapabilitiesTab tenantId={id || ''} />
+      <TenantCapabilitiesTab />
     </div>
   )
 }

--- a/src/pages/tenant-capabilities/TenantCapabilitiesTab.tsx
+++ b/src/pages/tenant-capabilities/TenantCapabilitiesTab.tsx
@@ -1,6 +1,6 @@
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
-import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import {
   ArrowBigUp,
   Check,
@@ -213,21 +213,21 @@ const CapabilityCard = ({
   )
 }
 
-interface TenantCapabilitiesTabProps {
-  tenantId: string
-}
+const TenantCapabilitiesTab = () => {
+  const {
+    tenant: tenantData,
+    isTenantLoading,
+    tenantError,
+  } = useSelectedTenant()
 
-const TenantCapabilitiesTab = ({ tenantId }: TenantCapabilitiesTabProps) => {
-  const { data: tenantData, isLoading, error } = useGetUserTenantById(tenantId)
-
-  if (isLoading)
+  if (isTenantLoading)
     return (
       <div className="flex justify-center p-8">
         <LoadingSpinner />
       </div>
     )
 
-  if (error) return <ErrorDisplay error={error} context="tenant" />
+  if (tenantError) return <ErrorDisplay error={tenantError} context="tenant" />
 
   if (!tenantData) return null
 

--- a/src/pages/tenant-details/TenantDetails.tsx
+++ b/src/pages/tenant-details/TenantDetails.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useLocation } from 'react-router-dom'
-import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import Button from '@/components/Button'
@@ -30,12 +30,12 @@ const TenantDetails = () => {
   }, [location.hash])
 
   const {
-    data: tenantData,
-    isLoading,
-    error,
-  } = useGetUserTenantById(tenantId || '')
+    tenant: tenantData,
+    isTenantLoading,
+    tenantError,
+  } = useSelectedTenant()
 
-  if (isLoading)
+  if (isTenantLoading)
     return (
       <div className="page-container">
         <div className="loading-container">
@@ -44,10 +44,10 @@ const TenantDetails = () => {
       </div>
     )
 
-  if (error)
+  if (tenantError)
     return (
       <div className="page-container p-12">
-        <ErrorDisplay error={error} context="tenant" />
+        <ErrorDisplay error={tenantError} context="tenant" />
       </div>
     )
 
@@ -62,7 +62,7 @@ const TenantDetails = () => {
     )
 
   return (
-    <div className="w-[100%] max-w-[1480px]">
+    <div className="w-full max-w-[1480px]">
       <header className="px-6 py-4">
         <div className="flex flex-col xl:flex-row items-start xl:items-center gap-4 xl:gap-6">
           <div className="flex w-full items-start justify-between xl:contents">

--- a/src/pages/tenant-details/TenantInfoTab.tsx
+++ b/src/pages/tenant-details/TenantInfoTab.tsx
@@ -1,8 +1,6 @@
 import { useEffect } from 'react'
-import {
-  useGetUserTenantById,
-  useGetUserTenantProjects,
-} from '@/hooks/useTenants'
+import { useGetUserTenantProjects } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 
@@ -35,7 +33,11 @@ interface TenantInfoTabProps {
 }
 
 const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
-  const { data: tenantData, isLoading, error } = useGetUserTenantById(tenantId)
+  const {
+    tenant: tenantData,
+    isTenantLoading,
+    tenantError,
+  } = useSelectedTenant()
 
   const {
     data: projectsData,
@@ -50,14 +52,15 @@ const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
     }
   }, [projectsData, hasNextProjectsPage, fetchNextProjectsPage])
 
-  if (isLoading)
+  if (isTenantLoading)
     return (
       <div className="loading-container">
         <LoadingSpinner size="sm" />
       </div>
     )
 
-  if (error) return <ErrorDisplay error={error} context="tenant info" />
+  if (tenantError)
+    return <ErrorDisplay error={tenantError} context="tenant info" />
 
   if (!tenantData) return null
 
@@ -109,7 +112,7 @@ const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
             ))}
           </div>
         ) : (
-          <div className="w-fit max-w-[320px] min-w-[180px] bg-surface-muted rounded-lg py-2 px-4">
+          <div className={`${cardClass} w-fit max-w-[320px] min-w-[180px]`}>
             <p className={noDataClass}>No projects assigned</p>
           </div>
         )}
@@ -139,7 +142,7 @@ const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
             ))}
           </div>
         ) : (
-          <div className={cardClass}>
+          <div className={`${cardClass} w-fit max-w-[320px] min-w-[180px]`}>
             <p className={noDataClass}>No contacts available</p>
           </div>
         )}

--- a/src/pages/tenant-details/TenantReadinessTab.tsx
+++ b/src/pages/tenant-details/TenantReadinessTab.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef } from 'react'
 import {
   useGetTenantReadiness,
-  useGetUserTenantById,
   useCheckReadinessMutation,
   useGetUserTenantStatus,
 } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import Button from '@/components/Button'
@@ -23,8 +23,8 @@ const TenantReadinessTab = ({ tenantId }: TenantReadinessTabProps) => {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [isRecentlyChecked, setIsRecentlyChecked] = useState(false)
 
-  const { data: tenantData, isLoading: tenantLoading } =
-    useGetUserTenantById(tenantId)
+  const { tenant: tenantData, isTenantLoading: tenantLoading } =
+    useSelectedTenant()
 
   const {
     data: readinessData,

--- a/src/pages/tenant-details/TenantStatusTab.tsx
+++ b/src/pages/tenant-details/TenantStatusTab.tsx
@@ -68,9 +68,7 @@ interface TenantStatusTabProps {
 }
 
 const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
-  const { profile } = useAuth()
-
-  const isSuperAdmin = profile?.roles?.includes('super_admin')
+  const { isSuperAdmin } = useAuth()
   const [expandedJobs, setExpandedJobs] = useState<Record<string, boolean>>({})
   const [editingJob, setEditingJob] = useState<string | null>(null)
   const [selectedStatus, setSelectedStatus] = useState<JobStatus | null>(null)

--- a/src/pages/tenant-reports/TenantReports.tsx
+++ b/src/pages/tenant-reports/TenantReports.tsx
@@ -1,11 +1,11 @@
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import { useParams } from 'react-router-dom'
-import { useGetUserTenantById } from '@/hooks/useTenants'
 import PageHeader from '@/components/PageHeader'
 import TenantReportsContent from './TenantReportsContent'
 
 const TenantReports = () => {
   const { id } = useParams<{ id: string }>()
-  const { data: tenantData } = useGetUserTenantById(id || '')
+  const { tenant: tenantData } = useSelectedTenant()
 
   return (
     <div className="page-container">

--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -5,7 +5,7 @@ import {
   useGetTopologyServiceTypes,
   useCreateTopologyEndpointMutation,
 } from '@/hooks/useTopology'
-import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import { toast } from 'sonner'
 import PageHeader from '@/components/PageHeader'
 import Button from '@/components/Button'
@@ -67,7 +67,7 @@ const CreateTopologyEndpoint = ({
   const navigate = useNavigate()
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const { data: tenantData } = useGetUserTenantById(tenantId)
+  const { tenant: tenantData } = useSelectedTenant()
 
   const { data: latestEndpoints, isLoading: isLoadingLatest } =
     useGetTopologyEndpoints(tenantId, '')

--- a/src/pages/tenant-topology/CreateTopologyGroup.tsx
+++ b/src/pages/tenant-topology/CreateTopologyGroup.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import {
   useGetTopologyGroups,
   useCreateTopologyGroupsMutation,
@@ -53,7 +53,7 @@ const CreateTopologyGroup = ({
   const navigate = useNavigate()
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const { data: tenantData } = useGetUserTenantById(tenantId)
+  const { tenant: tenantData } = useSelectedTenant()
 
   const { data: latestGroups, isLoading: isLoadingLatest } =
     useGetTopologyGroups(tenantId, '')

--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useLocation } from 'react-router-dom'
-import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import PageHeader from '@/components/PageHeader'
 import Tabs from '@/components/Tabs'
 import TopologyEndpoints from './TopologyEndpoints'
@@ -20,7 +20,7 @@ const TenantTopology = () => {
   const { id } = useParams<{ id: string }>()
   const tenantId = id ?? ''
 
-  const { data: tenantData } = useGetUserTenantById(tenantId)
+  const { tenant: tenantData } = useSelectedTenant()
 
   const location = useLocation()
   const [activeTab, setActiveTab] = useState<

--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
-import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import {
   useGetTopologyEndpoints,
   useCreateTopologyEndpointMutation,
@@ -35,7 +35,7 @@ interface TopologyEndpointsProps {
 }
 
 const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
-  const { data: tenantData } = useGetUserTenantById(tenantId)
+  const { tenant: tenantData } = useSelectedTenant()
   const [monitoredFilter, setMonitoredFilter] = useState<
     'all' | 'monitored' | 'not_monitored'
   >('all')

--- a/src/pages/tenant-topology/TopologyGroups.tsx
+++ b/src/pages/tenant-topology/TopologyGroups.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
-import { useGetUserTenantById } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import {
   useGetTopologyGroups,
   useCreateTopologyGroupsMutation,
@@ -34,7 +34,7 @@ interface TopologyGroupsProps {
 }
 
 const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
-  const { data: tenantData } = useGetUserTenantById(tenantId)
+  const { tenant: tenantData } = useSelectedTenant()
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [groupToDelete, setGroupToDelete] = useState<{
     group: GroupTopologyItem
@@ -163,10 +163,10 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
         </div>
       </div>
 
-      <DataTable tableClassName="table-fixed">
+      <DataTable>
         <thead className="bg-surface-strong border-b border-line">
           <tr>
-            <th className={`${thBase} w-[30%]`}>
+            <th className={`${thBase} w-[25%]`}>
               <SortableColumnHeader
                 isActive={sortColumn === 'subgroup'}
                 isAscending={sortAsc}
@@ -175,9 +175,9 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
                 Group
               </SortableColumnHeader>
             </th>
-            <th className={`${thBase} w-[40%]`}>Contacts</th>
-            <th className={`${thBase} w-[15%]`}>Date</th>
-            {showActions && <th className={`${thBase} w-[8%]`}>Actions</th>}
+            <th className={`${thBase}`}>Contacts</th>
+            <th className={`${thBase} w-44`}>Date</th>
+            {showActions && <th className={`${thBase} w-30`}>Actions</th>}
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
@@ -224,7 +224,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
                   {group.notifications?.contacts?.length ? (
                     <div className="flex flex-wrap gap-x-2 gap-y-0.5">
                       {group.notifications.contacts.map((contact, i, arr) => (
-                        <span key={contact}>
+                        <span key={contact} className="truncate">
                           {contact}
                           {i < arr.length - 1 ? ',' : ''}
                         </span>

--- a/src/routing/ProtectedRoute.tsx
+++ b/src/routing/ProtectedRoute.tsx
@@ -15,7 +15,7 @@ function ProtectedRoute({
   requiredRoles,
   redirectTo = '/',
 }: RoleProtectedProps) {
-  const { initialized, authenticated, profile } = useAuth()
+  const { initialized, authenticated, isSuperAdmin, profile } = useAuth()
   const location = useLocation()
   const [profileTimeout, setProfileTimeout] = useState(false)
 
@@ -50,8 +50,6 @@ function ProtectedRoute({
       </div>
     )
   }
-
-  const isSuperAdmin = profile?.roles?.includes('super_admin')
 
   const hasRequiredRole = (() => {
     if (isSuperAdmin) {


### PR DESCRIPTION
This PR adds a shared selected tenant context and migrates all sidebar tenant pages to consume it.

- Added a shared selected tenant context that provides the active tenant to all sidebar pages
- Refactored sidebar pages to use the shared context instead of fetching tenant data individually