### PR TITLE
[ARGO-5512] - Update topology endpoint form to separate URL and hostname fields

### DIFF
--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -34,7 +34,7 @@ const today = new Date().toISOString().split('T')[0]
 
 interface FormData {
   service: string
-  hostname: string
+  url: string
   tags: string[]
   group: string
   monitored: boolean
@@ -45,7 +45,7 @@ interface FormData {
 
 interface FormErrors {
   service: string
-  hostname: string
+  url: string
   group: string
   contacts: string[]
 }
@@ -87,7 +87,7 @@ const CreateTopologyEndpoint = ({
       const labelsTag = editingEndpoint.tags?.labels ?? ''
       return {
         service: editingEndpoint.service,
-        hostname: editingEndpoint.hostname,
+        url: editingEndpoint.tags?.info_URL ?? editingEndpoint.hostname,
         tags: labelsTag
           ? labelsTag
               .split(',')
@@ -110,7 +110,7 @@ const CreateTopologyEndpoint = ({
     }
     return {
       service: '',
-      hostname: '',
+      url: '',
       tags: [],
       group: '',
       monitored: true,
@@ -122,7 +122,7 @@ const CreateTopologyEndpoint = ({
 
   const [errors, setErrors] = useState<FormErrors>({
     service: '',
-    hostname: '',
+    url: '',
     group: '',
     contacts: [''],
   })
@@ -142,11 +142,11 @@ const CreateTopologyEndpoint = ({
     }
   }
 
-  const handleHostnameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
-    setFormData((prev) => ({ ...prev, hostname: value }))
+    setFormData((prev) => ({ ...prev, url: value }))
     if (value.trim()) {
-      setErrors((prev) => ({ ...prev, hostname: '' }))
+      setErrors((prev) => ({ ...prev, url: '' }))
     }
   }
 
@@ -189,7 +189,7 @@ const CreateTopologyEndpoint = ({
   const handleSubmit = () => {
     const newErrors: FormErrors = {
       service: '',
-      hostname: '',
+      url: '',
       group: '',
       contacts: formData.contacts.map(() => ''),
     }
@@ -201,8 +201,8 @@ const CreateTopologyEndpoint = ({
       hasError = true
     }
 
-    if (!formData.hostname.trim()) {
-      newErrors.hostname = 'URL is required'
+    if (!formData.url.trim()) {
+      newErrors.url = 'URL is required'
       hasError = true
     }
 
@@ -232,11 +232,21 @@ const CreateTopologyEndpoint = ({
       return
     }
 
+    const fullUrl = formData.url.trim()
+    let extractedHostname = fullUrl
+    try {
+      extractedHostname = new URL(fullUrl).hostname
+    } catch (e) {
+      console.warn('Could not parse URL hostname:', e)
+    }
+
     const updatedFields = {
       service: formData.service,
-      hostname: formData.hostname.trim(),
+      hostname: extractedHostname,
       tags: {
         monitored: formData.monitored ? '1' : '0',
+        info_URL: fullUrl,
+        hostname: extractedHostname,
         ...(formData.tags.length > 0
           ? { labels: formData.tags.join(',') }
           : {}),
@@ -253,17 +263,18 @@ const CreateTopologyEndpoint = ({
     }
 
     const payload = isEditMode
-      ? [
-          ...(latestEndpoints ?? []).filter(
-            (e) => e.hostname !== editingEndpoint.hostname,
-          ),
-          {
-            ...editingEndpoint,
-            ...updatedFields,
-            group: formData.group,
-            date: today,
-          },
-        ]
+      ? (latestEndpoints ?? []).map((e) =>
+          (e.tags?.info_URL ?? e.hostname) ===
+            (editingEndpoint.tags?.info_URL ?? editingEndpoint.hostname) &&
+          e.service === editingEndpoint.service
+            ? {
+                ...editingEndpoint,
+                ...updatedFields,
+                group: formData.group,
+                date: today,
+              }
+            : e,
+        )
       : [
           ...(latestEndpoints ?? []),
           {
@@ -402,20 +413,18 @@ const CreateTopologyEndpoint = ({
             </label>
             <input
               type="text"
-              name="hostname"
-              value={formData.hostname}
-              onChange={handleHostnameChange}
+              name="url"
+              value={formData.url}
+              onChange={handleUrlChange}
               placeholder="Enter the endpoint URL"
               className={
-                errors.hostname
+                errors.url
                   ? '!border-red-500 focus:!border-red-500 focus:!ring-red-500/10'
                   : ''
               }
             />
-            {errors.hostname && (
-              <span className="text-xs text-red-500 mt-1">
-                {errors.hostname}
-              </span>
+            {errors.url && (
+              <span className="text-xs text-red-500 mt-1">{errors.url}</span>
             )}
           </div>
 

--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -125,6 +125,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
       e.service.toLowerCase().includes(q) ||
       e.group.toLowerCase().includes(q) ||
       e.hostname.toLowerCase().includes(q) ||
+      (e.tags?.info_URL ?? '').toLowerCase().includes(q) ||
       monitoredLabel.includes(q)
     )
   })
@@ -144,7 +145,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           value={searchInput}
           onChange={setSearchInput}
           onClear={handleSearchClear}
-          placeholder="Search by service, URL or group..."
+          placeholder="Search by service, hostname, URL or group..."
           className="!mb-0 flex-1 max-w-xs xl:max-w-none"
         />
         {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
@@ -205,6 +206,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
                 Service
               </SortableColumnHeader>
             </th>
+            <th className={`${thBase} min-w-32`}>Hostname</th>
             <th className={`${thBase} min-w-40`}>URL</th>
             <th className={`${thBase} min-w-24`}>
               <SortableColumnHeader
@@ -231,7 +233,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
         <tbody className="divide-y divide-gray-100">
           {isLoading || isFetching ? (
             <tr>
-              <td colSpan={showActions ? 6 : 5} className="py-12">
+              <td colSpan={showActions ? 7 : 6} className="py-12">
                 <div className="flex justify-center">
                   <LoadingSpinner size="md" />
                 </div>
@@ -239,14 +241,14 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
             </tr>
           ) : error ? (
             <tr>
-              <td colSpan={showActions ? 6 : 5} className="py-6 px-12">
+              <td colSpan={showActions ? 7 : 6} className="py-6 px-12">
                 <ErrorDisplay error={error} context="topology endpoints" />
               </td>
             </tr>
           ) : !endpoints?.length ? (
             <tr>
               <td
-                colSpan={showActions ? 6 : 5}
+                colSpan={showActions ? 7 : 6}
                 className="text-center text-sm text-subtle italic py-6 px-12"
               >
                 No topology endpoints found
@@ -255,7 +257,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           ) : !paginated.length ? (
             <tr>
               <td
-                colSpan={showActions ? 6 : 5}
+                colSpan={showActions ? 7 : 6}
                 className="text-center text-sm text-subtle italic py-6 px-12"
               >
                 No endpoints match your filters
@@ -264,12 +266,19 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           ) : (
             paginated.map((endpoint) => (
               <tr
-                key={`${endpoint.hostname}_${endpoint.service}`}
+                key={`${endpoint.tags?.info_URL ?? endpoint.hostname}_${endpoint.service}`}
                 className="hover:bg-surface-muted transition-colors"
               >
                 <td className={tdBase}>{endpoint.service}</td>
                 <td className={`${tdBase} font-mono text-xs break-all`}>
-                  {endpoint.hostname}
+                  {endpoint.hostname || (
+                    <span className="pl-2 text-subtle">-</span>
+                  )}
+                </td>
+                <td className={`${tdBase} font-mono text-xs break-all`}>
+                  {endpoint.tags?.info_URL || (
+                    <span className="pl-2 text-subtle">-</span>
+                  )}
                 </td>
                 <td className={tdBase}>{endpoint.group}</td>
                 <td className={tdBase}>
@@ -333,7 +342,11 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
         message={
           <>
             Are you sure you want to delete the endpoint with URL{' '}
-            <strong>{endpointToDelete?.endpoint.hostname}</strong> ?
+            <strong>
+              {endpointToDelete?.endpoint.tags?.info_URL ??
+                endpointToDelete?.endpoint.hostname}
+            </strong>{' '}
+            ?
             <br />
             <span className="text-amber-600 font-medium">
               This action cannot be undone.


### PR DESCRIPTION
This PR updates the topology endpoint form to handle the URL and extracted hostname as separate values.

- Updated CreateTopologyEndpoint to store the full URL and extracted domain as separate fields in the endpoint payload
- Added separate Hostname and URL columns to the TopologyEndpoints table
- Updated search to match against both hostname and URL fields