### PR TITLE
[ARGO-5515] - Refactor capabilities page node configuration and status display

### DIFF
--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -598,6 +598,12 @@ export const useSetTenantNodeMutation = () => {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['user-tenant', variables.id] })
       queryClient.invalidateQueries({ queryKey: ['user-tenants'] })
+      queryClient.invalidateQueries({
+        queryKey: ['tenant-capability-availability', variables.id],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['tenant-capability-status', variables.id],
+      })
     },
     onError: (error) => {
       console.error('Set tenant node error:', error)
@@ -622,6 +628,12 @@ export const useSetNodeReportMutation = () => {
       })
       queryClient.invalidateQueries({
         queryKey: ['user-tenant', variables.tenantId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['tenant-capability-availability', variables.tenantId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['tenant-capability-status', variables.tenantId],
       })
     },
     onError: (error) => {

--- a/src/pages/build-status-page/BuildItemsTab.tsx
+++ b/src/pages/build-status-page/BuildItemsTab.tsx
@@ -116,8 +116,20 @@ const BuildItemsTab = ({
                       Drag and drop items to the preview panel to add them to a
                       group
                     </div>
-                    <div className="max-h-[500px] overflow-y-auto border border-line rounded px-4 py-1">
-                      <ul ref={parent}>
+                    <div className="max-h-[500px] overflow-y-auto border border-line rounded px-4 py-2 relative">
+                      {groupsFiltered.length === 0 && (
+                        <div className="absolute inset-0 flex flex-col items-center justify-center text-sm text-muted pointer-events-none text-xs text-subtle">
+                          Drop items here to unassign them
+                        </div>
+                      )}
+                      <ul
+                        ref={parent}
+                        className={
+                          groupsFiltered.length === 0
+                            ? 'min-h-16'
+                            : 'min-h-2 pb-2'
+                        }
+                      >
                         {(groupsFiltered ?? []).map((group) => (
                           <li key={group.name} className="my-2">
                             <StatusItem

--- a/src/pages/tenant-capabilities/CapabilityCard.tsx
+++ b/src/pages/tenant-capabilities/CapabilityCard.tsx
@@ -1,5 +1,5 @@
-import { type ReactElement } from 'react'
-import { ChevronRight } from 'lucide-react'
+import { type ReactElement, type ReactNode, useState } from 'react'
+import { ChevronRight, ChevronDown, ChevronUp } from 'lucide-react'
 import CapabilityEndpoint from './CapabilityEndpoint'
 
 const statItemClass = 'flex flex-col items-end border-l border-slate-100 pl-3'
@@ -9,8 +9,9 @@ const statValueClass = 'text-xl font-black leading-none mt-0.5'
 
 export interface Stats {
   name: string
-  value: number
+  value: number | string
   colorClass?: string
+  icon?: ReactElement
 }
 
 interface CapabilityCardProps {
@@ -26,6 +27,7 @@ interface CapabilityCardProps {
   stats?: Stats[]
   statsPlaceholder?: string
   statsPlaceholderLabel?: string
+  details?: ReactNode
 }
 
 const CapabilityCard = ({
@@ -41,7 +43,10 @@ const CapabilityCard = ({
   stats,
   statsPlaceholder,
   statsPlaceholderLabel,
+  details,
 }: CapabilityCardProps) => {
+  const [expanded, setExpanded] = useState(false)
+
   return (
     <div className="flex flex-col bg-white rounded-xl border border-slate-200 shadow-sm hover:shadow-md transition-all duration-300 overflow-hidden">
       <div className="p-4 flex-1">
@@ -55,17 +60,32 @@ const CapabilityCard = ({
             </h2>
           </div>
           <div className="flex items-center gap-3">
-            {stats
+            {stats && stats.length > 0
               ? stats.map((item) => (
                   <div key={item.name} className={statItemClass}>
                     <span className={statLabelClass}>
                       {item.name || 'Stat'}
                     </span>
-                    <span
-                      className={`${statValueClass} ${item.colorClass ? item.colorClass : item.value > 90 ? 'text-green-600' : item.value > 70 ? 'text-amber-600' : 'text-red-600'}`}
-                    >
-                      {item.value}
-                    </span>
+                    <div className="flex items-center gap-1.5 mt-0.5">
+                      {item.icon && (
+                        <div className={item.colorClass}>{item.icon}</div>
+                      )}
+                      <span
+                        className={`${statValueClass} ${
+                          item.colorClass
+                            ? item.colorClass
+                            : typeof item.value === 'number'
+                              ? item.value > 90
+                                ? 'text-green-600'
+                                : item.value > 70
+                                  ? 'text-amber-600'
+                                  : 'text-red-600'
+                              : 'text-slate-700'
+                        }`}
+                      >
+                        {item.value}
+                      </span>
+                    </div>
                   </div>
                 ))
               : statsPlaceholder && (
@@ -86,6 +106,27 @@ const CapabilityCard = ({
         <p className="text-sm text-slate-500 mb-4 leading-normal">
           {description}
         </p>
+
+        {details && (
+          <div className="mb-2">
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="text-xs text-brand font-medium flex items-center gap-1 hover:text-brand-strong transition-colors focus:outline-none cursor-pointer"
+            >
+              {expanded ? (
+                <ChevronUp className="size-3" />
+              ) : (
+                <ChevronDown className="size-3" />
+              )}
+              {expanded ? 'Hide status breakdown' : 'Show status breakdown'}
+            </button>
+            {expanded && (
+              <div className="mt-1 text-sm text-slate-600 p-3 bg-slate-50 rounded-lg border border-slate-100">
+                {details}
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="space-y-3">
           <CapabilityEndpoint label="User Interface" url={uiUrl} />

--- a/src/pages/tenant-capabilities/NodeConfigPanel.tsx
+++ b/src/pages/tenant-capabilities/NodeConfigPanel.tsx
@@ -1,172 +1,136 @@
-import { useState, useEffect } from 'react'
 import {
   useGetTenantReports,
   useSetTenantNodeMutation,
   useSetNodeReportMutation,
 } from '@/hooks/useTenants'
-import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/16/solid'
 import { toast } from 'sonner'
 import SelectDropdown from '@/components/SelectDropdown'
-import Button from '@/components/Button'
 import LoadingSpinner from '@/components/LoadingSpinner'
 
 interface NodeConfigPanelProps {
   tenantId: string
-  currentNode: boolean
+  isNodeEnabled: boolean
 }
 
-const NodeConfigPanel = ({ tenantId, currentNode }: NodeConfigPanelProps) => {
-  const [isOpen, setIsOpen] = useState(true)
-  const [nodeEnabled, setNodeEnabled] = useState(currentNode)
-  const [selectedReportId, setSelectedReportId] = useState('')
-  const [reportError, setReportError] = useState('')
-
+const NodeConfigPanel = ({ tenantId, isNodeEnabled }: NodeConfigPanelProps) => {
   const { data: reports, isLoading: reportsLoading } = useGetTenantReports(
     tenantId,
     undefined,
-    isOpen,
   )
-
-  useEffect(() => {
-    setNodeEnabled(currentNode)
-  }, [currentNode])
-
-  useEffect(() => {
-    if (reports) {
-      setSelectedReportId(reports.find((r) => r.node_report)?.id ?? '')
-    }
-  }, [reports])
 
   const setNodeMutation = useSetTenantNodeMutation()
   const setNodeReportMutation = useSetNodeReportMutation()
 
+  const currentSavedReportId = reports?.find((r) => r.node_report)?.id ?? ''
+
   const reportOptions =
-    reports?.map((r) => ({ value: r.id, label: r.name })) ?? []
-  const hasReports = reports && reports?.length > 0
+    reports?.map((report) => ({ value: report.id, label: report.name })) ?? []
+  const hasReports = reports && reports.length > 0
   const isPending = setNodeMutation.isPending || setNodeReportMutation.isPending
 
-  const handleCancel = () => {
-    setNodeEnabled(currentNode)
-    setSelectedReportId(reports?.find((r) => r.node_report)?.id ?? '')
-    setReportError('')
-    setIsOpen(false)
+  const hasSavedReport = !!currentSavedReportId
+
+  const handleReportChange = async (reportId: string) => {
+    if (!reportId) return
+    const toastId = toast.loading('Saving node report...')
+    try {
+      await setNodeReportMutation.mutateAsync({
+        tenantId,
+        reportId,
+      })
+      toast.success('Node report assigned successfully', { id: toastId })
+    } catch (error) {
+      toast.error(
+        `Failed to save report: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { id: toastId },
+      )
+    }
   }
 
-  const handleSave = async () => {
-    if (nodeEnabled && !selectedReportId) {
-      setReportError('A report is required when node is enabled')
-      return
-    }
-    setReportError('')
-
-    const toastId = toast.loading('Saving node configuration...')
-
+  const handleToggleNode = async () => {
+    const newValue = !isNodeEnabled
+    const toastId = toast.loading(
+      `${newValue ? 'Enabling' : 'Disabling'} node status...`,
+    )
     try {
-      await setNodeMutation.mutateAsync({ id: tenantId, node: nodeEnabled })
-
-      if (selectedReportId) {
-        await setNodeReportMutation.mutateAsync({
-          tenantId,
-          reportId: selectedReportId,
-        })
-      }
-
-      toast.dismiss(toastId)
-      toast.success('Node configuration saved')
-      setIsOpen(false)
+      await setNodeMutation.mutateAsync({ id: tenantId, node: newValue })
+      toast.success(`Node successfully ${newValue ? 'enabled' : 'disabled'}`, {
+        id: toastId,
+      })
     } catch (error) {
-      toast.dismiss(toastId)
       toast.error(
-        `Failed to save: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Failed to update node status: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { id: toastId },
       )
     }
   }
 
   return (
-    <div className={isOpen ? 'mb-8' : 'mb-6'}>
-      <p className="text-sm text-muted mb-1">
-        Enable this tenant as a node and assign a default node report
-      </p>
-      <div className="max-w-lg bg-white border border-line rounded-lg overflow-hidden">
-        <button
-          type="button"
-          onClick={() => setIsOpen((prev) => !prev)}
-          className="flex items-center justify-between w-full px-3 py-2 text-sm bg-surface-muted font-semibold text-muted hover:text-body hover:bg-surface-muted transition-colors cursor-pointer"
-        >
-          Configure Node
-          {isOpen ? (
-            <ChevronUpIcon className="size-5" />
+    <div className="mb-6 max-w-3xl bg-white border border-line rounded-lg py-3 px-4">
+      <h3 className="text-base font-semibold text-foreground mb-3">
+        Node Configuration
+      </h3>
+
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div className="flex-1">
+          <span className="text-sm font-semibold text-body block">
+            Node Report
+          </span>
+          <span className="text-xs text-muted">
+            Assign the default report for this node
+          </span>
+        </div>
+        <div className="w-full sm:w-52 flex items-center h-10">
+          {reportsLoading ? (
+            <LoadingSpinner size="sm" />
           ) : (
-            <ChevronDownIcon className="size-5" />
+            <SelectDropdown
+              value={currentSavedReportId}
+              onChange={handleReportChange}
+              options={reportOptions}
+              placeholder={
+                hasReports ? 'Select a report...' : 'No reports available'
+              }
+              disabled={isPending || !hasReports}
+            />
           )}
-        </button>
+        </div>
+      </div>
 
-        {isOpen && (
-          <div className="px-4 py-3 animate-fade-in">
-            {reportsLoading ? (
-              <div className="flex justify-center py-4">
-                <LoadingSpinner size="sm" />
-              </div>
-            ) : !hasReports ? (
-              <p className="text-sm text-amber-600 font-medium mb-3">
-                There are no available reports to select.
-              </p>
-            ) : null}
+      <hr className="border-line my-4" />
 
-            {!reportsLoading && (
-              <>
-                <div className="flex flex-col gap-3">
-                  <label className="flex items-center gap-3 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      className="toggle toggle-brand"
-                      checked={nodeEnabled}
-                      onChange={() => setNodeEnabled((prev) => !prev)}
-                      disabled={isPending}
-                    />
-                    <span className="text-sm font-semibold text-body">
-                      {nodeEnabled ? 'Node enabled' : 'Node disabled'}
-                    </span>
-                  </label>
-
-                  <div className="flex flex-col gap-1">
-                    <label className="text-sm font-semibold text-muted px-1">
-                      Node report <span className="required">*</span>
-                    </label>
-                    <SelectDropdown
-                      value={selectedReportId}
-                      onChange={(value) => {
-                        setSelectedReportId(value)
-                        if (value) setReportError('')
-                      }}
-                      options={reportOptions}
-                      placeholder="Select a report"
-                      disabled={!hasReports || isPending}
-                    />
-                    {reportError && (
-                      <span className="text-xs text-red-500 mt-1 px-1">
-                        {reportError}
-                      </span>
-                    )}
-                  </div>
-                </div>
-
-                <div className="flex gap-4 justify-end mt-4">
-                  <Button
-                    onClick={handleCancel}
-                    size="sm"
-                    variant="outline-secondary"
-                  >
-                    Cancel
-                  </Button>
-                  <Button onClick={handleSave} size="sm" disabled={isPending}>
-                    Save
-                  </Button>
-                </div>
-              </>
-            )}
-          </div>
-        )}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div className="flex-1">
+          <span
+            className={`text-sm font-semibold block ${
+              hasSavedReport ? 'text-body' : 'text-muted'
+            }`}
+          >
+            Node Status
+          </span>
+          <span className="text-xs text-muted">
+            {!hasSavedReport
+              ? 'A report must be selected first'
+              : 'Enable or disable this node'}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <span
+            className={`text-sm font-medium ${
+              !hasSavedReport ? 'text-muted' : 'text-body'
+            }`}
+          >
+            {isNodeEnabled ? 'Enabled' : 'Disabled'}
+          </span>
+          <input
+            type="checkbox"
+            className="toggle toggle-sm toggle-brand"
+            checked={isNodeEnabled}
+            onChange={handleToggleNode}
+            disabled={isPending || !hasSavedReport}
+            aria-label="Enable or disable node status"
+          />
+        </div>
       </div>
     </div>
   )

--- a/src/pages/tenant-capabilities/TenantCapabilities.tsx
+++ b/src/pages/tenant-capabilities/TenantCapabilities.tsx
@@ -1,15 +1,30 @@
 import { useParams } from 'react-router-dom'
 import { useAuth } from '@/auth/useAuth'
 import { useSelectedTenant } from '@/contexts/selected-tenant'
+import { useGetTenantReports } from '@/hooks/useTenants'
+import { Info } from 'lucide-react'
 import PageHeader from '@/components/PageHeader'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
 import TenantCapabilitiesTab from './TenantCapabilitiesTab'
 import NodeConfigPanel from './NodeConfigPanel'
 
 const TenantCapabilities = () => {
   const { id } = useParams<{ id: string }>()
   const { isSuperAdmin } = useAuth()
-  const { tenant, isTenantAdmin } = useSelectedTenant()
+  const { tenant, isTenantLoading, tenantError, isTenantAdmin } =
+    useSelectedTenant()
   const canConfigureNode = isSuperAdmin || isTenantAdmin
+
+  const {
+    data: reports,
+    isLoading: isReportsLoading,
+    error: reportsError,
+  } = useGetTenantReports(tenant?.id || '', undefined, !!tenant?.id)
+
+  const isNodeEnabled = !!tenant?.node
+  const hasNodeReport = reports?.some((report) => !!report.node_report)
+  const capabilitiesEnabled = isNodeEnabled && hasNodeReport
 
   return (
     <div className="page-container">
@@ -23,13 +38,43 @@ const TenantCapabilities = () => {
         }
         className="pb-2 mb-2"
       />
-      {canConfigureNode && tenant !== undefined && (
-        <NodeConfigPanel
-          tenantId={id || ''}
-          currentNode={tenant.node ?? false}
+
+      {isTenantLoading || isReportsLoading ? (
+        <div className="loading-container">
+          <LoadingSpinner size="md" />
+        </div>
+      ) : tenantError || reportsError ? (
+        <ErrorDisplay
+          error={(tenantError || reportsError) as Error}
+          context="capabilities"
         />
+      ) : (
+        <>
+          {canConfigureNode && tenant !== undefined && (
+            <NodeConfigPanel
+              tenantId={id || ''}
+              isNodeEnabled={tenant.node ?? false}
+            />
+          )}
+          {!capabilitiesEnabled ? (
+            <div className="flex flex-col items-center justify-center py-4 px-6 text-center rounded-xl bg-surface-muted mt-2">
+              <div className="bg-surface-strong p-2.5 rounded-full mb-2">
+                <Info className="size-5 text-muted" />
+              </div>
+              <h3 className="text-base font-semibold text-foreground mb-1">
+                Node Configuration Required
+              </h3>
+              <p className="text-sm text-muted max-w-md">
+                {canConfigureNode
+                  ? 'Please select a node report and enable node status above to view capabilities.'
+                  : 'This tenant is not currently configured as an active node. Capability data will be available here once the node is fully enabled.'}
+              </p>
+            </div>
+          ) : (
+            <TenantCapabilitiesTab />
+          )}
+        </>
       )}
-      <TenantCapabilitiesTab />
     </div>
   )
 }

--- a/src/pages/tenant-capabilities/TenantCapabilitiesTab.tsx
+++ b/src/pages/tenant-capabilities/TenantCapabilitiesTab.tsx
@@ -10,6 +10,24 @@ import CapabilityCard from './CapabilityCard'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 
+const statusConfig = [
+  { status: 'CRITICAL', colorClass: 'text-red-500', label: 'Critical' },
+  { status: 'DOWNTIME', colorClass: 'text-slate-500', label: 'Downtime' },
+  { status: 'WARNING', colorClass: 'text-yellow-500', label: 'Warning' },
+  { status: 'UNKNOWN', colorClass: 'text-slate-400', label: 'Unknown' },
+  { status: 'MISSING', colorClass: 'text-blue-500', label: 'Missing' },
+  { status: 'OK', colorClass: 'text-green-600', label: 'OK' },
+]
+
+const statusDisplayOrder = [
+  'OK',
+  'CRITICAL',
+  'WARNING',
+  'MISSING',
+  'DOWNTIME',
+  'UNKNOWN',
+]
+
 const TenantCapabilitiesTab = () => {
   const {
     tenant: tenantData,
@@ -42,37 +60,51 @@ const TenantCapabilitiesTab = () => {
     return [{ name: 'Avg Avail', value: avg }]
   })()
 
-  const statusStats = (() => {
+  const { statusStats, statusDetails } = (() => {
     const results = statusData?.data?.[0]?.results ?? []
     if (results.length === 0) {
-      return undefined
+      return { statusStats: undefined, statusDetails: null }
     }
-    const count = (value: string) =>
-      results.filter((result) => result.value === value).length
-    return [
-      { name: 'Operational', value: count('OK'), colorClass: 'text-green-600' },
-      {
-        name: 'Warning',
-        value: count('WARNING'),
-        colorClass: 'text-amber-500',
-      },
-      {
-        name: 'Critical',
-        value: count('CRITICAL'),
-        colorClass: 'text-red-500',
-      },
-      {
-        name: 'Unknown',
-        value: count('UNKNOWN'),
-        colorClass: 'text-slate-400',
-      },
-      { name: 'Missing', value: count('MISSING'), colorClass: 'text-blue-500' },
-      {
-        name: 'Downtime',
-        value: count('DOWNTIME'),
-        colorClass: 'text-slate-500',
-      },
-    ].filter((s) => s.value > 0)
+
+    const count = (status: string) =>
+      results.filter((r) => r.value === status).length
+
+    const counts = statusConfig
+      .map((p) => ({ ...p, count: count(p.status) }))
+      .filter((c) => c.count > 0)
+
+    if (counts.length === 0) {
+      return { statusStats: undefined, statusDetails: null }
+    }
+
+    const top = counts[0]
+
+    const statusStats = [
+      { name: 'Current State', value: top.label, colorClass: top.colorClass },
+    ]
+
+    const statusDetails = (
+      <div className="flex flex-wrap gap-x-4 gap-y-2">
+        {[...counts]
+          .sort(
+            (a, b) =>
+              statusDisplayOrder.indexOf(a.status) -
+              statusDisplayOrder.indexOf(b.status),
+          )
+          .map((c) => (
+            <div key={c.label} className="flex items-center gap-1">
+              <span className={`font-semibold text-xs ${c.colorClass}`}>
+                {c.label}
+              </span>
+              <span className="text-[10px] font-bold text-slate-500 bg-white border border-slate-200 px-1.5 py-0.5 rounded-full leading-none">
+                {c.count}
+              </span>
+            </div>
+          ))}
+      </div>
+    )
+
+    return { statusStats, statusDetails }
   })()
 
   if (isTenantLoading)
@@ -94,7 +126,7 @@ const TenantCapabilitiesTab = () => {
         description="Percentage of time a service is fully functional and accessible, based on monitored status history."
         uiUrl={`${tenantData.metadata?.instance?.ui_url}/${tenantData.info.name}/report-ar/CORE/SERVICEGROUPS`}
         apiUrl={`${BACKEND_API}/api/tenants/${tenantData.info.name}/results/ar`}
-        apiDoc={`${BACKEND_API}/swagger-ui/#/Admin/get_v1_admin_tenants__id__status`}
+        apiDoc={`${BACKEND_API}/swagger-ui/#/Capabilities/get_v1_tenants__id__capabilities_availability`}
         apiAccess={`${BACKEND_API}/oidc-client`}
         icon={<ClockIcon />}
         docUrl="https://argoeu.github.io/argo-monitoring/docs/reports/ar#availability"
@@ -107,11 +139,12 @@ const TenantCapabilitiesTab = () => {
         description="Real-time chronological health timelines, tracking states between OK, Warning, and Critical transitions."
         uiUrl={`${tenantData.metadata?.instance?.ui_url}/${tenantData.info.name}/report-status/CORE/SERVICEGROUPS`}
         apiUrl={`${BACKEND_API}/api/tenants/${tenantData.info.name}/status`}
-        apiDoc={`${BACKEND_API}/swagger-ui/#/Admin/get_v1_admin_tenants__id__status`}
+        apiDoc={`${BACKEND_API}/swagger-ui/#/Capabilities/get_v1_tenants__id__capabilities_status`}
         apiAccess={`${BACKEND_API}/oidc-client`}
         icon={<Rows4 />}
         docUrl="https://argoeu.github.io/argo-monitoring/docs/reports/status_timelines"
         stats={statusStats}
+        details={statusDetails}
       />
 
       <CapabilityCard


### PR DESCRIPTION
This PR refactors the Capabilities page to improve node configuration and status card data display.

- Refactored NodeConfigPanel with separate report selection and node toggle controls
- Added node and report requirement check to TenantCapabilities before showing capability cards
- Updated TenantCapabilitiesTab status stats to show current state with expandable breakdown
- Added capability query invalidation to node and report mutations