### PR TITLE
[ARGO-5516] - Hide actions column in topology tables for GOCDB topology type

### DIFF
--- a/src/pages/tenant-topology/hooks/useTopologyListState.ts
+++ b/src/pages/tenant-topology/hooks/useTopologyListState.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 
 type DateMode = 'latest' | 'custom'
 
@@ -33,9 +34,13 @@ export const useTopologyListState = <TSort extends string>({
     setCurrentPage(1)
   }, [committedDate])
 
+  const { tenant } = useSelectedTenant()
+  const isGocdb = tenant?.metadata?.instance?.topology?.type === 'GOCDB'
+
   const showActions =
-    dateMode === 'latest' ||
-    (dateMode === 'custom' && committedDate === latestDate && !!latestDate)
+    !isGocdb &&
+    (dateMode === 'latest' ||
+      (dateMode === 'custom' && committedDate === latestDate && !!latestDate))
 
   const handleDateInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDateInput(e.target.value)


### PR DESCRIPTION
This PR hides the Actions column in topology tables when the tenant topology type is GOCDB.