### PR TITLE
[ARGO-5520] - Include info_ID tag field in topology endpoint payload

### DIFF
--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -97,7 +97,10 @@ const CreateTopologyEndpoint = ({
         group: editingEndpoint.group,
         monitored: editingEndpoint.tags?.monitored === '1',
         metadata: Object.entries(editingEndpoint.tags ?? {})
-          .filter(([key]) => key !== 'monitored' && key !== 'labels')
+          .filter(
+            ([key]) =>
+              key !== 'monitored' && key !== 'labels' && key !== 'info_ID',
+          )
           .map(([key, value]) => ({ id: crypto.randomUUID(), key, value })),
         notificationsEnabled: editingEndpoint.notifications?.enabled ?? false,
         contacts: editingEndpoint.notifications?.contacts?.length
@@ -255,6 +258,9 @@ const CreateTopologyEndpoint = ({
             .filter((label) => label.key.trim())
             .map((label) => [label.key.trim(), label.value.trim()]),
         ),
+        ...(editingEndpoint?.tags?.info_ID
+          ? { info_ID: editingEndpoint.tags.info_ID }
+          : {}),
       },
       notifications: {
         enabled: formData.notificationsEnabled,
@@ -524,6 +530,22 @@ const CreateTopologyEndpoint = ({
               {
                 key: 'labels',
                 message: '"labels" cannot be used as a key',
+              },
+              {
+                key: 'monitored',
+                message: '"monitored" cannot be used as a key',
+              },
+              {
+                key: 'info_ID',
+                message: '"info_ID" cannot be used as a key',
+              },
+              {
+                key: 'info_URL',
+                message: '"info_URL" cannot be used as a key',
+              },
+              {
+                key: 'hostname',
+                message: '"hostname" cannot be used as a key',
               },
             ]}
           />

--- a/src/pages/tenant-topology/KeyValueInput.tsx
+++ b/src/pages/tenant-topology/KeyValueInput.tsx
@@ -47,9 +47,7 @@ const KeyValueInput = ({
     if (!disallowedKeys || !key.trim()) {
       return ''
     }
-    const match = disallowedKeys.find(
-      (dk) => dk.key.toLowerCase() === key.trim().toLowerCase(),
-    )
+    const match = disallowedKeys.find((dk) => dk.key === key.trim())
     return match?.message ?? ''
   }
 


### PR DESCRIPTION
This PR ensures the info_ID tag field is preserved in the topology endpoint payload on both create and update.

- Preserved info_ID from the original endpoint data when building the request payload
- Extended the metadata key blocklist with all reserved tag fields
- Changed disallowed key validation to exact-match (case-sensitive)