### PR TITLE
[ARGO-5527] - Add automatic ID assignment for topology endpoints

### DIFF
--- a/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
+++ b/src/pages/tenant-topology/CreateTopologyEndpoint.tsx
@@ -243,6 +243,14 @@ const CreateTopologyEndpoint = ({
       console.warn('Could not parse URL hostname:', e)
     }
 
+    const existingEndpoint = latestEndpoints?.find(
+      (e) => e.hostname === extractedHostname && e.service === formData.service,
+    )
+
+    const resolvedInfoId = isEditMode
+      ? (editingEndpoint.tags?.info_ID ?? crypto.randomUUID())
+      : (existingEndpoint?.tags?.info_ID ?? crypto.randomUUID())
+
     const updatedFields = {
       service: formData.service,
       hostname: extractedHostname,
@@ -258,9 +266,7 @@ const CreateTopologyEndpoint = ({
             .filter((label) => label.key.trim())
             .map((label) => [label.key.trim(), label.value.trim()]),
         ),
-        ...(editingEndpoint?.tags?.info_ID
-          ? { info_ID: editingEndpoint.tags.info_ID }
-          : {}),
+        info_ID: resolvedInfoId,
       },
       notifications: {
         enabled: formData.notificationsEnabled,


### PR DESCRIPTION
This PR adds automatic info_ID assignment to the topology endpoint form.

- Implemented automatic info_ID assignment in CreateTopologyEndpoint for both create and edit modes
- Updated endpoint handling to reuse an existing endpoint's id when the same endpoint already exists