### PR TITLE
[ARGO-5531] - Add Endpoints Access management page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import TenantDetails from './pages/tenant-details'
 import AssignProjects from './pages/AssignProjects'
 import CreateProject from './pages/CreateProject'
 import Administration from './pages/administration'
+import EndpointsAccess from './pages/endpoints-access'
 import ManageTenantMembers from './pages/manage-tenant-members'
 import MyInvitations from './pages/MyInvitations'
 import { InvitationReview } from './pages/InvitationReview'
@@ -153,6 +154,14 @@ function App() {
                   element={
                     <ProtectedRoute requiredRoles={['super_admin']}>
                       <Profile />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="endpoints-access"
+                  element={
+                    <ProtectedRoute requiredRoles={['super_admin']}>
+                      <EndpointsAccess />
                     </ProtectedRoute>
                   }
                 />

--- a/src/api/securedEndpoints.ts
+++ b/src/api/securedEndpoints.ts
@@ -1,0 +1,166 @@
+import type {
+  SecuredEndpointsPage,
+  AssignEndpointsRequest,
+  RoleAssignmentsResponse,
+  RoleEndpointAssignmentResponse,
+  Role,
+  RolesPage,
+  CreateRoleRequest,
+} from '@/types/securedEndpoints'
+
+const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+export const fetchSecuredEndpoints = async (
+  page: number = 1,
+  size: number = 10,
+  token: string,
+): Promise<SecuredEndpointsPage> => {
+  const response = await fetch(
+    `${BACKEND_API}/secured-endpoints?page=${page}&size=${size}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const assignEndpointsToRole = async (
+  roleId: string,
+  data: AssignEndpointsRequest,
+  token: string,
+): Promise<RoleEndpointAssignmentResponse> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/admin/roles/${roleId}/assign-endpoints`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(data),
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    const error = new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    ) as Error & { errors?: string[] }
+    error.errors = errorData.errors || []
+    throw error
+  }
+
+  return response.json()
+}
+
+export const fetchAssignedEndpoints = async (
+  token: string,
+): Promise<RoleAssignmentsResponse> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/admin/roles/assigned-endpoints`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchRoleAssignedEndpoints = async (
+  roleId: string,
+  token: string,
+): Promise<RoleAssignmentsResponse> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/admin/roles/${roleId}/assigned-endpoints`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchRoles = async (
+  page: number = 1,
+  size: number = 10,
+  token: string,
+): Promise<RolesPage> => {
+  const response = await fetch(
+    `${BACKEND_API}/roles?page=${page}&size=${size}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const createRole = async (
+  data: CreateRoleRequest,
+  token: string,
+): Promise<Role> => {
+  const response = await fetch(`${BACKEND_API}/roles`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    const error = new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    ) as Error & { errors?: string[] }
+    error.errors = errorData.errors || []
+    throw error
+  }
+
+  return response.json()
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -29,7 +29,7 @@ const variantClassMap: Record<ButtonVariant, string> = {
 const sizeClassMap: Record<ButtonSize, string> = {
   xs: 'px-2 py-1.5 text-xs',
   sm: 'px-3 py-1.5 text-sm',
-  md: 'px-4 py-2 text-[0.9375rem]',
+  md: 'px-4 py-1.5 text-[0.9375rem]',
   lg: 'px-6 py-2 text-base',
 }
 

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -25,13 +25,13 @@ const SearchInput = ({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="w-full py-2 pl-10 pr-10 text-sm"
+        className="w-full py-1.5 pl-10 pr-10 text-sm"
       />
       {value && (
         <button
           type="button"
           onClick={onClear}
-          className="absolute right-2 top-1/2 -translate-y-1/2 size-6 flex items-center justify-center p-3 bg-transparent border-none text-muted text-2xl cursor-pointer rounded-full transition-all hover:bg-surface-strong hover:text-body"
+          className="absolute right-2 top-1/2 -translate-y-1/2 size-6 flex items-center justify-center p-3.5 bg-transparent border-none text-muted text-2xl cursor-pointer rounded-full transition-all hover:bg-surface-strong hover:text-body"
           aria-label="Clear search"
         >
           ×

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   DocumentChartBarIcon,
   ServerStackIcon,
   CircleStackIcon,
+  LockClosedIcon,
 } from '@heroicons/react/16/solid'
 import { useGetUserInvitations } from '@/hooks/useInvitations'
 import type { Tenant } from '@/types/tenants'
@@ -152,6 +153,13 @@ function Sidebar({
               <SidebarNavItem to="/administration" onClick={onCloseMobileMenu}>
                 <UserGroupIcon className="size-4" aria-hidden />
                 Administration
+              </SidebarNavItem>
+              <SidebarNavItem
+                to="/endpoints-access"
+                onClick={onCloseMobileMenu}
+              >
+                <LockClosedIcon className="size-4" aria-hidden />
+                Endpoints Access
               </SidebarNavItem>
             </div>
           )}

--- a/src/hooks/useSecuredEndpoints.ts
+++ b/src/hooks/useSecuredEndpoints.ts
@@ -1,0 +1,138 @@
+import {
+  useMutation,
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { useAuth } from '@/auth/useAuth'
+import {
+  fetchSecuredEndpoints,
+  assignEndpointsToRole,
+  fetchAssignedEndpoints,
+  fetchRoleAssignedEndpoints,
+  fetchRoles,
+  createRole,
+} from '@/api/securedEndpoints'
+import type {
+  SecuredEndpointsPage,
+  AssignEndpointsRequest,
+  RoleAssignmentsResponse,
+  RoleEndpointAssignmentResponse,
+  Role,
+  RolesPage,
+  CreateRoleRequest,
+} from '@/types/securedEndpoints'
+
+export const useGetSecuredEndpoints = (
+  size: number = 100,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+
+  return useInfiniteQuery<SecuredEndpointsPage, Error>({
+    queryKey: ['secured-endpoints', size],
+    queryFn: ({ pageParam = 1 }) => {
+      if (!token) throw new Error('No authentication token available')
+      return fetchSecuredEndpoints(pageParam as number, size, token)
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.number_of_page < lastPage.total_pages) {
+        return lastPage.number_of_page + 1
+      }
+      return undefined
+    },
+    retry: false,
+    enabled: enabled && !!token,
+  })
+}
+
+export const useAssignEndpointsToRoleMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<
+    RoleEndpointAssignmentResponse,
+    Error,
+    { roleId: string; data: AssignEndpointsRequest }
+  >({
+    mutationFn: ({ roleId, data }) => {
+      if (!token) throw new Error('No authentication token available')
+      return assignEndpointsToRole(roleId, data, token)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['role-assigned-endpoints'] })
+      queryClient.invalidateQueries({ queryKey: ['assigned-endpoints'] })
+    },
+    onError: (error) => {
+      console.error('Assign endpoints to role error:', error)
+    },
+  })
+}
+
+export const useGetAssignedEndpoints = (enabled: boolean = true) => {
+  const { token } = useAuth()
+
+  return useQuery<RoleAssignmentsResponse, Error>({
+    queryKey: ['assigned-endpoints'],
+    queryFn: () => {
+      if (!token) throw new Error('No authentication token available')
+      return fetchAssignedEndpoints(token)
+    },
+    retry: false,
+    enabled: enabled && !!token,
+  })
+}
+
+export const useGetRoleAssignedEndpoints = (
+  roleId: string | null | undefined,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+
+  return useQuery<RoleAssignmentsResponse, Error>({
+    queryKey: ['role-assigned-endpoints', roleId],
+    queryFn: () => {
+      if (!token) throw new Error('No authentication token available')
+      if (!roleId) throw new Error('Role ID is required')
+      return fetchRoleAssignedEndpoints(roleId, token)
+    },
+    retry: false,
+    enabled: enabled && !!token && !!roleId,
+  })
+}
+
+export const useGetRoles = (
+  page: number = 1,
+  size: number = 10,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+  return useQuery<RolesPage, Error>({
+    queryKey: ['roles', page, size],
+    queryFn: () => {
+      if (!token) throw new Error('No authentication token available')
+      return fetchRoles(page, size, token)
+    },
+    retry: false,
+    enabled: enabled && !!token,
+  })
+}
+
+export const useCreateRoleMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<Role, Error, CreateRoleRequest>({
+    mutationFn: (data: CreateRoleRequest) => {
+      if (!token) throw new Error('No authentication token available')
+      return createRole(data, token)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['roles'] })
+    },
+    onError: (error) => {
+      console.error('Create role error:', error)
+    },
+  })
+}

--- a/src/pages/endpoints-access/CategoryPanel.tsx
+++ b/src/pages/endpoints-access/CategoryPanel.tsx
@@ -1,0 +1,103 @@
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+} from '@heroicons/react/16/solid'
+import EndpointListItem from './EndpointListItem'
+import type { SecuredEndpoint } from '@/types/securedEndpoints'
+
+export interface CategoryPanelProps {
+  label: string
+  endpoints: SecuredEndpoint[]
+  isCollapsed: boolean
+  onToggleCollapse: () => void
+  selectedActionIds: Set<string>
+  onToggleAction: (id: string, selectAll?: boolean, allIds?: string[]) => void
+}
+
+const CategoryPanel = ({
+  label,
+  endpoints,
+  isCollapsed,
+  onToggleCollapse,
+  selectedActionIds,
+  onToggleAction,
+}: CategoryPanelProps) => {
+  if (endpoints.length === 0) return null
+
+  const endpointIds = endpoints.map((ep) => ep.secured_endpoint_id)
+  const selectedCount = endpointIds.filter((id) =>
+    selectedActionIds.has(id),
+  ).length
+  const isAllChecked =
+    endpointIds.length > 0 && selectedCount === endpointIds.length
+  const isIndeterminate = selectedCount > 0 && !isAllChecked
+
+  const handleCategoryCheckboxChange = () => {
+    onToggleAction('', !isAllChecked, endpointIds)
+  }
+
+  return (
+    <div className="border border-line rounded-lg overflow-hidden bg-white shadow-sm ring-1 ring-black/5">
+      <button
+        type="button"
+        className="w-full flex items-center justify-between px-4 py-3 bg-surface-strong border-b border-line cursor-pointer select-none"
+        onClick={onToggleCollapse}
+        aria-expanded={!isCollapsed}
+      >
+        <div className="flex items-center gap-3 shrink-0">
+          <label
+            className="cursor-pointer group p-1 -m-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div
+              className={`relative size-4 shrink-0 rounded border flex items-center justify-center transition-colors ${
+                isAllChecked || isIndeterminate
+                  ? 'bg-brand border-brand'
+                  : 'border-line-strong bg-white group-hover:border-brand-muted'
+              }`}
+            >
+              <input
+                type="checkbox"
+                className="sr-only"
+                checked={isAllChecked || isIndeterminate}
+                onChange={handleCategoryCheckboxChange}
+              />
+              {isAllChecked && <CheckIcon className="size-3 text-white" />}
+              {isIndeterminate && !isAllChecked && (
+                <div className="w-2.5 h-0.5 bg-white rounded-full" />
+              )}
+            </div>
+          </label>
+          <span className="font-bold text-sm text-foreground">{label}</span>
+          <span className="text-xs text-muted font-normal">
+            ({selectedCount}/{endpointIds.length})
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 px-2 py-1 justify-end text-muted">
+          {isCollapsed ? (
+            <ChevronRightIcon className="size-5 shrink-0 transition-transform" />
+          ) : (
+            <ChevronDownIcon className="size-5 shrink-0 transition-transform" />
+          )}
+        </div>
+      </button>
+
+      {!isCollapsed && (
+        <div className="flex flex-col bg-white">
+          {endpoints.map((endpoint) => (
+            <EndpointListItem
+              key={endpoint.secured_endpoint_id}
+              endpoint={endpoint}
+              isChecked={selectedActionIds.has(endpoint.secured_endpoint_id)}
+              onToggle={() => onToggleAction(endpoint.secured_endpoint_id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CategoryPanel

--- a/src/pages/endpoints-access/EndpointListItem.tsx
+++ b/src/pages/endpoints-access/EndpointListItem.tsx
@@ -1,0 +1,68 @@
+import { CheckIcon } from '@heroicons/react/16/solid'
+import type { SecuredEndpoint } from '@/types/securedEndpoints'
+import { getFriendlyLabel } from './utils/friendlyLabels'
+
+interface EndpointListItemProps {
+  endpoint: SecuredEndpoint
+  isChecked: boolean
+  onToggle: () => void
+}
+
+const EndpointListItem = ({
+  endpoint,
+  isChecked,
+  onToggle,
+}: EndpointListItemProps) => {
+  const friendlyLabel = getFriendlyLabel(endpoint.action, endpoint.path)
+  const method = endpoint.action.toUpperCase()
+
+  return (
+    <label
+      className={`w-full flex items-center justify-between gap-8 px-4 py-2 text-left cursor-pointer transition-colors border-t border-line ${
+        isChecked ? 'bg-brand-subtle' : 'hover:bg-surface-muted'
+      }`}
+    >
+      <div className="flex items-center gap-3 w-5/12 min-w-0">
+        <div
+          className={`relative size-4 shrink-0 rounded border flex items-center justify-center transition-colors mt-0.5 self-start ${
+            isChecked ? 'bg-brand border-brand' : 'border-line-strong bg-white'
+          }`}
+        >
+          <input
+            type="checkbox"
+            className="sr-only"
+            checked={isChecked}
+            onChange={onToggle}
+          />
+          {isChecked && <CheckIcon className="size-3 text-white" />}
+        </div>
+        <div className="flex flex-col min-w-0 flex-1">
+          <span
+            className={`text-sm font-medium break-words ${isChecked ? 'text-foreground' : 'text-foreground/90'}`}
+          >
+            {friendlyLabel}
+          </span>
+          <div className="flex gap-1.5 mt-0.5">
+            <span className="text-xs text-subtle font-mono shrink-0">
+              {method}
+            </span>
+            <span className="text-xs text-subtle font-mono break-all">
+              {endpoint.path}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col min-w-0 flex-1 text-left">
+        <span
+          className="text-sm text-subtle line-clamp-3"
+          title={endpoint.description}
+        >
+          {endpoint.description}
+        </span>
+      </div>
+    </label>
+  )
+}
+
+export default EndpointListItem

--- a/src/pages/endpoints-access/EndpointsAccess.tsx
+++ b/src/pages/endpoints-access/EndpointsAccess.tsx
@@ -1,0 +1,205 @@
+import { useState, useMemo, useEffect } from 'react'
+import {
+  useGetSecuredEndpoints,
+  useGetRoles,
+  useGetRoleAssignedEndpoints,
+  useGetAssignedEndpoints,
+  useAssignEndpointsToRoleMutation,
+} from '@/hooks/useSecuredEndpoints'
+import { useRoleActionsManager } from './hooks/useRoleActionsManager'
+import { toast } from 'sonner'
+import PageHeader from '@/components/PageHeader'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ConfirmDialog from '@/components/ConfirmDialog'
+import RoleListPanel from './RoleListPanel'
+import RoleDetailsPanel from './RoleDetailsPanel'
+
+const EndpointsAccess = () => {
+  const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null)
+  const [pendingRoleId, setPendingRoleId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const main = document.querySelector('main')
+    if (main) {
+      main.style.overflowY = 'scroll'
+    }
+    return () => {
+      if (main) {
+        main.style.overflowY = ''
+      }
+    }
+  }, [])
+
+  const {
+    data: rolesData,
+    isLoading: isRolesLoading,
+    error: rolesError,
+  } = useGetRoles(1, 100)
+
+  const {
+    data: endpointsPagesData,
+    isLoading: isEndpointsLoading,
+    error: endpointsError,
+    fetchNextPage: fetchNextEndpointsPage,
+    hasNextPage: hasNextEndpointsPage,
+  } = useGetSecuredEndpoints()
+
+  useEffect(() => {
+    if (hasNextEndpointsPage) {
+      fetchNextEndpointsPage()
+    }
+  }, [endpointsPagesData, hasNextEndpointsPage, fetchNextEndpointsPage])
+
+  const endpointsList = useMemo(() => {
+    return (
+      endpointsPagesData?.pages?.flatMap((page) => page.content || []) || []
+    )
+  }, [endpointsPagesData])
+
+  const { data: roleAssignmentsData, isLoading: isRoleActionsLoading } =
+    useGetRoleAssignedEndpoints(selectedRoleId)
+
+  const { data: allAssignmentsData } = useGetAssignedEndpoints()
+
+  const { mutate: saveRoleActions, isPending: isMutating } =
+    useAssignEndpointsToRoleMutation()
+
+  const roleActionIds = useMemo(
+    () => roleAssignmentsData?.assignments?.[0]?.secured_endpoint_ids ?? [],
+    [roleAssignmentsData],
+  )
+
+  const { selectedActionIds, toggleAction, isDirty, addedCount, removedCount } =
+    useRoleActionsManager(selectedRoleId, roleActionIds)
+
+  const actionCounts = useMemo(() => {
+    const saved = Object.fromEntries(
+      (allAssignmentsData?.assignments ?? []).map((a) => [
+        a.role_id,
+        a.secured_endpoint_ids.length,
+      ]),
+    )
+    return {
+      ...saved,
+      ...(selectedRoleId && isDirty
+        ? { [selectedRoleId]: selectedActionIds.length }
+        : {}),
+    }
+  }, [allAssignmentsData, selectedRoleId, selectedActionIds, isDirty])
+
+  const roles = useMemo(() => rolesData?.content ?? [], [rolesData])
+
+  useEffect(() => {
+    if (!selectedRoleId && roles.length > 0) {
+      setSelectedRoleId(roles[0].id)
+    }
+  }, [selectedRoleId, roles])
+
+  const selectedRole = useMemo(
+    () => roles.find((r) => r.id === selectedRoleId) ?? null,
+    [selectedRoleId, roles],
+  )
+
+  const isLoading = isRolesLoading || isEndpointsLoading
+
+  const handleSelectRole = (roleId: string) => {
+    if (isDirty) {
+      setPendingRoleId(roleId)
+    } else {
+      setSelectedRoleId(roleId)
+    }
+  }
+
+  const handleConfirmRoleSwitch = () => {
+    setSelectedRoleId(pendingRoleId)
+    setPendingRoleId(null)
+  }
+
+  const handleCancelRoleSwitch = () => {
+    setPendingRoleId(null)
+  }
+
+  const handleSubmitActions = () => {
+    if (!selectedRoleId || !selectedRole) return
+
+    saveRoleActions(
+      {
+        roleId: selectedRoleId,
+        data: { secured_endpoint_ids: selectedActionIds },
+      },
+      {
+        onSuccess: () => {
+          toast.success('Role actions saved successfully')
+        },
+        onError: (err) => {
+          toast.error(`Failed to save role actions: ${err.message}`)
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        title="Endpoints Access"
+        subtitle="Manage authorization rules and access actions for roles"
+        className="mb-4"
+      />
+
+      <ConfirmDialog
+        isOpen={!!pendingRoleId}
+        title="Unsaved Changes"
+        message="You have unsaved changes. Switching roles will discard them. Are you sure?"
+        confirmLabel="Discard changes"
+        cancelLabel="Cancel"
+        onConfirm={handleConfirmRoleSwitch}
+        onCancel={handleCancelRoleSwitch}
+      />
+
+      {isLoading ? (
+        <div className="loading-container">
+          <LoadingSpinner size="md" />
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-x-8 items-start pb-10">
+          <div className="sticky top-4 bg-surface-muted rounded-lg p-4">
+            <RoleListPanel
+              roles={roles}
+              selectedRoleId={selectedRoleId}
+              onSelectRole={handleSelectRole}
+              actionCounts={actionCounts}
+              error={rolesError}
+            />
+          </div>
+
+          <div className="min-w-0">
+            {selectedRole ? (
+              <RoleDetailsPanel
+                key={selectedRoleId}
+                roleName={selectedRole.name}
+                endpointsList={endpointsList}
+                selectedActionIds={selectedActionIds}
+                onToggleAction={toggleAction}
+                onSubmit={handleSubmitActions}
+                isMutating={isMutating}
+                isDirty={isDirty}
+                addedCount={addedCount}
+                removedCount={removedCount}
+                isLoadingActions={isRoleActionsLoading}
+                error={endpointsError}
+              />
+            ) : (
+              <div className="flex items-center justify-center py-6 rounded-xl border border-line bg-surface-muted">
+                <p className="text-sm text-subtle italic">
+                  Select a role to manage its permissions
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default EndpointsAccess

--- a/src/pages/endpoints-access/RoleDetailsPanel.tsx
+++ b/src/pages/endpoints-access/RoleDetailsPanel.tsx
@@ -1,0 +1,263 @@
+import { useMemo, useState, useEffect, useRef } from 'react'
+import { useGroupCollapse } from './hooks/useEndpointManagement'
+import Button from '@/components/Button'
+import ConfirmDialog from '@/components/ConfirmDialog'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import SearchInput from '@/components/SearchInput'
+import SelectDropdown from '@/components/SelectDropdown'
+import CategoryPanel from './CategoryPanel'
+import { CATEGORY_MATCHERS } from './constants/endpointCategories'
+import { getFriendlyLabel } from './utils/friendlyLabels'
+import type { SecuredEndpoint } from '@/types/securedEndpoints'
+
+interface RoleDetailsPanelProps {
+  roleName: string
+  endpointsList: SecuredEndpoint[]
+  selectedActionIds: string[]
+  onToggleAction: (
+    actionId: string,
+    selectAll?: boolean,
+    allIds?: string[],
+  ) => void
+  onSubmit: () => void
+  isMutating: boolean
+  isDirty: boolean
+  addedCount: number
+  removedCount: number
+  isLoadingActions: boolean
+  error?: Error | null
+}
+
+const RoleDetailsPanel = ({
+  roleName,
+  endpointsList,
+  selectedActionIds,
+  onToggleAction,
+  onSubmit,
+  isMutating,
+  isDirty,
+  addedCount,
+  removedCount,
+  isLoadingActions,
+  error,
+}: RoleDetailsPanelProps) => {
+  const [searchInput, setSearchInput] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState('all')
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [isStuck, setIsStuck] = useState(false)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel) {
+      return
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsStuck(!entry.isIntersecting),
+      { threshold: 0 },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [])
+  const { collapsedGroups, handleToggleGroup, collapseAll, expandAll } =
+    useGroupCollapse()
+
+  const dynamicCategoryOptions = useMemo(() => {
+    const categoriesWithEndpoints = new Set<string>()
+    endpointsList.forEach((ep) => {
+      const category =
+        CATEGORY_MATCHERS.find((m) => m.match(ep.path))?.label ?? 'Other'
+      categoriesWithEndpoints.add(category)
+    })
+
+    const options = [{ value: 'all', label: 'All' }]
+    CATEGORY_MATCHERS.forEach(({ label }) => {
+      if (categoriesWithEndpoints.has(label)) {
+        options.push({ value: label, label })
+      }
+    })
+    if (categoriesWithEndpoints.has('Other')) {
+      options.push({ value: 'Other', label: 'Other' })
+    }
+    return options
+  }, [endpointsList])
+
+  const selectedActionIdsSet = useMemo(
+    () => new Set(selectedActionIds),
+    [selectedActionIds],
+  )
+
+  const groupedEndpoints = useMemo(() => {
+    const query = searchInput.trim().toLowerCase()
+
+    const grouped = endpointsList.reduce((acc, ep) => {
+      const isSearchMatch =
+        !query ||
+        ep.path.toLowerCase().includes(query) ||
+        ep.action.toLowerCase().includes(query) ||
+        (ep.description?.toLowerCase() || '').includes(query) ||
+        getFriendlyLabel(ep.action, ep.path).toLowerCase().includes(query)
+
+      if (!isSearchMatch) return acc
+
+      const category =
+        CATEGORY_MATCHERS.find((m) => m.match(ep.path))?.label ?? 'Other'
+
+      if (selectedCategory !== 'all' && selectedCategory !== category) {
+        return acc
+      }
+
+      if (!acc.has(category)) acc.set(category, [])
+      acc.get(category)!.push(ep)
+      return acc
+    }, new Map<string, SecuredEndpoint[]>())
+
+    const knownGroups = CATEGORY_MATCHERS.map(({ label }) => ({
+      label,
+      endpoints: grouped.get(label) ?? [],
+    })).filter((group) => group.endpoints.length > 0)
+
+    const otherEndpoints = grouped.get('Other') ?? []
+    return otherEndpoints.length > 0
+      ? [...knownGroups, { label: 'Other', endpoints: otherEndpoints }]
+      : knownGroups
+  }, [endpointsList, searchInput, selectedCategory])
+
+  const allLabels = groupedEndpoints.map((g) => g.label)
+  const areAllCollapsed =
+    allLabels.length > 0 && allLabels.every((l) => collapsedGroups.has(l))
+
+  const handleToggleAll = () => {
+    if (areAllCollapsed) {
+      expandAll()
+    } else {
+      collapseAll(allLabels)
+    }
+  }
+
+  const handleConfirmSave = () => {
+    setConfirmOpen(false)
+    onSubmit()
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div ref={sentinelRef} className="h-px" />
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        title="Confirm Role Permission Update"
+        message={
+          <>
+            Are you sure you want to save the changes for the{' '}
+            <strong>{roleName}</strong> role?
+          </>
+        }
+        confirmLabel="Save"
+        cancelLabel="Cancel"
+        onConfirm={handleConfirmSave}
+        onCancel={() => setConfirmOpen(false)}
+      />
+
+      <div
+        className={`sticky top-0 z-10 px-1 bg-white transition-all ${isStuck ? 'py-3 border-b border-line' : 'pb-1'}`}
+      >
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <h2 className="text-lg font-bold text-foreground leading-tight">
+              Configure Authorization Actions
+            </h2>
+            <p className="text-body text-sm">
+              Select the actions this role is permitted to access
+            </p>
+          </div>
+          <div className="flex items-center gap-3 shrink-0">
+            {isDirty && (addedCount > 0 || removedCount > 0) && (
+              <div className="flex flex-col items-end gap-0.5 text-xs">
+                {addedCount > 0 && (
+                  <span className="text-emerald-600">+{addedCount} added</span>
+                )}
+                {removedCount > 0 && (
+                  <span className="text-red-500">-{removedCount} removed</span>
+                )}
+              </div>
+            )}
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => setConfirmOpen(true)}
+              disabled={isMutating || !isDirty}
+              className="shrink-0"
+            >
+              {isMutating ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-1 flex flex-col sm:flex-row gap-4">
+        <div className="w-full sm:flex-1">
+          <SearchInput
+            value={searchInput}
+            onChange={setSearchInput}
+            onClear={() => setSearchInput('')}
+            placeholder="Search by action, path or label..."
+            className="w-full bg-white"
+            maxWidth="max-w-full"
+          />
+        </div>
+        <div className="flex gap-3 shrink-0">
+          <div className="w-full sm:w-52">
+            <SelectDropdown
+              value={selectedCategory}
+              onChange={setSelectedCategory}
+              options={dynamicCategoryOptions}
+              className="w-full"
+            />
+          </div>
+          {allLabels.length > 0 && (
+            <button
+              type="button"
+              onClick={handleToggleAll}
+              className="text-xs text-brand font-medium hover:text-brand-strong transition-colors focus:outline-none cursor-pointer whitespace-nowrap mb-1"
+            >
+              {areAllCollapsed ? 'Expand All' : 'Collapse All'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="p-1">
+        {error ? (
+          <ErrorDisplay error={error} context="endpoints" />
+        ) : isLoadingActions ? (
+          <div className="loading-container">
+            <LoadingSpinner size="md" />
+          </div>
+        ) : groupedEndpoints.length === 0 ? (
+          <div className="text-center bg-surface-muted rounded border border-line py-8">
+            <p className="text-sm text-subtle italic">
+              {searchInput ? 'No actions match search' : 'No actions found'}
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {groupedEndpoints.map(({ label, endpoints }) => (
+              <CategoryPanel
+                key={label}
+                label={label}
+                endpoints={endpoints}
+                isCollapsed={collapsedGroups.has(label)}
+                onToggleCollapse={() => handleToggleGroup(label)}
+                selectedActionIds={selectedActionIdsSet}
+                onToggleAction={onToggleAction}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default RoleDetailsPanel

--- a/src/pages/endpoints-access/RoleListPanel.tsx
+++ b/src/pages/endpoints-access/RoleListPanel.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react'
+import { PlusIcon } from '@heroicons/react/20/solid'
+import { useCreateRoleMutation } from '@/hooks/useSecuredEndpoints'
+import Button from '@/components/Button'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import { toast } from 'sonner'
+import type { Role } from '@/types/securedEndpoints'
+
+interface RoleListPanelProps {
+  roles: Role[]
+  selectedRoleId: string | null
+  onSelectRole: (roleId: string) => void
+  actionCounts: Record<string, number>
+  error?: Error | null
+}
+
+const RoleListPanel = ({
+  roles,
+  selectedRoleId,
+  onSelectRole,
+  actionCounts,
+  error,
+}: RoleListPanelProps) => {
+  const [isAdding, setIsAdding] = useState(false)
+  const [newRoleName, setNewRoleName] = useState('')
+
+  const { mutate: createRole, isPending } = useCreateRoleMutation()
+
+  const handleSave = () => {
+    const name = newRoleName.trim()
+    if (!name) return
+    createRole(
+      { name },
+      {
+        onSuccess: () => {
+          setNewRoleName('')
+          setIsAdding(false)
+          toast.success('Role created successfully')
+        },
+        onError: (err) => {
+          toast.error(`Failed to create role: ${err.message}`)
+        },
+      },
+    )
+  }
+
+  const handleCancel = () => {
+    setNewRoleName('')
+    setIsAdding(false)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') handleSave()
+    if (e.key === 'Escape') handleCancel()
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-base font-semibold text-foreground mb-1">
+        Select a role to manage its actions
+      </h3>
+
+      {error ? (
+        <ErrorDisplay error={error} context="roles" />
+      ) : (
+        <>
+          {roles.map((role) => {
+            const isSelected = selectedRoleId === role.id
+            const count = actionCounts[role.id] ?? 0
+            return (
+              <button
+                key={role.id}
+                type="button"
+                onClick={() => onSelectRole(role.id)}
+                className={`w-full flex items-center justify-between gap-2 px-4 py-3 text-left cursor-pointer transition-all border rounded-lg ${
+                  isSelected
+                    ? 'bg-brand-subtle border-brand ring-1 ring-brand-strong shadow-sm'
+                    : 'bg-white border-line hover:border-brand-muted hover:shadow-sm'
+                }`}
+              >
+                <span
+                  className={`font-semibold text-base ${
+                    isSelected ? 'text-brand-strong' : 'text-foreground'
+                  }`}
+                >
+                  {role.name}
+                </span>
+                <span className="text-xs font-bold px-1.5 py-0.5 rounded-full bg-surface-strong text-muted border border-line shrink-0">
+                  {count}
+                </span>
+              </button>
+            )
+          })}
+
+          {roles.length === 0 && !isAdding && (
+            <div className="text-center bg-surface-muted py-4 text-sm text-subtle">
+              No roles found
+            </div>
+          )}
+
+          {isAdding ? (
+            <div className="flex flex-col gap-1 mt-1 pt-2 border-t border-line">
+              <label className="text-sm font-medium text-body">
+                Add a new role
+              </label>
+              <input
+                autoFocus
+                type="text"
+                value={newRoleName}
+                onChange={(e) => setNewRoleName(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Role name"
+                className="text-sm py-1.5"
+                disabled={isPending}
+              />
+              <div className="flex gap-3 mt-1">
+                <Button
+                  variant="primary"
+                  size="xs"
+                  onClick={handleSave}
+                  disabled={!newRoleName.trim() || isPending}
+                >
+                  {isPending ? 'Saving...' : 'Save'}
+                </Button>
+                <Button
+                  variant="outline-secondary"
+                  size="xs"
+                  onClick={handleCancel}
+                  disabled={isPending}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setIsAdding(true)}
+              className="flex items-center gap-1 text-sm text-brand font-medium hover:text-brand-strong transition-colors mt-1 cursor-pointer"
+            >
+              <PlusIcon className="size-4" />
+              Add Role
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+export default RoleListPanel

--- a/src/pages/endpoints-access/constants/endpointCategories.ts
+++ b/src/pages/endpoints-access/constants/endpointCategories.ts
@@ -1,0 +1,37 @@
+export const CATEGORY_MATCHERS: Array<{
+  label: string
+  match: (path: string) => boolean
+}> = [
+  { label: 'Admin', match: (p) => p.startsWith('/v1/admin') },
+  {
+    label: ' API Resources',
+    match: (p) =>
+      p.startsWith('/v1/api-resources') || p.startsWith('/api-resources'),
+  },
+  { label: 'Automation', match: (p) => p.startsWith('/v1/automation') },
+  { label: 'Capabilities', match: (p) => p.includes('/capabilities/') },
+  { label: 'Encrypt', match: (p) => p.includes('/encrypt') },
+  { label: 'Profiles', match: (p) => p.includes('-profiles') },
+  { label: 'Public Status Pages', match: (p) => p.startsWith('/v1/public') },
+  { label: 'Reports', match: (p) => p.includes('/reports') },
+  {
+    label: 'Roles',
+    match: (p) => p.startsWith('/v1/roles') || p.startsWith('/roles'),
+  },
+  {
+    label: 'Secured Endpoints',
+    match: (p) =>
+      p.startsWith('/v1/secured-endpoints') ||
+      p.startsWith('/secured-endpoints'),
+  },
+  {
+    label: 'Status Pages',
+    match: (p) => p.includes('/pages') || p.includes('/status-pages'),
+  },
+  { label: 'Tenants', match: (p) => p.startsWith('/v1/tenants') },
+  { label: 'Topologies', match: (p) => p.includes('/topology') },
+  {
+    label: 'Users',
+    match: (p) => p.startsWith('/v1/users') || p.startsWith('/users'),
+  },
+]

--- a/src/pages/endpoints-access/hooks/useEndpointManagement.ts
+++ b/src/pages/endpoints-access/hooks/useEndpointManagement.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+
+export const useGroupCollapse = () => {
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
+
+  const handleToggleGroup = (label: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev)
+      if (next.has(label)) next.delete(label)
+      else next.add(label)
+      return next
+    })
+  }
+
+  const collapseAll = (labels: string[]) => {
+    setCollapsedGroups(new Set(labels))
+  }
+
+  const expandAll = () => {
+    setCollapsedGroups(new Set())
+  }
+
+  return { collapsedGroups, handleToggleGroup, collapseAll, expandAll }
+}

--- a/src/pages/endpoints-access/hooks/useRoleActionsManager.ts
+++ b/src/pages/endpoints-access/hooks/useRoleActionsManager.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect, useMemo } from 'react'
+
+export const useRoleActionsManager = (
+  selectedRoleId: string | null,
+  roleActionIds: string[],
+) => {
+  const [selectedActionIds, setSelectedActionIds] = useState<string[]>([])
+  const [hasUserModified, setHasUserModified] = useState(false)
+
+  useEffect(() => {
+    setSelectedActionIds(roleActionIds)
+    setHasUserModified(false)
+  }, [selectedRoleId, roleActionIds])
+
+  const isDirty = useMemo(() => {
+    if (!hasUserModified) return false
+    const saved = new Set(roleActionIds)
+    const current = new Set(selectedActionIds)
+    if (saved.size !== current.size) return true
+    return [...saved].some((id) => !current.has(id))
+  }, [roleActionIds, selectedActionIds, hasUserModified])
+
+  const addedCount = useMemo(() => {
+    if (!hasUserModified) return 0
+    const saved = new Set(roleActionIds)
+    return selectedActionIds.filter((id) => !saved.has(id)).length
+  }, [roleActionIds, selectedActionIds, hasUserModified])
+
+  const removedCount = useMemo(() => {
+    if (!hasUserModified) return 0
+    const current = new Set(selectedActionIds)
+    return roleActionIds.filter((id) => !current.has(id)).length
+  }, [roleActionIds, selectedActionIds, hasUserModified])
+
+  const toggleAction = (
+    actionId: string,
+    selectAll?: boolean,
+    allIds?: string[],
+  ) => {
+    setHasUserModified(true)
+    if (allIds && selectAll !== undefined) {
+      setSelectedActionIds((current) => {
+        const next = new Set(current)
+        if (selectAll) {
+          allIds.forEach((id) => next.add(id))
+        } else {
+          allIds.forEach((id) => next.delete(id))
+        }
+        return Array.from(next)
+      })
+      return
+    }
+
+    setSelectedActionIds((current) =>
+      current.includes(actionId)
+        ? current.filter((id) => id !== actionId)
+        : [...current, actionId],
+    )
+  }
+
+  return {
+    selectedActionIds,
+    toggleAction,
+    isDirty,
+    addedCount,
+    removedCount,
+  }
+}

--- a/src/pages/endpoints-access/index.ts
+++ b/src/pages/endpoints-access/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EndpointsAccess'

--- a/src/pages/endpoints-access/utils/friendlyLabels.ts
+++ b/src/pages/endpoints-access/utils/friendlyLabels.ts
@@ -1,0 +1,28 @@
+export const getFriendlyLabel = (method: string, path: string): string => {
+  const methodMap: Record<string, string> = {
+    GET: 'Read',
+    POST: 'Create',
+    PUT: 'Update',
+    PATCH: 'Update',
+    DELETE: 'Delete',
+  }
+
+  const action = methodMap[method.toUpperCase()] || method.toUpperCase()
+
+  let resource = path
+    .replace('/v1/', '')
+    .replace('/api/', '')
+    .split('/')
+    .filter((segment) => !segment.startsWith('{') && segment.length > 0)
+    .join(' ')
+
+  resource = resource
+    .replace(/-/g, ' ')
+    .toLowerCase()
+    .replace('tenants', 'tenant')
+    .replace('projects', 'project')
+
+  if (resource === '') resource = 'Endpoint'
+
+  return `${action} ${resource}`
+}

--- a/src/types/securedEndpoints.ts
+++ b/src/types/securedEndpoints.ts
@@ -1,0 +1,51 @@
+export type SecuredEndpoint = {
+  secured_endpoint_id: string
+  action: string
+  path: string
+  description?: string
+}
+
+export type SecuredEndpointsPage = {
+  content: SecuredEndpoint[]
+  size_of_page: number
+  number_of_page: number
+  total_elements: number
+  total_pages: number
+}
+
+export type RoleAssignment = {
+  role_id: string
+  role_name: string
+  secured_endpoint_ids: string[]
+}
+
+export type RoleAssignmentsResponse = {
+  assignments: RoleAssignment[]
+}
+
+export type AssignEndpointsRequest = {
+  secured_endpoint_ids: string[]
+}
+
+export type RoleEndpointAssignmentResponse = {
+  message: string
+  code: string
+}
+
+export type Role = {
+  id: string
+  name: string
+}
+
+export type RolesPage = {
+  content: Role[]
+  size_of_page: number
+  number_of_page: number
+  total_elements: number
+  total_pages: number
+  links: { href: string; rel: string }[]
+}
+
+export type CreateRoleRequest = {
+  name: string
+}


### PR DESCRIPTION
**⚠️ This PR should not be merged before [ARGO-5525](https://github.com/ARGOeu/argo-mon-status-api/pull/125) is merged.**

This PR adds a new admin page for managing role-based access to secured API endpoints.

- Added a page for managing roles and assigning authorized API endpoints to each role
- Added endpoint search, category filtering, and group expand/collapse in the permissions panel
- Added ability to create new roles directly from the page
- Implemented API integration for fetching roles, secured endpoints, and saving role assignments
- Added dynamic category filtering based on the available endpoints