### PR TITLE
[ARGO-5539] - Exclude logo from status page payload based on theme selection

### DIFF
--- a/src/pages/build-status-page/BuildStatusPage.tsx
+++ b/src/pages/build-status-page/BuildStatusPage.tsx
@@ -164,11 +164,13 @@ const BuildStatusPage = () => {
         theming: {
           option: themeOption,
           status: { icon: selectIcon, text: selectText },
-          logo:
-            logo &&
-            (logo?.startsWith('http') || logo?.startsWith('data:')
-              ? logo
-              : `${BACKEND_API}${logo}`),
+          ...(themeOption !== 'theme_2' &&
+            logo && {
+              logo:
+                logo.startsWith('http') || logo.startsWith('data:')
+                  ? logo
+                  : `${BACKEND_API}${logo}`,
+            }),
           color,
           columns,
         },


### PR DESCRIPTION
This PR fixes the status page save and update requests to exclude the logo field from the payload when the "No Logo" theme option is selected.