### PR TITLE
[ARGO-5543] - Add topology feed configuration to tenant form

### DIFF
--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -8,6 +8,7 @@ import type {
   ReportDetail,
   MetricProfileResponse,
   TenantReadinessResponse,
+  TopologyFeed,
   CapabilityAvailabilityResponse,
   CapabilityAvailabilityParams,
   CapabilityStatusResponse,
@@ -682,6 +683,55 @@ export const setNodeReport = async (
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+}
+
+export const fetchGetTopologyFeed = async (
+  tenantId: string,
+  token: string,
+): Promise<TopologyFeed> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/feeds/topology`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchUpdateTopologyFeed = async (
+  tenantId: string,
+  data: TopologyFeed,
+  token: string,
+): Promise<void> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/feeds/topology`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(data),
     },
   )
 

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -31,6 +31,8 @@ import {
   setNodeReport,
   fetchTenantCapabilityAvailability,
   fetchTenantCapabilityStatus,
+  fetchGetTopologyFeed,
+  fetchUpdateTopologyFeed,
 } from '@/api/tenants'
 import type {
   Job,
@@ -43,6 +45,7 @@ import type {
   ReportDetail,
   MetricProfileResponse,
   TenantReadinessResponse,
+  TopologyFeed,
   CapabilityAvailabilityResponse,
   CapabilityAvailabilityParams,
   CapabilityStatusResponse,
@@ -675,5 +678,43 @@ export const useGetTenantCapabilityStatus = (
     },
     retry: false,
     enabled: enabled && !!token && !!tenantId,
+  })
+}
+
+export const useGetTopologyFeedQuery = (
+  tenantId: string,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+  return useQuery<TopologyFeed, Error>({
+    queryKey: ['topology-feed', tenantId],
+    queryFn: () => {
+      if (!token) throw new Error('No authentication token available')
+      if (!tenantId) throw new Error('Tenant ID is required')
+      return fetchGetTopologyFeed(tenantId, token)
+    },
+    retry: false,
+    enabled: enabled && !!token && !!tenantId,
+  })
+}
+
+export const useUpdateTopologyFeedMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<void, Error, { tenantId: string; data: TopologyFeed }>({
+    mutationFn: ({ tenantId, data }) => {
+      if (!token) throw new Error('No authentication token available')
+      if (!tenantId) throw new Error('Tenant ID is required')
+      return fetchUpdateTopologyFeed(tenantId, data, token)
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['topology-feed', variables.tenantId],
+      })
+    },
+    onError: (error) => {
+      console.error('Update topology feed error:', error)
+    },
   })
 }

--- a/src/pages/create-tenant/ContactInformation.tsx
+++ b/src/pages/create-tenant/ContactInformation.tsx
@@ -8,7 +8,7 @@ const sectionClass =
 const sectionContentClass =
   'bg-surface-muted border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
 const iconButtonClass =
-  'flex items-center justify-center size-7 rounded-md bg-blue-500 text-white border-none cursor-pointer hover:bg-blue-600'
+  'flex items-center justify-center size-7 rounded-md bg-brand text-white border-none cursor-pointer hover:bg-brand-strong'
 const iconButtonDangerClass =
   'flex items-center justify-center size-7 rounded-md bg-red-500 text-white border-none cursor-pointer hover:bg-red-600'
 

--- a/src/pages/create-tenant/CreateTenant.tsx
+++ b/src/pages/create-tenant/CreateTenant.tsx
@@ -4,8 +4,11 @@ import {
   useCreateTenantMutation,
   useGetUserTenantById,
   useUpdateUserTenantMutation,
+  useGetTopologyFeedQuery,
+  useUpdateTopologyFeedMutation,
 } from '@/hooks/useTenants'
-import type { Metadata } from '@/types/tenants'
+import type { Metadata, TopologyFeed } from '@/types/tenants'
+import type { TopologyFeedFormState } from './InfrastructureMetadata'
 import { toast } from 'sonner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import Button from '@/components/Button'
@@ -17,6 +20,27 @@ import Tabs from '@/components/Tabs'
 import TenantBasicInfoTab from './TenantBasicInfoTab'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+const buildFeedPayload = (feed: TopologyFeedFormState): TopologyFeed => {
+  if (feed.type === 'CSV') {
+    return {
+      type: feed.type,
+      feed_url: feed.feed_url,
+      paginated: 'false',
+      fetch_type: ['ServiceGroups'],
+      uid_endpoints: '',
+    }
+  }
+  if (feed.type === 'eosc-service-catalog') {
+    return {
+      type: feed.type,
+      feed_service_groups: feed.feed_service_groups,
+      feed_service_endpoints: feed.feed_service_endpoints,
+      feed_service_endpoints_extensions: feed.feed_service_endpoints_extensions,
+    }
+  }
+  return { type: feed.type }
+}
 
 const CreateTenant = () => {
   const { id: tenantId } = useParams<{ id?: string }>()
@@ -51,6 +75,13 @@ const CreateTenant = () => {
     useState(false)
   const [hasMetadataValidationError, setHasMetadataValidationError] =
     useState(false)
+  const [topologyFeed, setTopologyFeed] = useState<TopologyFeedFormState>({
+    type: '',
+    feed_url: '',
+    feed_service_groups: '',
+    feed_service_endpoints: '',
+    feed_service_endpoints_extensions: '',
+  })
 
   const navigateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -62,12 +93,16 @@ const CreateTenant = () => {
 
   const createMutation = useCreateTenantMutation()
   const updateMutation = useUpdateUserTenantMutation()
+  const updateTopologyFeedMutation = useUpdateTopologyFeedMutation()
 
   const {
     data: tenantData,
     isLoading: isTenantLoading,
     error: tenantError,
   } = useGetUserTenantById(tenantId || '')
+
+  const { data: topologyFeedData, isLoading: topologyFeedLoading } =
+    useGetTopologyFeedQuery(tenantId || '', isEditMode)
 
   useEffect(() => {
     if (isEditMode && tenantData) {
@@ -119,6 +154,19 @@ const CreateTenant = () => {
       }
     }
   }, [isEditMode, tenantData])
+
+  useEffect(() => {
+    if (isEditMode && topologyFeedData) {
+      setTopologyFeed({
+        type: topologyFeedData.type || '',
+        feed_url: topologyFeedData.feed_url || '',
+        feed_service_groups: topologyFeedData.feed_service_groups || '',
+        feed_service_endpoints: topologyFeedData.feed_service_endpoints || '',
+        feed_service_endpoints_extensions:
+          topologyFeedData.feed_service_endpoints_extensions || '',
+      })
+    }
+  }, [isEditMode, topologyFeedData])
 
   const hasTenantDetailsErrors = () => {
     return (
@@ -222,6 +270,8 @@ const CreateTenant = () => {
       }
     }
 
+    const feedPayload = buildFeedPayload(topologyFeed)
+
     if (isEditMode && tenantId) {
       updateMutation.mutate(
         {
@@ -234,10 +284,18 @@ const CreateTenant = () => {
         },
         {
           onSuccess: () => {
-            toast.success('Tenant updated successfully!')
-            navigateTimerRef.current = setTimeout(
-              () => navigate(`/tenants/${tenantId}/details`),
-              2000,
+            updateTopologyFeedMutation.mutate(
+              { tenantId, data: feedPayload },
+              {
+                onSuccess: () => {
+                  toast.success('Tenant updated successfully!')
+                  navigateTimerRef.current = setTimeout(
+                    () => navigate(`/tenants/${tenantId}/details`),
+                    2000,
+                  )
+                },
+                onError,
+              },
             )
           },
           onError,
@@ -247,12 +305,28 @@ const CreateTenant = () => {
       createMutation.mutate(
         { info: submitData, contacts: contactsData, metadata: metadataObj },
         {
-          onSuccess: () => {
-            toast.success('Tenant created successfully!')
-            navigateTimerRef.current = setTimeout(
-              () => navigate(`/administration#tenants`),
-              2000,
-            )
+          onSuccess: (createdTenant) => {
+            if (createdTenant.id) {
+              updateTopologyFeedMutation.mutate(
+                { tenantId: createdTenant.id, data: feedPayload },
+                {
+                  onSuccess: () => {
+                    toast.success('Tenant created successfully!')
+                    navigateTimerRef.current = setTimeout(
+                      () => navigate(`/administration#tenants`),
+                      2000,
+                    )
+                  },
+                  onError,
+                },
+              )
+            } else {
+              toast.success('Tenant created successfully!')
+              navigateTimerRef.current = setTimeout(
+                () => navigate(`/administration#tenants`),
+                2000,
+              )
+            }
           },
           onError,
         },
@@ -262,7 +336,7 @@ const CreateTenant = () => {
 
   return (
     <div className="page-container">
-      {isEditMode && isTenantLoading ? (
+      {isEditMode && (isTenantLoading || topologyFeedLoading) ? (
         <div className="loading-container">
           <LoadingSpinner />
         </div>
@@ -308,6 +382,7 @@ const CreateTenant = () => {
               disabled={
                 createMutation.isPending ||
                 updateMutation.isPending ||
+                updateTopologyFeedMutation.isPending ||
                 !!errors.name ||
                 !!errors.email ||
                 !!errors.website ||
@@ -321,10 +396,13 @@ const CreateTenant = () => {
                     contact.type.trim(),
                 ) ||
                 hasContactValidationError ||
-                hasMetadataValidationError
+                hasMetadataValidationError ||
+                !topologyFeed.type
               }
             >
-              {createMutation.isPending || updateMutation.isPending
+              {createMutation.isPending ||
+              updateMutation.isPending ||
+              updateTopologyFeedMutation.isPending
                 ? 'Saving...'
                 : isEditMode
                   ? 'Update'
@@ -348,7 +426,7 @@ const CreateTenant = () => {
                 {
                   id: 'metadata',
                   label: 'Infrastructure Settings',
-                  hasError: hasMetadataValidationError,
+                  hasError: hasMetadataValidationError || !topologyFeed.type,
                 },
               ]}
               activeTab={activeTab}
@@ -384,8 +462,9 @@ const CreateTenant = () => {
               <InfrastructureMetadata
                 metadata={metadata}
                 onMetadataChange={setMetadata}
+                topologyFeed={topologyFeed}
+                onTopologyFeedChange={setTopologyFeed}
                 onValidationChange={setHasMetadataValidationError}
-                initialData={tenantData?.metadata || null}
               />
             </div>
           </form>

--- a/src/pages/create-tenant/FormField.tsx
+++ b/src/pages/create-tenant/FormField.tsx
@@ -1,0 +1,38 @@
+interface FormFieldProps {
+  label: string
+  type?: string
+  name?: string
+  value: string
+  onChange: React.ChangeEventHandler<HTMLInputElement>
+  placeholder?: string
+  error?: string
+  required?: boolean
+}
+
+const FormField = ({
+  label,
+  type = 'text',
+  name,
+  value,
+  onChange,
+  placeholder,
+  error,
+  required,
+}: FormFieldProps) => (
+  <div className="flex flex-col">
+    <label className="text-sm font-medium text-body mb-1">
+      {label}
+      {required && <span className="required"> *</span>}
+    </label>
+    <input
+      type={type}
+      name={name}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+    />
+    {error && <span className="text-red-400 text-sm mt-1">{error}</span>}
+  </div>
+)
+
+export default FormField

--- a/src/pages/create-tenant/InfrastructureMetadata.tsx
+++ b/src/pages/create-tenant/InfrastructureMetadata.tsx
@@ -1,21 +1,37 @@
 import { useState } from 'react'
 import { useGetUserContactTypes } from '@/hooks/useTenants'
 import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
-import type { Metadata } from '@/types/tenants'
 import SelectDropdown from '@/components/SelectDropdown'
+import FormField from './FormField'
 
 const sectionClass =
   'grid grid-cols-1 md:grid-cols-[300px_1fr] gap-4 md:gap-8 mb-6 animate-fade-in'
 const sectionContentClass =
   'bg-surface-muted border border-line rounded-lg px-6 py-4 flex flex-col gap-2.5'
 const fieldGridClass =
-  'grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-3'
+  'grid grid-cols-[repeat(auto-fit,minmax(250px,1fr))] gap-3'
 const iconButtonClass =
-  'flex items-center justify-center size-7 rounded-md bg-blue-500 text-white border-none cursor-pointer hover:bg-blue-600'
+  'flex items-center justify-center size-7 rounded-md bg-brand text-white border-none cursor-pointer hover:bg-brand-strong'
 const iconButtonDangerClass =
   'flex items-center justify-center size-7 rounded-md bg-red-500 text-white border-none cursor-pointer hover:bg-red-600'
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const urlRegex = /^https?:\/\/.+\..+/
+
+const FEED_TYPE_OPTIONS = [
+  { value: 'internal', label: 'Internal' },
+  { value: 'CSV', label: 'CSV' },
+  { value: 'eosc-service-catalog', label: 'EOSC Service Catalog' },
+  { value: 'external', label: 'External' },
+]
+
+export type TopologyFeedFormState = {
+  type: string
+  feed_url: string
+  feed_service_groups: string
+  feed_service_endpoints: string
+  feed_service_endpoints_extensions: string
+}
 
 interface InfrastructureMetadataProps {
   metadata: {
@@ -38,31 +54,45 @@ interface InfrastructureMetadataProps {
     auth_name: string
     auth_url: string
   }) => void
+  topologyFeed: TopologyFeedFormState
+  onTopologyFeedChange: (feed: TopologyFeedFormState) => void
   onValidationChange?: (hasError: boolean) => void
-  initialData?: Metadata | null
 }
 
 const InfrastructureMetadata = ({
   metadata,
   onMetadataChange,
+  topologyFeed,
+  onTopologyFeedChange,
   onValidationChange,
 }: InfrastructureMetadataProps) => {
   const [errors, setErrors] = useState(() => ({
     uiUrl: '',
     poemUrl: '',
-    topologyUrl: '',
     authUrl: '',
     internalListsEmails: metadata.internalLists.map(() => ({ email: '' })),
   }))
-
   const { data: contactTypes, isLoading: isContactTypesLoading } =
     useGetUserContactTypes()
 
-  const urlErrorMesage =
+  const urlErrorMessage =
     'Please enter a valid URL (must start with http:// or https://)'
 
-  const handleTopologyTypeChange = (value: string) => {
-    onMetadataChange({ ...metadata, topology_type: value })
+  const handleFeedTypeChange = (value: string) => {
+    onTopologyFeedChange({
+      type: value,
+      feed_url: '',
+      feed_service_groups: '',
+      feed_service_endpoints: '',
+      feed_service_endpoints_extensions: '',
+    })
+  }
+
+  const handleFeedFieldChange = (
+    field: keyof Omit<TopologyFeedFormState, 'type'>,
+    value: string,
+  ) => {
+    onTopologyFeedChange({ ...topologyFeed, [field]: value })
   }
 
   const handleInternalListTypeChange = (index: number, value: string) => {
@@ -73,7 +103,6 @@ const InfrastructureMetadata = ({
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value: fieldValue } = e.target
-    const urlRegex = /^https?:\/\/.+\..+/
 
     onMetadataChange({
       ...metadata,
@@ -82,13 +111,12 @@ const InfrastructureMetadata = ({
 
     if (name === 'ui_url') {
       if (fieldValue && !urlRegex.test(fieldValue)) {
-        setErrors((prev) => ({ ...prev, uiUrl: urlErrorMesage }))
+        setErrors((prev) => ({ ...prev, uiUrl: urlErrorMessage }))
         onValidationChange?.(true)
       } else {
         setErrors((prev) => ({ ...prev, uiUrl: '' }))
         const hasErrors =
           !!errors.poemUrl ||
-          !!errors.topologyUrl ||
           !!errors.authUrl ||
           errors.internalListsEmails.some((err) => err.email)
         onValidationChange?.(hasErrors)
@@ -97,28 +125,12 @@ const InfrastructureMetadata = ({
 
     if (name === 'poem_url') {
       if (fieldValue && !urlRegex.test(fieldValue)) {
-        setErrors((prev) => ({ ...prev, poemUrl: urlErrorMesage }))
+        setErrors((prev) => ({ ...prev, poemUrl: urlErrorMessage }))
         onValidationChange?.(true)
       } else {
         setErrors((prev) => ({ ...prev, poemUrl: '' }))
         const hasErrors =
           !!errors.uiUrl ||
-          !!errors.topologyUrl ||
-          !!errors.authUrl ||
-          errors.internalListsEmails.some((err) => err.email)
-        onValidationChange?.(hasErrors)
-      }
-    }
-
-    if (name === 'topology_url') {
-      if (fieldValue && !urlRegex.test(fieldValue)) {
-        setErrors((prev) => ({ ...prev, topologyUrl: urlErrorMesage }))
-        onValidationChange?.(true)
-      } else {
-        setErrors((prev) => ({ ...prev, topologyUrl: '' }))
-        const hasErrors =
-          !!errors.uiUrl ||
-          !!errors.poemUrl ||
           !!errors.authUrl ||
           errors.internalListsEmails.some((err) => err.email)
         onValidationChange?.(hasErrors)
@@ -127,14 +139,13 @@ const InfrastructureMetadata = ({
 
     if (name === 'auth_url') {
       if (fieldValue && !urlRegex.test(fieldValue)) {
-        setErrors((prev) => ({ ...prev, authUrl: urlErrorMesage }))
+        setErrors((prev) => ({ ...prev, authUrl: urlErrorMessage }))
         onValidationChange?.(true)
       } else {
         setErrors((prev) => ({ ...prev, authUrl: '' }))
         const hasErrors =
           !!errors.uiUrl ||
           !!errors.poemUrl ||
-          !!errors.topologyUrl ||
           errors.internalListsEmails.some((err) => err.email)
         onValidationChange?.(hasErrors)
       }
@@ -166,7 +177,6 @@ const InfrastructureMetadata = ({
         const hasAnyError =
           !!errors.uiUrl ||
           !!errors.poemUrl ||
-          !!errors.topologyUrl ||
           !!errors.authUrl ||
           updatedErrors.some((err) => err.email)
         onValidationChange?.(hasAnyError)
@@ -208,7 +218,6 @@ const InfrastructureMetadata = ({
       const hasAnyError =
         !!errors.uiUrl ||
         !!errors.poemUrl ||
-        !!errors.topologyUrl ||
         !!errors.authUrl ||
         updatedErrors.some((err) => err.email)
       onValidationChange?.(hasAnyError)
@@ -220,8 +229,38 @@ const InfrastructureMetadata = ({
       <div className={sectionClass}>
         <div className="pt-2 pl-2">
           <h2 className="section-title">Instance URLs</h2>
+          <p className="section-description">Instance URL configurations</p>
+        </div>
+
+        <div className={sectionContentClass}>
+          <div className={fieldGridClass}>
+            <FormField
+              label="UI URL"
+              type="url"
+              name="ui_url"
+              value={metadata.ui_url}
+              onChange={handleChange}
+              placeholder="Enter UI URL"
+              error={errors.uiUrl}
+            />
+            <FormField
+              label="POEM URL"
+              type="url"
+              name="poem_url"
+              value={metadata.poem_url}
+              onChange={handleChange}
+              placeholder="Enter POEM URL"
+              error={errors.poemUrl}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className={sectionClass}>
+        <div className="pt-2 pl-2">
+          <h2 className="section-title">Topology Feed</h2>
           <p className="section-description">
-            Primary instance URL configurations
+            Feed configuration for topology data
           </p>
         </div>
 
@@ -229,99 +268,68 @@ const InfrastructureMetadata = ({
           <div className={fieldGridClass}>
             <div className="flex flex-col">
               <label className="text-sm font-medium text-body mb-1">
-                UI URL
+                Type <span className="required">*</span>
               </label>
-              <input
-                type="url"
-                name="ui_url"
-                value={metadata.ui_url}
-                onChange={handleChange}
-                placeholder="Enter UI URL"
-              />
-              {errors.uiUrl && (
-                <span className="text-red-400 text-sm mt-1">
-                  {errors.uiUrl}
-                </span>
-              )}
-            </div>
-
-            <div className="flex flex-col">
-              <label className="text-sm font-medium text-body mb-1">
-                POEM URL
-              </label>
-              <input
-                type="url"
-                name="poem_url"
-                value={metadata.poem_url}
-                onChange={handleChange}
-                placeholder="Enter POEM URL"
-              />
-              {errors.poemUrl && (
-                <span className="text-red-400 text-sm mt-1">
-                  {errors.poemUrl}
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className={sectionClass}>
-        <div className="pt-2 pl-2">
-          <h2 className="section-title">Topology</h2>
-          <p className="section-description">Topology configuration settings</p>
-        </div>
-
-        <div className={sectionContentClass}>
-          <div className={fieldGridClass}>
-            <div className="flex flex-col">
-              <label className="text-sm font-medium text-body mb-1">Type</label>
-              {isContactTypesLoading ? (
-                <div className="text-sm text-muted">Loading...</div>
-              ) : (
-                <SelectDropdown
-                  value={metadata.topology_type}
-                  onChange={handleTopologyTypeChange}
-                  options={[
-                    { value: 'GOCDB', label: 'GOCdb' },
-                    { value: 'CSV', label: 'CSV' },
-                  ]}
-                  placeholder="Select type"
-                />
-              )}
-            </div>
-
-            <div className="flex flex-col">
-              <label className="text-sm font-medium text-body mb-1">
-                Service URL
-              </label>
-              <input
-                type="url"
-                name="topology_url"
-                value={metadata.topology_url}
-                onChange={handleChange}
-                placeholder="Enter topology URL"
-              />
-              {errors.topologyUrl && (
-                <span className="text-red-400 text-sm mt-1">
-                  {errors.topologyUrl}
-                </span>
-              )}
-            </div>
-
-            <div className="flex flex-col">
-              <label className="text-sm font-medium text-body mb-1">
-                Data Feed
-              </label>
-              <input
-                type="text"
-                name="topology_feed"
-                value={metadata.topology_feed}
-                onChange={handleChange}
-                placeholder="Enter topology feed"
+              <SelectDropdown
+                value={topologyFeed.type}
+                onChange={handleFeedTypeChange}
+                options={FEED_TYPE_OPTIONS}
+                placeholder="Select feed type"
               />
             </div>
           </div>
+
+          {topologyFeed.type === 'CSV' && (
+            <div className={fieldGridClass}>
+              <FormField
+                label="URL"
+                type="url"
+                value={topologyFeed.feed_url}
+                onChange={(e) =>
+                  handleFeedFieldChange('feed_url', e.target.value)
+                }
+                placeholder="Enter feed URL"
+              />
+            </div>
+          )}
+
+          {topologyFeed.type === 'eosc-service-catalog' && (
+            <div className={fieldGridClass}>
+              <FormField
+                label="Service Groups URL"
+                type="url"
+                value={topologyFeed.feed_service_groups}
+                onChange={(e) =>
+                  handleFeedFieldChange('feed_service_groups', e.target.value)
+                }
+                placeholder="Enter service groups feed URL"
+              />
+              <FormField
+                label="Service Endpoints URL"
+                type="url"
+                value={topologyFeed.feed_service_endpoints}
+                onChange={(e) =>
+                  handleFeedFieldChange(
+                    'feed_service_endpoints',
+                    e.target.value,
+                  )
+                }
+                placeholder="Enter service endpoints feed URL"
+              />
+              <FormField
+                label="Service Endpoint Extensions URL"
+                type="url"
+                value={topologyFeed.feed_service_endpoints_extensions}
+                onChange={(e) =>
+                  handleFeedFieldChange(
+                    'feed_service_endpoints_extensions',
+                    e.target.value,
+                  )
+                }
+                placeholder="Enter service endpoint extensions feed URL"
+              />
+            </div>
+          )}
         </div>
       </div>
 
@@ -335,7 +343,7 @@ const InfrastructureMetadata = ({
           {metadata.internalLists.map((list, index) => (
             <div
               key={index}
-              className="flex flex-col gap-2 pb-4 mb-2 border-b border-line last:border-b-0 last:mb-0 last:pb-0"
+              className="flex flex-col gap-1 pb-4 mb-2 border-b border-line last:border-b-0 last:mb-0 last:pb-0"
             >
               <div className="flex justify-between items-center mb-1.5">
                 <span className="text-base font-semibold text-body">
@@ -367,23 +375,15 @@ const InfrastructureMetadata = ({
               </div>
 
               <div className={fieldGridClass}>
-                <div className="flex flex-col">
-                  <label className="text-sm font-medium text-body mb-1">
-                    Email
-                  </label>
-                  <input
-                    type="email"
-                    name="email"
-                    value={list.email}
-                    onChange={(e) => handleInternalListChange(index, e)}
-                    placeholder="Enter email address"
-                  />
-                  {errors.internalListsEmails[index]?.email && (
-                    <span className="text-red-400 text-sm mt-1">
-                      {errors.internalListsEmails[index].email}
-                    </span>
-                  )}
-                </div>
+                <FormField
+                  label="Email"
+                  type="email"
+                  name="email"
+                  value={list.email}
+                  onChange={(e) => handleInternalListChange(index, e)}
+                  placeholder="Enter email address"
+                  error={errors.internalListsEmails[index]?.email}
+                />
 
                 <div className="flex flex-col">
                   <label className="text-sm font-medium text-body mb-1">
@@ -425,36 +425,22 @@ const InfrastructureMetadata = ({
 
         <div className={sectionContentClass}>
           <div className={fieldGridClass}>
-            <div className="flex flex-col">
-              <label className="text-sm font-medium text-body mb-1">
-                Auth Name
-              </label>
-              <input
-                type="text"
-                name="auth_name"
-                value={metadata.auth_name}
-                onChange={handleChange}
-                placeholder="Enter authentication name"
-              />
-            </div>
-
-            <div className="flex flex-col">
-              <label className="text-sm font-medium text-body mb-1">
-                Auth URL
-              </label>
-              <input
-                type="url"
-                name="auth_url"
-                value={metadata.auth_url}
-                onChange={handleChange}
-                placeholder="Enter authentication URL"
-              />
-              {errors.authUrl && (
-                <span className="text-red-400 text-sm mt-1">
-                  {errors.authUrl}
-                </span>
-              )}
-            </div>
+            <FormField
+              label="Auth Name"
+              name="auth_name"
+              value={metadata.auth_name}
+              onChange={handleChange}
+              placeholder="Enter authentication name"
+            />
+            <FormField
+              label="Auth URL"
+              type="url"
+              name="auth_url"
+              value={metadata.auth_url}
+              onChange={handleChange}
+              placeholder="Enter authentication URL"
+              error={errors.authUrl}
+            />
           </div>
         </div>
       </div>

--- a/src/pages/tenant-details/TenantInfoTab.tsx
+++ b/src/pages/tenant-details/TenantInfoTab.tsx
@@ -1,5 +1,8 @@
 import { useEffect } from 'react'
-import { useGetUserTenantProjects } from '@/hooks/useTenants'
+import {
+  useGetUserTenantProjects,
+  useGetTopologyFeedQuery,
+} from '@/hooks/useTenants'
 import { useSelectedTenant } from '@/contexts/selected-tenant'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
@@ -45,6 +48,9 @@ const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
     fetchNextPage: fetchNextProjectsPage,
     hasNextPage: hasNextProjectsPage,
   } = useGetUserTenantProjects(tenantId, true)
+
+  const { data: topologyFeedData, isLoading: topologyFeedLoading } =
+    useGetTopologyFeedQuery(tenantId, !!tenantId)
 
   useEffect(() => {
     if (hasNextProjectsPage) {
@@ -155,13 +161,15 @@ const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
             Infrastructure Metadata
           </h2>
         </div>
-        {metadata &&
-        (metadata.instance ||
-          metadata.internalLists ||
-          metadata.auth_metadata) ? (
+        {(metadata &&
+          (metadata.instance ||
+            metadata.internalLists ||
+            metadata.auth_metadata)) ||
+        topologyFeedData ||
+        topologyFeedLoading ? (
           <div className="bg-surface-muted rounded-lg py-2 px-4 flex flex-col gap-2">
             {/* Instance Information */}
-            {metadata.instance && (
+            {metadata?.instance && (
               <>
                 <div className="pt-2 border-t border-line first:pt-0 first:border-t-0">
                   <h3 className="text-base font-semibold text-body">
@@ -204,35 +212,40 @@ const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
                     </p>
                   </div>
                 </div>
+              </>
+            )}
 
-                {/* Topology */}
-                {metadata.instance.topology && (
-                  <>
-                    <div className="pt-2 border-t border-line">
-                      <h3 className="text-base font-semibold text-body">
-                        Topology
-                      </h3>
+            {/* Topology Feed */}
+            <>
+              <div className="pt-2 border-t border-line first:pt-0 first:border-t-0">
+                <h3 className="text-base font-semibold text-body">
+                  Topology Feed
+                </h3>
+              </div>
+              {topologyFeedLoading ? (
+                <LoadingSpinner size="xs" inline />
+              ) : topologyFeedData ? (
+                <>
+                  <div className={cardRowClass}>
+                    <div className={infoGroupClass}>
+                      <label className={labelClass}>Type</label>
+                      <p className={valueClass}>{topologyFeedData.type}</p>
                     </div>
+                  </div>
+
+                  {topologyFeedData.type === 'CSV' && (
                     <div className={cardRowClass}>
                       <div className={infoGroupClass}>
-                        <label className={labelClass}>Type</label>
+                        <label className={labelClass}>Feed URL</label>
                         <p className={valueClass}>
-                          {metadata.instance.topology.type || (
-                            <span className={noDataClass}>Not provided</span>
-                          )}
-                        </p>
-                      </div>
-                      <div className={infoGroupClass}>
-                        <label className={labelClass}>URL</label>
-                        <p className={valueClass}>
-                          {metadata.instance.topology.url ? (
+                          {topologyFeedData.feed_url ? (
                             <a
-                              href={metadata.instance.topology.url}
+                              href={topologyFeedData.feed_url}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className={linkClass}
+                              className={`${linkClass} break-words`}
                             >
-                              {metadata.instance.topology.url}
+                              {topologyFeedData.feed_url}
                             </a>
                           ) : (
                             <span className={noDataClass}>Not provided</span>
@@ -240,40 +253,79 @@ const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
                         </p>
                       </div>
                     </div>
+                  )}
+
+                  {topologyFeedData.type === 'eosc-service-catalog' && (
                     <div className={cardRowClass}>
                       <div className={infoGroupClass}>
-                        <label className={labelClass}>Feed</label>
-                        <p className={`${valueClass} max-w-[45%]`}>
-                          {metadata.instance.topology.feed ? (
-                            metadata.instance.topology.feed.startsWith(
-                              'http',
-                            ) ? (
-                              <a
-                                href={metadata.instance.topology.feed}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className={`${linkClass} break-words`}
-                              >
-                                {metadata.instance.topology.feed}
-                              </a>
-                            ) : (
-                              <span className="break-words">
-                                {metadata.instance.topology.feed}
-                              </span>
-                            )
+                        <label className={labelClass}>Service Groups URL</label>
+                        <p className={valueClass}>
+                          {topologyFeedData.feed_service_groups ? (
+                            <a
+                              href={topologyFeedData.feed_service_groups}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={`${linkClass} break-words`}
+                            >
+                              {topologyFeedData.feed_service_groups}
+                            </a>
+                          ) : (
+                            <span className={noDataClass}>Not provided</span>
+                          )}
+                        </p>
+                      </div>
+                      <div className={infoGroupClass}>
+                        <label className={labelClass}>
+                          Service Endpoints URL
+                        </label>
+                        <p className={valueClass}>
+                          {topologyFeedData.feed_service_endpoints ? (
+                            <a
+                              href={topologyFeedData.feed_service_endpoints}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={`${linkClass} break-words`}
+                            >
+                              {topologyFeedData.feed_service_endpoints}
+                            </a>
+                          ) : (
+                            <span className={noDataClass}>Not provided</span>
+                          )}
+                        </p>
+                      </div>
+                      <div className={infoGroupClass}>
+                        <label className={labelClass}>
+                          Service Endpoint Extensions URL
+                        </label>
+                        <p className={valueClass}>
+                          {topologyFeedData.feed_service_endpoints_extensions ? (
+                            <a
+                              href={
+                                topologyFeedData.feed_service_endpoints_extensions
+                              }
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={`${linkClass} break-words`}
+                            >
+                              {
+                                topologyFeedData.feed_service_endpoints_extensions
+                              }
+                            </a>
                           ) : (
                             <span className={noDataClass}>Not provided</span>
                           )}
                         </p>
                       </div>
                     </div>
-                  </>
-                )}
-              </>
-            )}
+                  )}
+                </>
+              ) : (
+                <span className={noDataClass}>Not configured</span>
+              )}
+            </>
 
             {/* Internal Lists */}
-            {metadata.internalLists && metadata.internalLists.length > 0 && (
+            {metadata?.internalLists && metadata.internalLists.length > 0 && (
               <>
                 <div className="pt-2 border-t border-line">
                   <h3 className="text-base font-semibold text-body">
@@ -301,7 +353,7 @@ const TenantInfoTab = ({ tenantId }: TenantInfoTabProps) => {
             )}
 
             {/* Authentication Metadata */}
-            {metadata.auth_metadata && (
+            {metadata?.auth_metadata && (
               <>
                 <div className="pt-2 border-t border-line">
                   <h3 className="text-base font-semibold text-body">

--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
-import { useSelectedTenant } from '@/contexts/selected-tenant'
 import {
   useGetTopologyEndpoints,
   useCreateTopologyEndpointMutation,
@@ -35,7 +34,6 @@ interface TopologyEndpointsProps {
 }
 
 const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
-  const { tenant: tenantData } = useSelectedTenant()
   const [monitoredFilter, setMonitoredFilter] = useState<
     'all' | 'monitored' | 'not_monitored'
   >('all')
@@ -59,6 +57,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
     dateInput,
     committedDate,
     showActions,
+    isExternal,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,
@@ -148,7 +147,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           placeholder="Search by service, hostname, URL or group..."
           className="!mb-0 flex-1 max-w-xs xl:max-w-none"
         />
-        {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
+        {!isExternal && (
           <Button
             variant="primary"
             size="md"

--- a/src/pages/tenant-topology/TopologyGroups.tsx
+++ b/src/pages/tenant-topology/TopologyGroups.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
-import { useSelectedTenant } from '@/contexts/selected-tenant'
 import {
   useGetTopologyGroups,
   useCreateTopologyGroupsMutation,
@@ -34,7 +33,6 @@ interface TopologyGroupsProps {
 }
 
 const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
-  const { tenant: tenantData } = useSelectedTenant()
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [groupToDelete, setGroupToDelete] = useState<{
     group: GroupTopologyItem
@@ -55,6 +53,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
     dateInput,
     committedDate,
     showActions,
+    isExternal,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,
@@ -150,7 +149,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
             ]}
             className="w-36"
           />
-          {tenantData?.metadata?.instance?.topology?.type !== 'GOCDB' && (
+          {!isExternal && (
             <Button
               size="md"
               variant="primary"

--- a/src/pages/tenant-topology/hooks/useTopologyListState.ts
+++ b/src/pages/tenant-topology/hooks/useTopologyListState.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useSelectedTenant } from '@/contexts/selected-tenant'
+import { useGetTopologyFeedQuery } from '@/hooks/useTenants'
 
 type DateMode = 'latest' | 'custom'
 
@@ -35,10 +36,14 @@ export const useTopologyListState = <TSort extends string>({
   }, [committedDate])
 
   const { tenant } = useSelectedTenant()
-  const isGocdb = tenant?.metadata?.instance?.topology?.type === 'GOCDB'
+  const { data: topologyFeedData } = useGetTopologyFeedQuery(
+    tenant?.id ?? '',
+    !!tenant?.id,
+  )
+  const isExternal = topologyFeedData?.type === 'external'
 
   const showActions =
-    !isGocdb &&
+    !isExternal &&
     (dateMode === 'latest' ||
       (dateMode === 'custom' && committedDate === latestDate && !!latestDate))
 
@@ -83,6 +88,7 @@ export const useTopologyListState = <TSort extends string>({
     dateInput,
     committedDate,
     showActions,
+    isExternal,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,

--- a/src/types/tenants.ts
+++ b/src/types/tenants.ts
@@ -32,6 +32,17 @@ export type Metadata = {
   auth_metadata?: AuthMetadata
 }
 
+export type TopologyFeed = {
+  type: string
+  feed_url?: string
+  feed_service_groups?: string
+  feed_service_endpoints?: string
+  feed_service_endpoints_extensions?: string
+  paginated?: string
+  fetch_type?: string[]
+  uid_endpoints?: string
+}
+
 export type TenantInfo = {
   name: string
   email: string


### PR DESCRIPTION
This PR implements topology feed configuration in the tenant form and displays the configured feed details in the tenant info view.

- Updated the Infrastructure Settings tab with a Topology Feed section and conditional fields per feed type
- Refactored the tenant form to load and validate topology feed data alongside the rest of the form
- Implemented a reusable form field component in the tenant creation flow
- Added API and hook integration for fetching and updating topology feed configuration
- Updated the tenant info tab to display topology feed details based on the configured feed type

