### PR TITLE
[ARGO-5553] - Extend status page builder with theme options and preview layouts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import EndpointsAccess from './pages/endpoints-access'
 import ManageTenantMembers from './pages/manage-tenant-members'
 import MyInvitations from './pages/MyInvitations'
 import { InvitationReview } from './pages/InvitationReview'
-import { ExpandableStatus } from './pages/ExpandableStatus'
+import PublicStatusPage from './pages/PublicStatusPage'
 import {
   TenantTopology,
   CreateTopologyEndpoint,
@@ -65,7 +65,7 @@ function App() {
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
           <Routes>
-            <Route path="status/:slug" element={<ExpandableStatus />} />
+            <Route path="status/:slug" element={<PublicStatusPage />} />
             <Route element={<AuthLayout />}>
               <Route path="invitation/:id" element={<InvitationReview />} />
               <Route element={<Layout />}>

--- a/src/components/StatusLegend.tsx
+++ b/src/components/StatusLegend.tsx
@@ -1,0 +1,67 @@
+import {
+  ArrowDownCircleIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  QuestionMarkCircleIcon,
+  XCircleIcon,
+} from '@heroicons/react/16/solid'
+
+interface StatusLegendProps {
+  iconMode: string
+}
+
+const StatusLegend = ({ iconMode }: StatusLegendProps) => (
+  <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+    <div className="flex items-center gap-2">
+      {iconMode === 'icon' ? (
+        <CheckCircleIcon className="size-4 text-success" />
+      ) : (
+        <div className="status status-lg status-success"></div>
+      )}
+      <span className="text-muted font-medium">Operational</span>
+    </div>
+    <div className="flex items-center gap-2">
+      {iconMode === 'icon' ? (
+        <XCircleIcon className="size-4 text-error" />
+      ) : (
+        <div className="status status-lg status-error"></div>
+      )}
+      <span className="text-muted font-medium">Critical</span>
+    </div>
+    <div className="flex items-center gap-2">
+      {iconMode === 'icon' ? (
+        <ExclamationTriangleIcon className="size-4 text-warning" />
+      ) : (
+        <div className="status status-lg status-warning"></div>
+      )}
+      <span className="text-muted font-medium">Warning</span>
+    </div>
+    <div className="flex items-center gap-2">
+      {iconMode === 'icon' ? (
+        <ExclamationCircleIcon className="size-4 text-info" />
+      ) : (
+        <div className="status status-lg status-info"></div>
+      )}
+      <span className="text-muted font-medium">Missing</span>
+    </div>
+    <div className="flex items-center gap-2">
+      {iconMode === 'icon' ? (
+        <ArrowDownCircleIcon className="size-4 text-black" />
+      ) : (
+        <div className="status status-lg status-neutral"></div>
+      )}
+      <span className="text-muted font-medium">Downtime</span>
+    </div>
+    <div className="flex items-center gap-2">
+      {iconMode === 'icon' ? (
+        <QuestionMarkCircleIcon className="size-4 text-subtle" />
+      ) : (
+        <div className="status status-lg status-unknown"></div>
+      )}
+      <span className="text-muted font-medium">Unknown</span>
+    </div>
+  </div>
+)
+
+export default StatusLegend

--- a/src/pages/ExpandableStatus.tsx
+++ b/src/pages/ExpandableStatus.tsx
@@ -1,163 +1,82 @@
-import { useParams } from 'react-router-dom'
-import {
-  ArrowDownCircleIcon,
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  QuestionMarkCircleIcon,
-  XCircleIcon,
-} from '@heroicons/react/16/solid'
-import { useGetStatusQuery } from '@/hooks/useStatus'
 import ExpandableGroup from '@/components/ExpandableGroup'
-import LoadingSpinner from '@/components/LoadingSpinner'
-import ErrorDisplay from '@/components/ErrorDisplay'
+import StatusLegend from '@/components/StatusLegend'
+import type { PageConfig } from '@/types/pages'
 
-const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+interface ExpandableStatusProps {
+  statusData: PageConfig
+  logo?: string
+}
 
-export const ExpandableStatus = () => {
-  const { slug } = useParams<{ slug: string }>()
-
-  const { data: statusData, isLoading } = useGetStatusQuery(slug || '')
+export const ExpandableStatus = ({
+  statusData,
+  logo,
+}: ExpandableStatusProps) => {
+  const iconMode = statusData.theming?.status.icon || 'led'
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 py-6">
-      <div className="container mx-auto max-w-5xl">
-        {isLoading ? (
-          <div className="flex flex-col items-center justify-center mt-32">
-            <LoadingSpinner />
-            <div className="text-lg text-muted">Loading status page...</div>
-          </div>
-        ) : statusData ? (
-          <div className="bg-white rounded-xl shadow-lg overflow-hidden">
-            <header
-              className="flex items-center gap-4 px-8 py-5 border-b border-line"
-              style={{
-                backgroundColor: statusData.theming?.color || '#FFFFFF',
-              }}
-            >
-              {statusData.theming?.logo && (
-                <img
-                  alt="Logo"
-                  className="h-10 object-contain shrink-0"
-                  src={
-                    statusData.theming.logo.startsWith('http') ||
-                    statusData.theming.logo.startsWith('data:')
-                      ? statusData.theming.logo
-                      : `${BACKEND_API}${statusData.theming.logo}`
-                  }
-                />
-              )}
-              <div>
-                <h1 className="text-xl font-semibold text-foreground">
-                  {statusData.title}
-                </h1>
-                {statusData.description && (
-                  <p className="text-sm text-muted">{statusData.description}</p>
-                )}
-              </div>
-            </header>
+    <div className="bg-white rounded-xl shadow-lg overflow-hidden">
+      <header
+        className="flex items-center gap-4 px-8 py-5 border-b border-line"
+        style={{ backgroundColor: statusData.theming?.color || '#FFFFFF' }}
+      >
+        {logo && (
+          <img alt="Logo" className="h-10 object-contain shrink-0" src={logo} />
+        )}
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">
+            {statusData.title}
+          </h1>
+          {statusData.description && (
+            <p className="text-sm text-muted">{statusData.description}</p>
+          )}
+        </div>
+      </header>
 
-            <main
-              className={`py-6 ${statusData?.theming?.columns === 'one' ? 'px-36' : 'px-18'}`}
-            >
-              <div className="flex flex-wrap items-center gap-6 mb-6 text-sm">
-                <div className="flex items-center gap-2">
-                  {statusData?.theming?.status.icon === 'icon' ? (
-                    <CheckCircleIcon className="size-4 text-success" />
-                  ) : (
-                    <div className="status status-lg status-success"></div>
-                  )}
-                  <span className="text-muted font-medium">Operational</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  {statusData?.theming?.status.icon === 'icon' ? (
-                    <XCircleIcon className="size-4 text-error" />
-                  ) : (
-                    <div className="status status-lg status-error"></div>
-                  )}
-                  <span className="text-muted font-medium">Critical</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  {statusData?.theming?.status.icon === 'icon' ? (
-                    <ExclamationTriangleIcon className="size-4 text-warning" />
-                  ) : (
-                    <div className="status status-lg status-warning"></div>
-                  )}
-                  <span className="text-muted font-medium">Warning</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  {statusData?.theming?.status.icon === 'icon' ? (
-                    <ExclamationCircleIcon className="size-4 text-info" />
-                  ) : (
-                    <div className="status status-lg status-info"></div>
-                  )}
-                  <span className="text-muted font-medium">Missing</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  {statusData?.theming?.status.icon === 'icon' ? (
-                    <ArrowDownCircleIcon className="size-4 text-black" />
-                  ) : (
-                    <div className="status status-lg status-neutral"></div>
-                  )}
-                  <span className="text-muted font-medium">Downtime</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  {statusData?.theming?.status.icon === 'icon' ? (
-                    <QuestionMarkCircleIcon className="size-4 text-subtle" />
-                  ) : (
-                    <div className="status status-lg status-unknown"></div>
-                  )}
-                  <span className="text-muted font-medium">Unknown</span>
-                </div>
-              </div>
-              {statusData.groups && statusData.groups.length > 0 ? (
-                <div className="space-y-4">
-                  {statusData.groups.map((group) => (
-                    <ExpandableGroup
-                      key={group.name}
-                      name={group.name}
-                      alias={group.alias || ''}
-                      items={group.list}
-                      iconMode={statusData?.theming?.status.icon || 'led'}
-                      textMode={statusData?.theming?.status.text || 'none'}
-                      columns={statusData?.theming?.columns || 'one'}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-12 text-muted">
-                  No status information available
-                </div>
-              )}
-            </main>
-            <footer className="p-8 mt-8 bg-surface-muted border-t border-line">
-              <div className="text-center text-sm font-medium text-muted tracking-wide">
-                Last updated:{' '}
-                {new Date().toLocaleDateString('en-GB', {
-                  day: 'numeric',
-                  month: 'short',
-                  year: 'numeric',
-                  timeZone: 'UTC',
-                })}
-                ,{' '}
-                {new Date().toLocaleTimeString('en-GB', {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                  timeZone: 'UTC',
-                })}{' '}
-                (UTC)
-              </div>
-            </footer>
+      <main
+        className={`py-6 ${statusData.theming?.columns === 'one' ? 'px-36' : 'px-18'}`}
+      >
+        <div className="mb-6">
+          <StatusLegend iconMode={iconMode} />
+        </div>
+
+        {statusData.groups && statusData.groups.length > 0 ? (
+          <div className="space-y-4">
+            {statusData.groups.map((group) => (
+              <ExpandableGroup
+                key={group.name}
+                name={group.name}
+                alias={group.alias || ''}
+                items={group.list}
+                iconMode={iconMode}
+                textMode={statusData.theming?.status.text || 'none'}
+                columns={statusData.theming?.columns || 'one'}
+              />
+            ))}
           </div>
         ) : (
-          <div className="page-container">
-            <ErrorDisplay
-              error="Failed to load status page"
-              context="status page"
-            />
+          <div className="text-center py-12 text-muted">
+            No status information available
           </div>
         )}
-      </div>
+      </main>
+      <footer className="p-8 mt-8 bg-surface-muted border-t border-line">
+        <div className="text-center text-sm font-medium text-muted tracking-wide">
+          Last updated:{' '}
+          {new Date().toLocaleDateString('en-GB', {
+            day: 'numeric',
+            month: 'short',
+            year: 'numeric',
+            timeZone: 'UTC',
+          })}
+          ,{' '}
+          {new Date().toLocaleTimeString('en-GB', {
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: 'UTC',
+          })}{' '}
+          (UTC)
+        </div>
+      </footer>
     </div>
   )
 }

--- a/src/pages/PublicStatusPage.tsx
+++ b/src/pages/PublicStatusPage.tsx
@@ -1,0 +1,65 @@
+import { useParams } from 'react-router-dom'
+import { useGetStatusQuery } from '@/hooks/useStatus'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import { ExpandableStatus } from './ExpandableStatus'
+import { Status } from './Status'
+import type { ThemeOption } from '@/types/pages'
+
+const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+const resolveLogo = (
+  option?: ThemeOption,
+  raw?: string,
+): string | undefined => {
+  if (!raw || !option?.includes('with_logo')) return undefined
+  return raw.startsWith('http') || raw.startsWith('data:')
+    ? raw
+    : `${BACKEND_API}${raw}`
+}
+
+const PublicStatusPage = () => {
+  const { slug } = useParams<{ slug: string }>()
+
+  const { data: statusData, isLoading } = useGetStatusQuery(slug || '')
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 py-6">
+      <div className="container mx-auto max-w-5xl">
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center mt-32">
+            <LoadingSpinner />
+            <div className="text-lg text-muted">Loading status page...</div>
+          </div>
+        ) : statusData ? (
+          statusData.theming?.option?.startsWith('theme_2') ? (
+            <Status
+              statusData={statusData}
+              logo={resolveLogo(
+                statusData.theming?.option,
+                statusData.theming?.logo,
+              )}
+            />
+          ) : (
+            <ExpandableStatus
+              statusData={statusData}
+              logo={resolveLogo(
+                statusData.theming?.option,
+                statusData.theming?.logo,
+              )}
+            />
+          )
+        ) : (
+          <div className="page-container">
+            <ErrorDisplay
+              error="Failed to load status page"
+              context="status page"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default PublicStatusPage

--- a/src/pages/Status.tsx
+++ b/src/pages/Status.tsx
@@ -1,201 +1,111 @@
-import { useParams } from 'react-router-dom'
-import {
-  ArrowDownCircleIcon,
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  QuestionMarkCircleIcon,
-  XCircleIcon,
-} from '@heroicons/react/16/solid'
-import { useGetStatusQuery } from '@/hooks/useStatus'
 import ViewGroup from '@/components/ViewGroup'
-import LoadingSpinner from '@/components/LoadingSpinner'
-import ErrorDisplay from '@/components/ErrorDisplay'
+import StatusLegend from '@/components/StatusLegend'
+import type { PageConfig } from '@/types/pages'
 
-const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+interface StatusProps {
+  statusData: PageConfig
+  logo?: string
+}
 
-export const Status = () => {
-  const { slug } = useParams<{ slug: string }>()
-
-  const { data: statusData, isLoading } = useGetStatusQuery(slug || '')
+export const Status = ({ statusData, logo }: StatusProps) => {
+  const iconMode = statusData.theming?.status.icon || 'led'
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 py-6">
-      <div className="container mx-auto max-w-5xl">
-        {isLoading ? (
-          <div className="flex flex-col items-center justify-center mt-32">
-            <LoadingSpinner />
-            <div className="text-lg text-muted">Loading status page...</div>
-          </div>
-        ) : statusData ? (
-          <div className="bg-white rounded-xl shadow-lg overflow-hidden">
-            <header className="relative">
-              <div className="relative h-64">
-                <div
-                  className="absolute inset-0"
-                  style={{
-                    backgroundImage:
-                      'url(/background-image-public-status-pages.png)',
-                    backgroundSize: 'cover',
-                    backgroundPosition: 'center',
-                    backgroundRepeat: 'no-repeat',
-                  }}
-                />
-              </div>
+    <div className="bg-white rounded-xl shadow-lg overflow-hidden">
+      <header className="relative">
+        <div className="relative h-64">
+          <div
+            className="absolute inset-0"
+            style={{
+              backgroundImage: 'url(/background-image-public-status-pages.png)',
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              backgroundRepeat: 'no-repeat',
+            }}
+          />
+        </div>
 
-              {(statusData.theming?.option === 'theme_1' ||
-                !statusData.theming?.option) &&
-              statusData.theming?.logo ? (
-                <div className="relative flex justify-center -mt-20">
-                  <div className="bg-white rounded-full p-2 shadow-xl">
-                    <img
-                      alt="Logo"
-                      className="h-32 w-32 object-contain"
-                      src={
-                        statusData.theming?.logo?.startsWith('http') ||
-                        statusData.theming?.logo?.startsWith('data:')
-                          ? statusData.theming?.logo
-                          : `${BACKEND_API}${statusData.theming?.logo}`
-                      }
-                      style={{
-                        borderRadius: '50%',
-                        backgroundSize: 'contain',
-                        backgroundPosition: 'center',
-                      }}
-                    />
-                  </div>
-                </div>
-              ) : null}
-
-              <div
-                className={`text-center pt-2 pb-3 px-24 ${
-                  (statusData.theming?.option === 'theme_1' ||
-                    !statusData.theming?.option) &&
-                  statusData.theming?.logo
-                    ? 'mt-4'
-                    : 'mt-8'
-                }`}
+        {logo && (
+          <div className="relative flex justify-center -mt-20">
+            <div className="bg-white rounded-full p-2 shadow-xl">
+              <img
+                alt="Logo"
+                className="h-32 w-32 object-contain"
+                src={logo}
                 style={{
-                  backgroundColor: statusData.theming?.color || '#FFFFFF',
+                  borderRadius: '50%',
+                  backgroundSize: 'contain',
+                  backgroundPosition: 'center',
                 }}
-              >
-                <div className="space-y-3">
-                  <h1 className="text-4xl font-semibold text-muted mb-1">
-                    {statusData.title}
-                  </h1>
-                  {statusData.description && (
-                    <p className="text-lg text-body max-w-2xl mx-auto">
-                      {statusData.description}
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              <div className="px-16 mt-6 mb-2 flex justify-center">
-                <div className="flex flex-wrap items-center justify-center gap-6 text-sm">
-                  <div className="flex items-center gap-2">
-                    {statusData?.theming?.status.icon === 'icon' ? (
-                      <CheckCircleIcon className="size-4 text-success" />
-                    ) : (
-                      <div className="status status-lg status-success"></div>
-                    )}
-                    <span className="text-muted font-medium">Operational</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {statusData?.theming?.status.icon === 'icon' ? (
-                      <XCircleIcon className="size-4 text-error" />
-                    ) : (
-                      <div className="status status-lg status-error"></div>
-                    )}
-                    <span className="text-muted font-medium">Critical</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {statusData?.theming?.status.icon === 'icon' ? (
-                      <ExclamationTriangleIcon className="size-4 text-warning" />
-                    ) : (
-                      <div className="status status-lg status-warning"></div>
-                    )}
-                    <span className="text-muted font-medium">Warning</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {statusData?.theming?.status.icon === 'icon' ? (
-                      <ExclamationCircleIcon className="size-4 text-info" />
-                    ) : (
-                      <div className="status status-lg status-info"></div>
-                    )}
-                    <span className="text-muted font-medium">Missing</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {statusData?.theming?.status.icon === 'icon' ? (
-                      <ArrowDownCircleIcon className="size-4 text-black" />
-                    ) : (
-                      <div className="status status-lg status-neutral"></div>
-                    )}
-                    <span className="text-muted font-medium">Downtime</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {statusData?.theming?.status.icon === 'icon' ? (
-                      <QuestionMarkCircleIcon className="size-4 text-subtle" />
-                    ) : (
-                      <div className="status status-lg status-unknown"></div>
-                    )}
-                    <span className="text-muted font-medium">Unknown</span>
-                  </div>
-                </div>
-              </div>
-            </header>
-            <main
-              className={`py-2 ${statusData?.theming?.columns === 'one' ? 'px-36' : 'px-18'}`}
-            >
-              {statusData.groups && statusData.groups.length > 0 ? (
-                <div className="space-y-4">
-                  {statusData.groups.map((group) => (
-                    <div key={group.name}>
-                      <ViewGroup
-                        columns={statusData?.theming?.columns || 'one'}
-                        name={group.name}
-                        alias={group.alias || ''}
-                        items={group.list}
-                        iconMode={statusData?.theming?.status.icon || 'led'}
-                        textMode={statusData?.theming?.status.text || 'none'}
-                      />
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-12 text-muted">
-                  No status information available
-                </div>
-              )}
-            </main>
-            <footer className="p-8 mt-8 bg-surface-muted border-t border-line">
-              <div className="text-center text-sm font-medium text-muted tracking-wide">
-                Last updated:{' '}
-                {new Date().toLocaleDateString('en-GB', {
-                  day: 'numeric',
-                  month: 'short',
-                  year: 'numeric',
-                  timeZone: 'UTC',
-                })}
-                ,{' '}
-                {new Date().toLocaleTimeString('en-GB', {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                  timeZone: 'UTC',
-                })}{' '}
-                (UTC)
-              </div>
-            </footer>
-          </div>
-        ) : (
-          <div className="page-container">
-            <ErrorDisplay
-              error="Failed to load status page"
-              context="status page"
-            />
+              />
+            </div>
           </div>
         )}
-      </div>
+
+        <div
+          className={`text-center pt-2 pb-3 px-24 ${logo ? 'mt-4' : 'mt-8'}`}
+          style={{ backgroundColor: statusData.theming?.color || '#FFFFFF' }}
+        >
+          <div className="space-y-3">
+            <h1 className="text-4xl font-semibold text-muted mb-1">
+              {statusData.title}
+            </h1>
+            {statusData.description && (
+              <p className="text-lg text-body max-w-2xl mx-auto">
+                {statusData.description}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="px-16 mt-6 mb-2 flex justify-center">
+          <StatusLegend iconMode={iconMode} />
+        </div>
+      </header>
+
+      <main
+        className={`py-2 ${statusData.theming?.columns === 'one' ? 'px-36' : 'px-18'}`}
+      >
+        {statusData.groups && statusData.groups.length > 0 ? (
+          <div className="space-y-4">
+            {statusData.groups.map((group) => (
+              <div key={group.name}>
+                <ViewGroup
+                  columns={statusData.theming?.columns || 'one'}
+                  name={group.name}
+                  alias={group.alias || ''}
+                  items={group.list}
+                  iconMode={iconMode}
+                  textMode={statusData.theming?.status.text || 'none'}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12 text-muted">
+            No status information available
+          </div>
+        )}
+      </main>
+
+      <footer className="p-8 mt-8 bg-surface-muted border-t border-line">
+        <div className="text-center text-sm font-medium text-muted tracking-wide">
+          Last updated:{' '}
+          {new Date().toLocaleDateString('en-GB', {
+            day: 'numeric',
+            month: 'short',
+            year: 'numeric',
+            timeZone: 'UTC',
+          })}
+          ,{' '}
+          {new Date().toLocaleTimeString('en-GB', {
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: 'UTC',
+          })}{' '}
+          (UTC)
+        </div>
+      </footer>
     </div>
   )
 }

--- a/src/pages/build-status-page/BuildExpandableGroup.tsx
+++ b/src/pages/build-status-page/BuildExpandableGroup.tsx
@@ -1,0 +1,154 @@
+import { useState, useEffect, useRef } from 'react'
+import { useDragAndDrop } from '@formkit/drag-and-drop/react'
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  TrashIcon,
+} from '@heroicons/react/16/solid'
+import { GripVertical } from 'lucide-react'
+import type { StatusItemType } from '@/types/common'
+import Button from '@/components/Button'
+import { StatusIcon } from '@/pages/build-status-page/StatusIcon'
+import StatusLabel from '@/pages/build-status-page/StatusLabel'
+
+type Props = {
+  name: string
+  alias: string
+  items: StatusItemType[]
+  iconMode: string
+  textMode: string
+  columns?: string
+  group: string
+  onRename: (alias: string) => void
+  onRemove: () => void
+  onItemsChange: (items: StatusItemType[]) => void
+  onChangeAlias: (itemName: string, newAlias: string) => void
+}
+
+const BuildExpandableGroup = ({
+  name,
+  alias,
+  items,
+  iconMode,
+  textMode,
+  columns = 'one',
+  group,
+  onRename,
+  onRemove,
+  onItemsChange,
+  onChangeAlias,
+}: Props) => {
+  const [open, setOpen] = useState(true)
+
+  const [listRef, orderedItems, setOrderedItems] = useDragAndDrop<
+    HTMLUListElement,
+    StatusItemType
+  >(items, { group, dragHandle: '.dnd-handle' })
+
+  const prev = useRef<StatusItemType[] | null>(null)
+
+  useEffect(() => {
+    if (prev.current !== orderedItems) {
+      prev.current = orderedItems
+      onItemsChange(orderedItems)
+    }
+  }, [orderedItems, onItemsChange])
+
+  const handleLocalAliasChange = (itemName: string, newAlias: string) => {
+    setOrderedItems((prevItems) =>
+      prevItems.map((item) =>
+        item.name === itemName ? { ...item, alias: newAlias } : item,
+      ),
+    )
+    onChangeAlias(itemName, newAlias)
+  }
+
+  return (
+    <div className="rounded-xl border border-line">
+      <div
+        className="w-full flex items-center justify-between px-5 py-4 cursor-pointer bg-surface-muted rounded-t-xl"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <div className="flex items-center gap-3">
+          {open ? (
+            <ChevronDownIcon className="size-5" />
+          ) : (
+            <ChevronRightIcon className="size-5" />
+          )}
+          <div onClick={(e) => e.stopPropagation()}>
+            <StatusLabel
+              group={name}
+              label={name}
+              alias={alias}
+              onChangeAlias={onRename}
+              isGroupLabel
+            />
+          </div>
+          <span className="text-sm text-muted">
+            ({orderedItems.length} resource
+            {orderedItems.length !== 1 ? 's' : ''})
+          </span>
+        </div>
+        <div onClick={(e) => e.stopPropagation()}>
+          <Button
+            className="p-0 tooltip tooltip-left ml-2 flex-shrink-0"
+            size="sm"
+            variant="outline-secondary"
+            onClick={onRemove}
+            data-tip="Remove group"
+          >
+            <TrashIcon className="size-4 text-subtle hover:text-muted" />
+          </Button>
+        </div>
+      </div>
+
+      <div
+        className={`border-t border-line rounded-b-xl overflow-hidden${open ? '' : ' hidden'}`}
+      >
+        <ul
+          ref={listRef}
+          className={columns === 'two' ? 'grid grid-cols-2' : ''}
+        >
+          {orderedItems.map((item, index) => (
+            <li
+              key={item.name}
+              className={`border-b border-line bg-white ${
+                columns === 'two'
+                  ? index % 2 === 0
+                    ? 'border-r border-line'
+                    : ''
+                  : 'last:border-b-0'
+              }`}
+            >
+              <div className="dnd-handle cursor-grab flex items-center gap-3 px-8 py-3 w-full">
+                <GripVertical className="text-subtle h-4 w-4 flex-shrink-0" />
+                <div className="flex-1 min-w-0 flex items-center justify-between gap-4">
+                  <StatusLabel
+                    group={name}
+                    label={item.name}
+                    alias={item.alias || ''}
+                    onChangeAlias={(newAlias) =>
+                      handleLocalAliasChange(item.name, newAlias)
+                    }
+                  />
+                  <StatusIcon
+                    status={item.status}
+                    iconMode={iconMode}
+                    textMode={textMode}
+                  />
+                </div>
+              </div>
+            </li>
+          ))}
+          {orderedItems.length === 0 && (
+            <li className="text-xs text-subtle px-3 py-4 border border-dashed border-line-strong text-center mx-5 my-2 rounded">
+              Drop items here
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default BuildExpandableGroup

--- a/src/pages/build-status-page/BuildPagePreview.tsx
+++ b/src/pages/build-status-page/BuildPagePreview.tsx
@@ -1,10 +1,11 @@
 import Button from '@/components/Button'
+import StatusLegend from '@/components/StatusLegend'
+import { isWithLogo, resolveLogoSrc } from '@/utils/logoUtils'
+import BuildExpandableGroup from '@/pages/build-status-page/BuildExpandableGroup'
+import BuildStatus from '@/pages/build-status-page/BuildStatus'
 import EditLabel from '@/pages/build-status-page/EditLabel'
-import StatusGroup from './StatusGroup'
-import { getStatusClass } from '@/utils/status'
 import type { StatusGroupType, StatusItemType } from '@/types/common'
-
-const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+import type { ThemeOption } from '@/types/pages'
 
 interface BuildPagePreviewProps {
   color: string
@@ -17,7 +18,7 @@ interface BuildPagePreviewProps {
   selectIcon: string
   selectText: string
   report: string
-  themeOption: 'theme_1' | 'theme_2'
+  themeOption: ThemeOption
   groupsMutationIsPending: boolean
   onTitleChange: (value: string) => void
   onDescChange: (value: string) => void
@@ -52,60 +53,39 @@ const BuildPagePreview = ({
   onRemoveGroup,
   onChangeItemAlias,
   onAddStatusGroup,
-}: BuildPagePreviewProps) => (
-  <div className="border border-line rounded-lg p-4 shadow-md w-full max-w-3xl self-start">
-    <header style={{ backgroundColor: color }} className="p-3 mb-2 rounded-lg">
-      <div className="flex flex-col items-center">
-        {logo && themeOption === 'theme_1' && (
-          <img
-            src={
-              logo?.startsWith('http') || logo?.startsWith('data:')
-                ? logo
-                : `${BACKEND_API}${logo}`
-            }
-            className="my-2 h-20 w-auto object-contain"
-            alt="Logo"
-          />
-        )}
-        <div className="flex flex-row items-center gap-1 mb-1">
-          <EditLabel
-            label={title}
-            onChange={onTitleChange}
-            size="text-3xl"
-            placeholder="Add a title"
-          />
-          <span className="required h-8">*</span>
-        </div>
-        <EditLabel
-          label={desc}
-          onChange={onDescChange}
-          size="text-base"
-          textArea={true}
-          placeholder="Add a description"
-          color="#6a7282"
+}: BuildPagePreviewProps) => {
+  const theme2 = themeOption.startsWith('theme_2')
+
+  if (theme2) {
+    return (
+      <div className="w-full max-w-3xl self-start">
+        <BuildStatus
+          color={color}
+          logo={logo}
+          title={title}
+          desc={desc}
+          statusGroups={statusGroups}
+          groupName={groupName}
+          columns={columns}
+          selectIcon={selectIcon}
+          selectText={selectText}
+          report={report}
+          themeOption={themeOption}
+          groupsMutationIsPending={groupsMutationIsPending}
+          onTitleChange={onTitleChange}
+          onDescChange={onDescChange}
+          onUpdateGroup={onUpdateGroup}
+          onRenameGroup={onRenameGroup}
+          onRemoveGroup={onRemoveGroup}
+          onChangeItemAlias={onChangeItemAlias}
+          onAddStatusGroup={onAddStatusGroup}
         />
       </div>
-    </header>
-    <div>
-      {statusGroups.map((col, index) => (
-        <StatusGroup
-          key={col.name}
-          name={col.name}
-          alias={col.alias || ''}
-          items={col.list}
-          group={groupName}
-          columns={columns}
-          getStatusClass={getStatusClass}
-          onItemsChange={(next) => onUpdateGroup(index, next)}
-          onRename={(nextName) => onRenameGroup(index, nextName)}
-          onRemove={() => onRemoveGroup(index)}
-          onChangeAlias={onChangeItemAlias}
-          iconMode={selectIcon}
-          textMode={selectText}
-        />
-      ))}
-    </div>
-    <div className="text-center mt-6">
+    )
+  }
+
+  const addGroupButton = (
+    <div className="text-center mt-4">
       <div
         className={!report ? 'tooltip' : ''}
         data-tip={!report ? 'Please select a report first to add groups' : ''}
@@ -119,7 +99,76 @@ const BuildPagePreview = ({
         </Button>
       </div>
     </div>
-  </div>
-)
+  )
+
+  return (
+    <div className="border border-line rounded-lg shadow-md w-full max-w-3xl self-start">
+      {/* Theme 1 header */}
+      <header
+        className="flex items-center gap-4 px-6 py-4 border-b border-line rounded-t-lg"
+        style={{ backgroundColor: color }}
+      >
+        {isWithLogo(themeOption) && logo && (
+          <img
+            alt="Logo"
+            className="h-12 object-contain shrink-0"
+            src={resolveLogoSrc(logo)}
+          />
+        )}
+        <div>
+          <div className="flex flex-row items-center gap-1">
+            <EditLabel
+              label={title}
+              onChange={onTitleChange}
+              size="text-xl"
+              placeholder="Add a title"
+            />
+            <span className="required h-6">*</span>
+          </div>
+          <EditLabel
+            label={desc}
+            onChange={onDescChange}
+            size="text-sm"
+            textArea={true}
+            placeholder="Add a description"
+            color="#6a7282"
+          />
+        </div>
+      </header>
+
+      {/* Theme 1 layout */}
+      <main className="p-4">
+        <div className="mb-4">
+          <StatusLegend iconMode={selectIcon} />
+        </div>
+
+        {statusGroups.length > 0 && (
+          <div className="space-y-4">
+            {statusGroups.map((col, index) => (
+              <BuildExpandableGroup
+                key={col.name}
+                name={col.name}
+                alias={col.alias || ''}
+                items={col.list}
+                iconMode={selectIcon}
+                textMode={selectText}
+                columns={columns}
+                group={groupName}
+                onRename={(nextName) => onRenameGroup(index, nextName)}
+                onRemove={() => onRemoveGroup(index)}
+                onItemsChange={(next) => onUpdateGroup(index, next)}
+                onChangeAlias={(itemName, newAlias) =>
+                  onChangeItemAlias(col.name, itemName, newAlias)
+                }
+              />
+            ))}
+          </div>
+        )}
+
+        {addGroupButton}
+      </main>
+    </div>
+  )
+}
 
 export default BuildPagePreview

--- a/src/pages/build-status-page/BuildStatus.tsx
+++ b/src/pages/build-status-page/BuildStatus.tsx
@@ -1,0 +1,163 @@
+import Button from '@/components/Button'
+import StatusLegend from '@/components/StatusLegend'
+import { isWithLogo, resolveLogoSrc } from '@/utils/logoUtils'
+import EditLabel from '@/pages/build-status-page/EditLabel'
+import StatusGroup from '@/pages/build-status-page/StatusGroup'
+import { getStatusClass } from '@/utils/status'
+import type { StatusGroupType, StatusItemType } from '@/types/common'
+import type { ThemeOption } from '@/types/pages'
+
+interface BuildStatusProps {
+  color: string
+  logo: string
+  title: string
+  desc: string
+  statusGroups: StatusGroupType[]
+  groupName: string
+  columns: string
+  selectIcon: string
+  selectText: string
+  report: string
+  themeOption: ThemeOption
+  groupsMutationIsPending: boolean
+  onTitleChange: (value: string) => void
+  onDescChange: (value: string) => void
+  onUpdateGroup: (index: number, items: StatusItemType[]) => void
+  onRenameGroup: (index: number, alias: string) => void
+  onRemoveGroup: (index: number) => void
+  onChangeItemAlias: (
+    groupName: string,
+    itemName: string,
+    newAlias: string,
+  ) => void
+  onAddStatusGroup: () => void
+}
+
+const BuildStatus = ({
+  color,
+  logo,
+  title,
+  desc,
+  statusGroups,
+  groupName,
+  columns,
+  selectIcon,
+  selectText,
+  report,
+  themeOption,
+  groupsMutationIsPending,
+  onTitleChange,
+  onDescChange,
+  onUpdateGroup,
+  onRenameGroup,
+  onRemoveGroup,
+  onChangeItemAlias,
+  onAddStatusGroup,
+}: BuildStatusProps) => {
+  const resolvedLogo =
+    logo && isWithLogo(themeOption) ? resolveLogoSrc(logo) : undefined
+
+  return (
+    <div className="bg-white rounded-xl shadow-lg overflow-hidden">
+      <header className="relative">
+        <div className="relative h-48">
+          <div
+            className="absolute inset-0"
+            style={{
+              backgroundImage: 'url(/background-image-public-status-pages.png)',
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              backgroundRepeat: 'no-repeat',
+            }}
+          />
+        </div>
+
+        {resolvedLogo && (
+          <div className="relative flex justify-center -mt-20">
+            <div className="bg-white rounded-full p-2 shadow-xl">
+              <img
+                alt="Logo"
+                className="h-32 w-32 object-contain"
+                src={resolvedLogo}
+                style={{
+                  borderRadius: '50%',
+                  backgroundSize: 'contain',
+                  backgroundPosition: 'center',
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        <div
+          className={`text-center pt-2 pb-3 px-24 ${resolvedLogo ? 'mt-1' : 'mt-0'}`}
+          style={{ backgroundColor: color }}
+        >
+          <div className="space-y-3">
+            <div className="flex flex-row items-center justify-center gap-1 mb-1">
+              <EditLabel
+                label={title}
+                onChange={onTitleChange}
+                size="text-xl"
+                placeholder="Add a title"
+              />
+              <span className="required h-8">*</span>
+            </div>
+            <div className="flex justify-center">
+              <EditLabel
+                label={desc}
+                onChange={onDescChange}
+                size="text-base"
+                textArea={true}
+                placeholder="Add a description"
+                color="#6a7282"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="px-16 my-1 flex justify-center">
+          <StatusLegend iconMode={selectIcon} />
+        </div>
+      </header>
+
+      <main className="px-4">
+        {statusGroups.map((col, index) => (
+          <StatusGroup
+            key={col.name}
+            name={col.name}
+            alias={col.alias || ''}
+            items={col.list}
+            columns={columns}
+            iconMode={selectIcon}
+            textMode={selectText}
+            group={groupName}
+            getStatusClass={getStatusClass}
+            onRename={(nextName) => onRenameGroup(index, nextName)}
+            onRemove={() => onRemoveGroup(index)}
+            onItemsChange={(next) => onUpdateGroup(index, next)}
+            onChangeAlias={onChangeItemAlias}
+          />
+        ))}
+        <div className="text-center mt-4 mb-4">
+          <div
+            className={!report ? 'tooltip' : ''}
+            data-tip={
+              !report ? 'Please select a report first to add groups' : ''
+            }
+          >
+            <Button
+              disabled={!report || groupsMutationIsPending}
+              onClick={onAddStatusGroup}
+              variant="outline-secondary"
+            >
+              Click here to Add a new Group
+            </Button>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export default BuildStatus

--- a/src/pages/build-status-page/BuildStatusPage.tsx
+++ b/src/pages/build-status-page/BuildStatusPage.tsx
@@ -26,6 +26,7 @@ import BuildThemingTab from './BuildThemingTab'
 import BuildPagePreview from './BuildPagePreview'
 import { useBuildStatusPage } from './useBuildStatusPage'
 import type { StatusItemType, StatusGroupType } from '@/types/common'
+import type { ThemeOption } from '@/types/pages'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 const DND_GROUP = 'status-board'
@@ -50,9 +51,8 @@ const BuildStatusPage = () => {
   const [desc, setDesc] = useState('')
   const [selectIcon, setSelectIcon] = useState('led')
   const [selectText, setSelectText] = useState('none')
-  const [themeOption, setThemeOption] = useState<'theme_1' | 'theme_2'>(
-    'theme_1',
-  )
+  const [themeOption, setThemeOption] =
+    useState<ThemeOption>('theme_1_with_logo')
   const [color, setColor] = useState('#FFFFFF')
   const [logo, setLogo] = useState('')
   const [logoUrl, setLogoUrl] = useState('')
@@ -62,8 +62,6 @@ const BuildStatusPage = () => {
   const [saved, setSaved] = useState(false)
   // remembers each item's last position in the LEFT list
   const leftIndexRef = useRef<Map<string, number>>(new Map())
-  // Track next group ID to avoid duplicate names when groups are deleted
-  const nextGroupIdRef = useRef(1)
 
   const { tenants: tenantsData } = useSelectedTenant()
   const { data: reportsData, isLoading: reportsLoading } = useGetTenantReports(
@@ -109,7 +107,6 @@ const BuildStatusPage = () => {
     saveMutate: savePageMutation.mutate,
     updateMutate: updatePageMutation.mutate,
     groupsMutate: groupsMutation.mutate,
-    nextGroupIdRef,
     leftIndexRef,
   })
 
@@ -133,7 +130,7 @@ const BuildStatusPage = () => {
       if (!tenantId) setTenantId(pageData.tenant_id)
       setSelectIcon(pageData.config?.theming?.status.icon || 'led')
       setSelectText(pageData.config?.theming?.status.text || 'none')
-      setThemeOption(pageData.config?.theming?.option || 'theme_1')
+      setThemeOption(pageData.config?.theming?.option || 'theme_1_with_logo')
       setColor(pageData.config?.theming?.color || '')
       setLogo(pageData.config?.theming?.logo || '')
       if (pageData.config?.theming?.logo) {
@@ -231,19 +228,6 @@ const BuildStatusPage = () => {
       columns,
     })
 
-  if (isEditMode && pageLoading) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <LoadingSpinner size="md" />
-        <span className="ml-2">Loading page data...</span>
-      </div>
-    )
-  }
-
-  if (isEditMode && pageError) {
-    return <ErrorDisplay error={pageError} context="page" />
-  }
-
   return (
     <div>
       <div className="flex flex-col justify-center items-center px-6 md:px-0">
@@ -258,157 +242,165 @@ const BuildStatusPage = () => {
             className="pb-1 mb-3"
           />
 
-          <div className="flex flex-col md:flex-row justify-between md:items-center gap-3 md:gap-6 mb-1 md:mb-4">
-            <Tabs
-              tabs={[
-                {
-                  id: 'config',
-                  label: 'Config',
-                  icon: Cog6ToothIcon,
-                  hasError: !name.trim() || !slug.trim() || !tenantId,
-                },
-                {
-                  id: 'items',
-                  label: 'Items',
-                  icon: CubeIcon,
-                  hasError:
-                    statusGroups.length === 0 ||
-                    statusGroups.some((g) => g.list.length === 0),
-                },
-                { id: 'theming', label: 'Theming', icon: PaintBrushIcon },
-              ]}
-              activeTab={activeTab}
-              onChange={(id) =>
-                setActiveTab(id as 'config' | 'items' | 'theming')
-              }
-              className="flex-1 w-full"
-            />
-            <div className="flex justify-end gap-4 w-full md:w-auto 2xl:mr-25">
-              {saved && (
-                <Button
-                  variant="outline-primary"
-                  size="md"
-                  onClick={() =>
-                    window.open(
-                      `${window.location.origin}/status/${slug}`,
-                      '_blank',
-                    )
-                  }
-                >
-                  View Page
-                  <ArrowTopRightOnSquareIcon className="size-4 shrink-0" />
-                </Button>
-              )}
-              <Button
-                variant="primary"
-                size="md"
-                onClick={onSave}
-                disabled={isSaving}
-              >
-                {isSaving ? 'Saving...' : isEditMode ? 'Update' : 'Save'}
-              </Button>
+          {isEditMode && pageLoading ? (
+            <div className="loading-container">
+              <LoadingSpinner size="md" />
             </div>
-          </div>
-
-          <div className="flex items-center gap-[3px] mb-3">
-            <span className="inline-block size-[6px] rounded-full bg-red-500 shrink-0" />
-            <span className="text-sm text-muted font-medium">:</span>
-            <span className="text-sm text-subtle">
-              Indicates required fields are missing or invalid
-            </span>
-          </div>
-
-          <div
-            className={
-              activeTab === 'config'
-                ? ''
-                : 'flex flex-col xl:grid xl:grid-cols-[2fr_3fr] gap-8'
-            }
-          >
-            <div
-              className={activeTab === 'config' ? 'max-w-4xl w-full' : 'w-full'}
-            >
-              <div className={activeTab === 'config' ? 'block pt-1' : 'hidden'}>
-                <BuildConfigTab
-                  name={name}
-                  slug={slug}
-                  tenantId={tenantId}
-                  isEditMode={isEditMode}
-                  isTenantSelectionDisabled={isTenantSelectionDisabled}
-                  tenantsData={tenantsData}
-                  reportsData={reportsData}
-                  onNameChange={handleNameChange}
-                  onSlugChange={handleSlugChange}
-                  onTenantChange={handleTenantChange}
+          ) : isEditMode && pageError ? (
+            <ErrorDisplay error={pageError} context="page" />
+          ) : (
+            <>
+              <div className="flex flex-col md:flex-row justify-between md:items-center gap-3 md:gap-6 mb-1 md:mb-4">
+                <Tabs
+                  tabs={[
+                    {
+                      id: 'config',
+                      label: 'Config',
+                      icon: Cog6ToothIcon,
+                      hasError: !name.trim() || !slug.trim() || !tenantId,
+                    },
+                    {
+                      id: 'items',
+                      label: 'Items',
+                      icon: CubeIcon,
+                      hasError:
+                        statusGroups.length === 0 ||
+                        statusGroups.some((g) => g.list.length === 0),
+                    },
+                    { id: 'theming', label: 'Theming', icon: PaintBrushIcon },
+                  ]}
+                  activeTab={activeTab}
+                  onChange={(id) =>
+                    setActiveTab(id as 'config' | 'items' | 'theming')
+                  }
+                  className="flex-1 w-full"
                 />
+                <div className="flex justify-end gap-4 w-full md:w-auto 2xl:mr-25">
+                  {saved && (
+                    <Button
+                      variant="outline-primary"
+                      size="md"
+                      onClick={() =>
+                        window.open(
+                          `${window.location.origin}/status/${slug}`,
+                          '_blank',
+                        )
+                      }
+                    >
+                      View Page
+                      <ArrowTopRightOnSquareIcon className="size-4 shrink-0" />
+                    </Button>
+                  )}
+                  <Button
+                    variant="primary"
+                    size="md"
+                    onClick={onSave}
+                    disabled={isSaving}
+                  >
+                    {isSaving ? 'Saving...' : isEditMode ? 'Update' : 'Save'}
+                  </Button>
+                </div>
               </div>
 
-              <div className={activeTab === 'items' ? 'block pt-1' : 'hidden'}>
-                <BuildItemsTab
-                  tenantId={tenantId}
-                  report={report}
-                  reportsData={reportsData}
-                  reportsLoading={reportsLoading}
-                  groupsMutationIsPending={groupsMutationIsPending}
-                  groupsMutationData={groupsMutationData}
-                  parent={parent}
-                  items={items}
-                  statusGroups={statusGroups}
-                  selectIcon={selectIcon}
-                  selectText={selectText}
-                  onReportChange={(value) => setReport(value)}
-                />
+              <div className="flex items-center gap-[3px] mb-3">
+                <span className="inline-block size-[6px] rounded-full bg-red-500 shrink-0" />
+                <span className="text-sm text-muted font-medium">:</span>
+                <span className="text-sm text-subtle">
+                  Indicates required fields are missing or invalid
+                </span>
               </div>
 
               <div
-                className={activeTab === 'theming' ? 'block pt-1' : 'hidden'}
+                className={
+                  activeTab === 'config'
+                    ? ''
+                    : 'flex flex-col xl:grid xl:grid-cols-[2fr_3fr] gap-8'
+                }
               >
-                <BuildThemingTab
-                  color={color}
-                  logoUrl={logoUrl}
-                  logoPreview={logoPreview}
-                  selectIcon={selectIcon}
-                  selectText={selectText}
-                  columns={columns}
-                  themeOption={themeOption}
-                  onColorChange={(v) => setColor(v)}
-                  onLogoUrlChange={handleLogoUrlChange}
-                  onRemoveLogo={handleRemoveLogo}
-                  onLogoFileChange={handleLogoFileChange}
-                  onIconChange={(v) => setSelectIcon(v)}
-                  onTextChange={(v) => setSelectText(v)}
-                  onColumnsChange={(v) => setColumns(v)}
-                  onThemeOptionChange={(v) =>
-                    setThemeOption(v as 'theme_1' | 'theme_2')
+                <div
+                  className={
+                    activeTab === 'config' ? 'max-w-4xl w-full' : 'w-full'
                   }
-                />
-              </div>
-            </div>
+                >
+                  <div className={activeTab === 'config' ? 'block' : 'hidden'}>
+                    <BuildConfigTab
+                      name={name}
+                      slug={slug}
+                      tenantId={tenantId}
+                      isEditMode={isEditMode}
+                      isTenantSelectionDisabled={isTenantSelectionDisabled}
+                      tenantsData={tenantsData}
+                      reportsData={reportsData}
+                      onNameChange={handleNameChange}
+                      onSlugChange={handleSlugChange}
+                      onTenantChange={handleTenantChange}
+                    />
+                  </div>
 
-            {activeTab !== 'config' && (
-              <BuildPagePreview
-                color={color}
-                logo={logo}
-                title={title}
-                desc={desc}
-                statusGroups={statusGroups}
-                groupName={DND_GROUP}
-                columns={columns}
-                selectIcon={selectIcon}
-                selectText={selectText}
-                report={report}
-                themeOption={themeOption}
-                groupsMutationIsPending={groupsMutationIsPending}
-                onTitleChange={setTitle}
-                onDescChange={setDesc}
-                onUpdateGroup={updateGroup}
-                onRenameGroup={renameGroup}
-                onRemoveGroup={removeGroup}
-                onChangeItemAlias={handleChangeItemAlias}
-                onAddStatusGroup={handleAddStatusGroup}
-              />
-            )}
-          </div>
+                  <div className={activeTab === 'items' ? 'block' : 'hidden'}>
+                    <BuildItemsTab
+                      tenantId={tenantId}
+                      report={report}
+                      reportsData={reportsData}
+                      reportsLoading={reportsLoading}
+                      groupsMutationIsPending={groupsMutationIsPending}
+                      groupsMutationData={groupsMutationData}
+                      parent={parent}
+                      items={items}
+                      statusGroups={statusGroups}
+                      selectIcon={selectIcon}
+                      selectText={selectText}
+                      onReportChange={(value) => setReport(value)}
+                    />
+                  </div>
+
+                  <div className={activeTab === 'theming' ? 'block' : 'hidden'}>
+                    <BuildThemingTab
+                      color={color}
+                      logoUrl={logoUrl}
+                      logoPreview={logoPreview}
+                      selectIcon={selectIcon}
+                      selectText={selectText}
+                      columns={columns}
+                      themeOption={themeOption}
+                      onColorChange={(v) => setColor(v)}
+                      onLogoUrlChange={handleLogoUrlChange}
+                      onRemoveLogo={handleRemoveLogo}
+                      onLogoFileChange={handleLogoFileChange}
+                      onIconChange={(v) => setSelectIcon(v)}
+                      onTextChange={(v) => setSelectText(v)}
+                      onColumnsChange={(v) => setColumns(v)}
+                      onThemeOptionChange={(v) => setThemeOption(v)}
+                    />
+                  </div>
+                </div>
+
+                {activeTab !== 'config' && (
+                  <BuildPagePreview
+                    color={color}
+                    logo={logo}
+                    title={title}
+                    desc={desc}
+                    statusGroups={statusGroups}
+                    groupName={DND_GROUP}
+                    columns={columns}
+                    selectIcon={selectIcon}
+                    selectText={selectText}
+                    report={report}
+                    themeOption={themeOption}
+                    groupsMutationIsPending={groupsMutationIsPending}
+                    onTitleChange={setTitle}
+                    onDescChange={setDesc}
+                    onUpdateGroup={updateGroup}
+                    onRenameGroup={renameGroup}
+                    onRemoveGroup={removeGroup}
+                    onChangeItemAlias={handleChangeItemAlias}
+                    onAddStatusGroup={handleAddStatusGroup}
+                  />
+                )}
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/build-status-page/BuildThemingTab.tsx
+++ b/src/pages/build-status-page/BuildThemingTab.tsx
@@ -3,12 +3,12 @@ import {
   XMarkIcon,
   PhotoIcon,
   CheckCircleIcon,
-  QuestionMarkCircleIcon,
 } from '@heroicons/react/16/solid'
 import { BanIcon, Columns2Icon, SquareIcon } from 'lucide-react'
 import { useDropzone } from 'react-dropzone'
 import { toast } from 'sonner'
 import SelectGroup from './SelectGroup'
+import type { ThemeOption } from '@/types/pages'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
 
@@ -21,7 +21,7 @@ interface BuildThemingTabProps {
   selectIcon: string
   selectText: string
   columns: string
-  themeOption: 'theme_1' | 'theme_2'
+  themeOption: ThemeOption
   onColorChange: (value: string) => void
   onLogoUrlChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onRemoveLogo: (e: React.MouseEvent) => void
@@ -29,7 +29,7 @@ interface BuildThemingTabProps {
   onIconChange: (value: string) => void
   onTextChange: (value: string) => void
   onColumnsChange: (value: string) => void
-  onThemeOptionChange: (value: 'theme_1' | 'theme_2') => void
+  onThemeOptionChange: (value: ThemeOption) => void
 }
 
 const BuildThemingTab = ({
@@ -112,33 +112,32 @@ const BuildThemingTab = ({
             </div>
 
             <div>
-              <label className="flex items-center gap-1 text-sm font-medium text-body mb-1">
-                Theme:
-                <div
-                  className="tooltip tooltip-right"
-                  data-tip="Select whether the public status page will feature a logo at the top."
-                >
-                  <QuestionMarkCircleIcon className="w-4.5 h-4.5 text-muted cursor-help" />
-                </div>
-              </label>
+              <label className={labelClass}>Theme:</label>
               <SelectGroup
                 selected={themeOption}
-                onChange={(val) =>
-                  onThemeOptionChange(val as 'theme_1' | 'theme_2')
-                }
+                className="grid grid-cols-2 gap-2"
+                onChange={(val) => onThemeOptionChange(val as ThemeOption)}
               >
-                <SelectGroup.Item value="theme_1">
-                  <PhotoIcon className="w-4" />
-                  <div>With Logo</div>
+                <SelectGroup.Item value="theme_1_with_logo">
+                  <PhotoIcon className="w-4 shrink-0" />
+                  <div>Theme 1 with Logo</div>
                 </SelectGroup.Item>
-                <SelectGroup.Item value="theme_2">
-                  <BanIcon className="w-4" />
-                  <div>No Logo</div>
+                <SelectGroup.Item value="theme_1_no_logo">
+                  <BanIcon className="w-4 shrink-0" />
+                  <div>Theme 1 with no Logo</div>
+                </SelectGroup.Item>
+                <SelectGroup.Item value="theme_2_with_logo">
+                  <PhotoIcon className="w-4 shrink-0" />
+                  <div>Theme 2 with Logo</div>
+                </SelectGroup.Item>
+                <SelectGroup.Item value="theme_2_no_logo">
+                  <BanIcon className="w-4 shrink-0" />
+                  <div>Theme 2 with no Logo</div>
                 </SelectGroup.Item>
               </SelectGroup>
             </div>
 
-            {themeOption === 'theme_1' && (
+            {themeOption.includes('with_logo') && (
               <div>
                 <label className={labelClass}>Logo:</label>
                 <div
@@ -165,7 +164,7 @@ const BuildThemingTab = ({
                       </button>
                       <img
                         alt="Logo"
-                        className="w-24 w-h-24 object-contain rounded"
+                        className="h-24 w-24 object-contain rounded"
                         src={
                           logoPreview?.startsWith('http') ||
                           logoPreview?.startsWith('data:')

--- a/src/pages/build-status-page/SelectGroup.tsx
+++ b/src/pages/build-status-page/SelectGroup.tsx
@@ -13,6 +13,7 @@ interface SelectGroupProps {
   children: ReactElement<SelectItemProps> | ReactElement<SelectItemProps>[]
   selected?: string
   onChange?: (value: string) => void
+  className?: string
 }
 
 interface SelectItemData {
@@ -20,7 +21,12 @@ interface SelectItemData {
   children: ReactNode
 }
 
-const SelectGroup = ({ children, selected, onChange }: SelectGroupProps) => {
+const SelectGroup = ({
+  children,
+  selected,
+  onChange,
+  className,
+}: SelectGroupProps) => {
   const items =
     Children.map(children, (child: ReactElement<SelectItemProps>) => {
       if (child?.type === SelectItem) {
@@ -39,7 +45,7 @@ const SelectGroup = ({ children, selected, onChange }: SelectGroupProps) => {
   }
 
   return (
-    <div className="flex flex-row gap-2 flex-wrap">
+    <div className={className ?? 'flex flex-row gap-2 flex-wrap'}>
       {items.map((item: SelectItemData) => {
         const isSelected = selected === item.value
 
@@ -47,7 +53,7 @@ const SelectGroup = ({ children, selected, onChange }: SelectGroupProps) => {
           <button
             key={item.value}
             onClick={() => handleClick(item.value)}
-            className={`btn h-9 px-3 text-sm ${
+            className={`btn !h-auto !py-1.5 px-3 text-sm ${
               isSelected
                 ? 'bg-brand-subtle border-brand text-brand hover:bg-brand-muted hover:border-brand font-medium'
                 : 'bg-surface-muted border-line text-body hover:bg-surface-strong hover:border-line-strong font-normal'

--- a/src/pages/build-status-page/StatusGroup.tsx
+++ b/src/pages/build-status-page/StatusGroup.tsx
@@ -51,8 +51,8 @@ export default function StatusGroup(props: StatusGroupProps) {
   }, [orderedItems, onItemsChange])
 
   return (
-    <div className="mb-5">
-      <div className="flex flex-row justify-center items-center px-0 py-2 relative">
+    <div className="mb-3">
+      <div className="flex flex-row justify-center items-center pr-12 py-2 relative">
         <StatusLabel
           group={props.name}
           label={props.name}
@@ -63,7 +63,7 @@ export default function StatusGroup(props: StatusGroupProps) {
         />
         {!props.readOnly && (
           <Button
-            className="p-0 absolute right-0 tooltip"
+            className="p-0 absolute right-0 tooltip tooltip-left"
             size="sm"
             variant="outline-secondary"
             onClick={props.onRemove}

--- a/src/pages/build-status-page/StatusLabel.tsx
+++ b/src/pages/build-status-page/StatusLabel.tsx
@@ -42,7 +42,7 @@ const StatusLabel = (props: StatusLabelProps) => {
   }
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex items-center gap-3 min-w-0">
       {editMode && !props.readOnly ? (
         <>
           <input
@@ -64,24 +64,14 @@ const StatusLabel = (props: StatusLabelProps) => {
                 data-tip={props.readOnly ? '' : 'edit'}
               >
                 <span
-                  className={`${props.isGroupLabel ? 'font-bold text-xl' : 'font-medium text-sm'} ${props.readOnly ? 'text-body' : 'text-muted'} ${!props.readOnly ? 'cursor-pointer border-b border-transparent hover:border-black hover:border-dashed' : ''} tracking-wide break-words`}
-                  style={{
-                    wordBreak: 'break-word',
-                    overflowWrap: 'break-word',
-                  }}
+                  className={`${props.isGroupLabel ? 'font-bold text-lg' : 'font-medium text-sm'} ${props.readOnly ? 'text-body' : 'text-muted'} ${!props.readOnly ? 'cursor-pointer border-b border-transparent hover:border-black hover:border-dashed' : ''} tracking-wide break-all max-w-full line-clamp-2`}
                   onClick={props.readOnly ? undefined : handleEdit}
                 >
                   {props.alias ? props.alias : props.label}
                 </span>
               </div>
             ) : (
-              <span
-                className="font-medium text-muted border-b border-transparent text-sm tracking-wide break-words"
-                style={{
-                  wordBreak: 'break-word',
-                  overflowWrap: 'break-word',
-                }}
-              >
+              <span className="font-medium text-muted border-b border-transparent text-sm tracking-wide break-all line-clamp-2">
                 {props.label}
               </span>
             )}

--- a/src/pages/build-status-page/useBuildStatusPage.tsx
+++ b/src/pages/build-status-page/useBuildStatusPage.tsx
@@ -7,8 +7,16 @@ import type {
 } from '@/hooks/usePages'
 import type { useGroupsMutation } from '@/hooks/useGroups'
 import type { StatusItemType, StatusGroupType } from '@/types/common'
+import type { ThemeOption } from '@/types/pages'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+const getNextGroupNumber = (groups: StatusGroupType[]): number => {
+  const usedNames = new Set(groups.map((g) => g.name))
+  let n = groups.length + 1
+  while (usedNames.has(`group-${n}`)) n++
+  return n
+}
 
 export type PageFormValues = {
   name: string
@@ -19,7 +27,7 @@ export type PageFormValues = {
   desc: string
   selectIcon: string
   selectText: string
-  themeOption: 'theme_1' | 'theme_2'
+  themeOption: ThemeOption
   color: string
   logo: string
   columns: string
@@ -49,7 +57,6 @@ interface UseBuildStatusPageParams {
   saveMutate: ReturnType<typeof useSavePageMutation>['mutate']
   updateMutate: ReturnType<typeof useUpdatePageMutation>['mutate']
   groupsMutate: ReturnType<typeof useGroupsMutation>['mutate']
-  nextGroupIdRef: RefObject<number>
   leftIndexRef: RefObject<Map<string, number>>
 }
 
@@ -63,7 +70,6 @@ export const useBuildStatusPage = ({
   saveMutate,
   updateMutate,
   groupsMutate,
-  nextGroupIdRef,
   leftIndexRef,
 }: UseBuildStatusPageParams) => {
   const navigate = useNavigate()
@@ -71,18 +77,6 @@ export const useBuildStatusPage = ({
   const initGroups = (groups: StatusGroupType[]) => {
     setStatusGroups(groups)
     setSaved(true)
-
-    if (groups.length > 0) {
-      const maxId = groups.reduce((max, group) => {
-        const match = group.name.match(/^group-(\d+)$/)
-        if (match) {
-          const id = parseInt(match[1], 10)
-          return id > max ? id : max
-        }
-        return max
-      }, 0)
-      nextGroupIdRef.current = maxId + 1
-    }
   }
 
   const triggerGroupsMutation = (tenantId: string, reportId: string) => {
@@ -90,16 +84,17 @@ export const useBuildStatusPage = ({
   }
 
   const handleAddStatusGroup = () => {
-    const newGroupId = nextGroupIdRef.current
-    setStatusGroups((prev) => [
-      ...prev,
-      {
-        name: `group-${newGroupId}`,
-        alias: `group-${newGroupId}`,
-        list: [],
-      },
-    ])
-    nextGroupIdRef.current = newGroupId + 1
+    setStatusGroups((prev) => {
+      const n = getNextGroupNumber(prev)
+      return [
+        ...prev,
+        {
+          name: `group-${n}`,
+          alias: `group-${n}`,
+          list: [],
+        },
+      ]
+    })
   }
 
   const handleChangeItemAlias = (
@@ -202,7 +197,7 @@ export const useBuildStatusPage = ({
         theming: {
           option: themeOption,
           status: { icon: selectIcon, text: selectText },
-          ...(themeOption !== 'theme_2' &&
+          ...(themeOption.includes('with_logo') &&
             logo && {
               logo:
                 logo.startsWith('http') || logo.startsWith('data:')

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -52,8 +52,14 @@ export type PageThemingStatus = {
   text: string
 }
 
+export type ThemeOption =
+  | 'theme_1_with_logo'
+  | 'theme_1_no_logo'
+  | 'theme_2_with_logo'
+  | 'theme_2_no_logo'
+
 export type PageTheming = {
-  option?: 'theme_1' | 'theme_2'
+  option?: ThemeOption
   status: PageThemingStatus
   color?: string
   logo?: string

--- a/src/utils/logoUtils.ts
+++ b/src/utils/logoUtils.ts
@@ -1,0 +1,10 @@
+import type { ThemeOption } from '@/types/pages'
+
+const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+export const isWithLogo = (option: ThemeOption) => option.includes('with_logo')
+
+export const resolveLogoSrc = (logo: string) =>
+  logo.startsWith('http') || logo.startsWith('data:')
+    ? logo
+    : `${BACKEND_API}${logo}`

--- a/src/utils/themeOptions.ts
+++ b/src/utils/themeOptions.ts
@@ -1,0 +1,10 @@
+import type { ThemeOption } from '@/types/pages'
+
+const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+export const isWithLogo = (option: ThemeOption) => option.includes('with_logo')
+
+export const resolveLogoSrc = (logo: string) =>
+  logo.startsWith('http') || logo.startsWith('data:')
+    ? logo
+    : `${BACKEND_API}${logo}`


### PR DESCRIPTION
This PR adds theme selection to the status page builder and updates the preview panel to show the selected layout in real time.

- Updated the theming tab to display theme choices in a grid and conditionally show the logo section
- Added components for each theme's builder preview layout
- Added a public status page that dispatches between layouts based on the saved theme
- Refactored the expandable status component into a presentational component