### PR TITLE
WIP - [ARGO-5575] - Add scope selection for endpoint assignments

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -85,6 +85,15 @@
   textarea::placeholder {
     color: var(--color-subtle);
   }
+
+  input[type='radio'] {
+    appearance: auto !important;
+    border: none !important;
+    background: transparent !important;
+    padding: 0 !important;
+    box-shadow: none !important;
+    cursor: pointer;
+  }
 }
 
 /* Reusable UI classes used across the codebase. */

--- a/src/pages/endpoints-access/CategoryPanel.tsx
+++ b/src/pages/endpoints-access/CategoryPanel.tsx
@@ -1,18 +1,18 @@
-import {
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-} from '@heroicons/react/16/solid'
+import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/16/solid'
 import EndpointListItem from './EndpointListItem'
-import type { SecuredEndpoint } from '@/types/securedEndpoints'
+import type {
+  SecuredEndpoint,
+  EndpointAssignment,
+} from '@/types/securedEndpoints'
 
 export interface CategoryPanelProps {
   label: string
   endpoints: SecuredEndpoint[]
   isCollapsed: boolean
   onToggleCollapse: () => void
-  selectedActionIds: Set<string>
-  onToggleAction: (id: string, selectAll?: boolean, allIds?: string[]) => void
+  selectedAssignments: Map<string, EndpointAssignment>
+  onToggleAction: (id: string) => void
+  onSetScope: (endpointId: string, scope: string) => void
 }
 
 const CategoryPanel = ({
@@ -20,22 +20,15 @@ const CategoryPanel = ({
   endpoints,
   isCollapsed,
   onToggleCollapse,
-  selectedActionIds,
+  selectedAssignments,
   onToggleAction,
+  onSetScope,
 }: CategoryPanelProps) => {
   if (endpoints.length === 0) return null
 
-  const endpointIds = endpoints.map((ep) => ep.secured_endpoint_id)
-  const selectedCount = endpointIds.filter((id) =>
-    selectedActionIds.has(id),
+  const selectedCount = endpoints.filter((ep) =>
+    selectedAssignments.has(ep.secured_endpoint_id),
   ).length
-  const isAllChecked =
-    endpointIds.length > 0 && selectedCount === endpointIds.length
-  const isIndeterminate = selectedCount > 0 && !isAllChecked
-
-  const handleCategoryCheckboxChange = () => {
-    onToggleAction('', !isAllChecked, endpointIds)
-  }
 
   return (
     <div className="border border-line rounded-lg overflow-hidden bg-white shadow-sm ring-1 ring-black/5">
@@ -46,32 +39,9 @@ const CategoryPanel = ({
         aria-expanded={!isCollapsed}
       >
         <div className="flex items-center gap-3 shrink-0">
-          <label
-            className="cursor-pointer group p-1 -m-1"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div
-              className={`relative size-4 shrink-0 rounded border flex items-center justify-center transition-colors ${
-                isAllChecked || isIndeterminate
-                  ? 'bg-brand border-brand'
-                  : 'border-line-strong bg-white group-hover:border-brand-muted'
-              }`}
-            >
-              <input
-                type="checkbox"
-                className="sr-only"
-                checked={isAllChecked || isIndeterminate}
-                onChange={handleCategoryCheckboxChange}
-              />
-              {isAllChecked && <CheckIcon className="size-3 text-white" />}
-              {isIndeterminate && !isAllChecked && (
-                <div className="w-2.5 h-0.5 bg-white rounded-full" />
-              )}
-            </div>
-          </label>
           <span className="font-bold text-sm text-foreground">{label}</span>
           <span className="text-xs text-muted font-normal">
-            ({selectedCount}/{endpointIds.length})
+            ({selectedCount}/{endpoints.length})
           </span>
         </div>
 
@@ -90,8 +60,11 @@ const CategoryPanel = ({
             <EndpointListItem
               key={endpoint.secured_endpoint_id}
               endpoint={endpoint}
-              isChecked={selectedActionIds.has(endpoint.secured_endpoint_id)}
+              assignment={selectedAssignments.get(endpoint.secured_endpoint_id)}
               onToggle={() => onToggleAction(endpoint.secured_endpoint_id)}
+              onSetScope={(scope: string) =>
+                onSetScope(endpoint.secured_endpoint_id, scope)
+              }
             />
           ))}
         </div>

--- a/src/pages/endpoints-access/EndpointListItem.tsx
+++ b/src/pages/endpoints-access/EndpointListItem.tsx
@@ -1,67 +1,121 @@
 import { CheckIcon } from '@heroicons/react/16/solid'
-import type { SecuredEndpoint } from '@/types/securedEndpoints'
+import type {
+  SecuredEndpoint,
+  EndpointAssignment,
+} from '@/types/securedEndpoints'
 import { getFriendlyLabel } from './utils/friendlyLabels'
+
+const getScopeLabel = (scope: string): string => {
+  if (scope === 'MINE') return 'Own Only'
+  return scope.charAt(0).toUpperCase() + scope.slice(1).toLowerCase()
+}
 
 interface EndpointListItemProps {
   endpoint: SecuredEndpoint
-  isChecked: boolean
+  assignment: EndpointAssignment | undefined
   onToggle: () => void
+  onSetScope: (scope: string) => void
 }
 
 const EndpointListItem = ({
   endpoint,
-  isChecked,
+  assignment,
   onToggle,
+  onSetScope,
 }: EndpointListItemProps) => {
+  const isChecked = assignment !== undefined
   const friendlyLabel = getFriendlyLabel(endpoint.action, endpoint.path)
   const method = endpoint.action.toUpperCase()
+  const hasScopes = endpoint.scopes && endpoint.scopes.length > 0
 
   return (
-    <label
-      className={`w-full flex items-center justify-between gap-8 px-4 py-2 text-left cursor-pointer transition-colors border-t border-line ${
+    <div
+      className={`border-t border-line transition-colors ${
         isChecked ? 'bg-brand-subtle' : 'hover:bg-surface-muted'
       }`}
     >
-      <div className="flex items-center gap-3 w-5/12 min-w-0">
-        <div
-          className={`relative size-4 shrink-0 rounded border flex items-center justify-center transition-colors mt-0.5 self-start ${
-            isChecked ? 'bg-brand border-brand' : 'border-line-strong bg-white'
-          }`}
-        >
-          <input
-            type="checkbox"
-            className="sr-only"
-            checked={isChecked}
-            onChange={onToggle}
-          />
-          {isChecked && <CheckIcon className="size-3 text-white" />}
-        </div>
-        <div className="flex flex-col min-w-0 flex-1">
-          <span
-            className={`text-sm font-medium break-words ${isChecked ? 'text-foreground' : 'text-foreground/90'}`}
+      <label className="w-full flex items-center justify-between gap-8 px-4 py-2 text-left cursor-pointer">
+        <div className="flex items-center gap-3 w-5/12 min-w-0">
+          <div
+            className={`relative size-4 shrink-0 rounded border flex items-center justify-center transition-colors mt-0.5 self-start ${
+              isChecked
+                ? 'bg-brand border-brand'
+                : 'border-line-strong bg-white'
+            }`}
           >
-            {friendlyLabel}
-          </span>
-          <div className="flex gap-1.5 mt-0.5">
-            <span className="text-xs text-subtle font-mono shrink-0">
-              {method}
+            <input
+              type="checkbox"
+              className="sr-only"
+              checked={isChecked}
+              onChange={() => {
+                onToggle()
+                if (!isChecked && endpoint.scopes?.[0])
+                  onSetScope(endpoint.scopes[0])
+              }}
+            />
+            {isChecked && <CheckIcon className="size-3 text-white" />}
+          </div>
+          <div className="flex flex-col min-w-0 flex-1">
+            <span
+              className={`text-sm font-medium break-words ${isChecked ? 'text-foreground' : 'text-foreground/90'}`}
+            >
+              {friendlyLabel}
             </span>
-            <span className="text-xs text-subtle font-mono break-all">
-              {endpoint.path}
-            </span>
+            <div className="flex gap-1.5 mt-0.5">
+              <span className="text-xs text-subtle font-mono shrink-0">
+                {method}
+              </span>
+              <span className="text-xs text-subtle font-mono break-all">
+                {endpoint.path}
+              </span>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div className="flex flex-col min-w-0 flex-1 text-left">
-        <span
-          className="text-sm text-subtle line-clamp-3"
-          title={endpoint.description}
+        <div className="flex flex-col min-w-0 flex-1 text-left">
+          <span
+            className="text-sm text-subtle line-clamp-3"
+            title={endpoint.description}
+          >
+            {endpoint.description}
+          </span>
+        </div>
+      </label>
+
+      {hasScopes && (
+        <div
+          className={`flex items-center gap-3 pl-11 pr-4 pb-2 ${
+            !isChecked ? 'pointer-events-none opacity-40' : ''
+          }`}
         >
-          {endpoint.description}
-        </span>
-      </div>
-    </label>
+          <span className="text-xs font-medium text-muted shrink-0">
+            Scope:
+          </span>
+          <div className="flex items-center gap-4">
+            {endpoint.scopes!.map((scope) => (
+              <label
+                key={scope}
+                className={`inline-flex items-center gap-1.5 ${isChecked ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+              >
+                <input
+                  type="radio"
+                  name={`scope-${endpoint.secured_endpoint_id}`}
+                  value={scope}
+                  checked={assignment?.scope === scope}
+                  onChange={() => onSetScope(scope)}
+                  className="accent-brand"
+                />
+                <span
+                  className={`text-xs select-none ${isChecked ? 'text-body' : 'text-subtle'}`}
+                >
+                  {getScopeLabel(scope)}
+                </span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/src/pages/endpoints-access/EndpointsAccess.tsx
+++ b/src/pages/endpoints-access/EndpointsAccess.tsx
@@ -20,13 +20,17 @@ const EndpointsAccess = () => {
 
   useEffect(() => {
     const main = document.querySelector('main')
-    if (main) {
-      main.style.overflowY = 'scroll'
+    if (!main) return
+
+    const apply = () => {
+      main.style.overflowY = window.innerWidth >= 1024 ? 'scroll' : ''
     }
+
+    apply()
+    window.addEventListener('resize', apply)
     return () => {
-      if (main) {
-        main.style.overflowY = ''
-      }
+      window.removeEventListener('resize', apply)
+      main.style.overflowY = ''
     }
   }, [])
 
@@ -64,28 +68,34 @@ const EndpointsAccess = () => {
   const { mutate: saveRoleActions, isPending: isMutating } =
     useAssignEndpointsToRoleMutation()
 
-  const roleActionIds = useMemo(
-    () => roleAssignmentsData?.assignments?.[0]?.secured_endpoint_ids ?? [],
+  const roleAssignments = useMemo(
+    () => roleAssignmentsData?.assignments?.[0]?.secured_endpoints ?? [],
     [roleAssignmentsData],
   )
 
-  const { selectedActionIds, toggleAction, isDirty, addedCount, removedCount } =
-    useRoleActionsManager(selectedRoleId, roleActionIds)
+  const {
+    selectedAssignments,
+    toggleAction,
+    setScope,
+    isDirty,
+    addedCount,
+    removedCount,
+  } = useRoleActionsManager(roleAssignments)
 
   const actionCounts = useMemo(() => {
     const saved = Object.fromEntries(
       (allAssignmentsData?.assignments ?? []).map((a) => [
         a.role_id,
-        a.secured_endpoint_ids.length,
+        a.secured_endpoints?.length ?? 0,
       ]),
     )
     return {
       ...saved,
       ...(selectedRoleId && isDirty
-        ? { [selectedRoleId]: selectedActionIds.length }
+        ? { [selectedRoleId]: selectedAssignments.length }
         : {}),
     }
-  }, [allAssignmentsData, selectedRoleId, selectedActionIds, isDirty])
+  }, [allAssignmentsData, selectedRoleId, selectedAssignments, isDirty])
 
   const roles = useMemo(() => rolesData?.content ?? [], [rolesData])
 
@@ -125,7 +135,7 @@ const EndpointsAccess = () => {
     saveRoleActions(
       {
         roleId: selectedRoleId,
-        data: { secured_endpoint_ids: selectedActionIds },
+        data: { secured_endpoint_assignments: selectedAssignments },
       },
       {
         onSuccess: () => {
@@ -162,7 +172,7 @@ const EndpointsAccess = () => {
         </div>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-x-8 items-start pb-10">
-          <div className="sticky top-4 bg-surface-muted rounded-lg p-4">
+          <div className="lg:sticky lg:top-4 bg-surface-muted rounded-lg p-4 mb-6 lg:mb-0">
             <RoleListPanel
               roles={roles}
               selectedRoleId={selectedRoleId}
@@ -178,8 +188,9 @@ const EndpointsAccess = () => {
                 key={selectedRoleId}
                 roleName={selectedRole.name}
                 endpointsList={endpointsList}
-                selectedActionIds={selectedActionIds}
+                selectedAssignments={selectedAssignments}
                 onToggleAction={toggleAction}
+                onSetScope={setScope}
                 onSubmit={handleSubmitActions}
                 isMutating={isMutating}
                 isDirty={isDirty}

--- a/src/pages/endpoints-access/RoleDetailsPanel.tsx
+++ b/src/pages/endpoints-access/RoleDetailsPanel.tsx
@@ -9,17 +9,17 @@ import SelectDropdown from '@/components/SelectDropdown'
 import CategoryPanel from './CategoryPanel'
 import { CATEGORY_MATCHERS } from './constants/endpointCategories'
 import { getFriendlyLabel } from './utils/friendlyLabels'
-import type { SecuredEndpoint } from '@/types/securedEndpoints'
+import type {
+  SecuredEndpoint,
+  EndpointAssignment,
+} from '@/types/securedEndpoints'
 
 interface RoleDetailsPanelProps {
   roleName: string
   endpointsList: SecuredEndpoint[]
-  selectedActionIds: string[]
-  onToggleAction: (
-    actionId: string,
-    selectAll?: boolean,
-    allIds?: string[],
-  ) => void
+  selectedAssignments: EndpointAssignment[]
+  onToggleAction: (actionId: string) => void
+  onSetScope: (endpointId: string, scope: string) => void
   onSubmit: () => void
   isMutating: boolean
   isDirty: boolean
@@ -32,8 +32,9 @@ interface RoleDetailsPanelProps {
 const RoleDetailsPanel = ({
   roleName,
   endpointsList,
-  selectedActionIds,
+  selectedAssignments,
   onToggleAction,
+  onSetScope,
   onSubmit,
   isMutating,
   isDirty,
@@ -83,9 +84,9 @@ const RoleDetailsPanel = ({
     return options
   }, [endpointsList])
 
-  const selectedActionIdsSet = useMemo(
-    () => new Set(selectedActionIds),
-    [selectedActionIds],
+  const selectedAssignmentsMap = useMemo(
+    () => new Map(selectedAssignments.map((a) => [a.secured_endpoint_id, a])),
+    [selectedAssignments],
   )
 
   const groupedEndpoints = useMemo(() => {
@@ -160,7 +161,7 @@ const RoleDetailsPanel = ({
       />
 
       <div
-        className={`sticky top-0 z-10 px-1 bg-white transition-all ${isStuck ? 'py-3 border-b border-line' : 'pb-1'}`}
+        className={`lg:sticky lg:top-0 z-10 px-1 bg-white transition-all ${isStuck ? 'py-3 border-b border-line' : 'pb-1'}`}
       >
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <div className="min-w-0 flex-1">
@@ -249,8 +250,9 @@ const RoleDetailsPanel = ({
                 endpoints={endpoints}
                 isCollapsed={collapsedGroups.has(label)}
                 onToggleCollapse={() => handleToggleGroup(label)}
-                selectedActionIds={selectedActionIdsSet}
+                selectedAssignments={selectedAssignmentsMap}
                 onToggleAction={onToggleAction}
+                onSetScope={onSetScope}
               />
             ))}
           </div>

--- a/src/pages/endpoints-access/hooks/useRoleActionsManager.ts
+++ b/src/pages/endpoints-access/hooks/useRoleActionsManager.ts
@@ -1,66 +1,74 @@
 import { useState, useEffect, useMemo } from 'react'
+import type { EndpointAssignment } from '@/types/securedEndpoints'
 
 export const useRoleActionsManager = (
-  selectedRoleId: string | null,
-  roleActionIds: string[],
+  roleAssignments: EndpointAssignment[],
 ) => {
-  const [selectedActionIds, setSelectedActionIds] = useState<string[]>([])
+  const [selectedAssignments, setSelectedAssignments] = useState<
+    EndpointAssignment[]
+  >([])
   const [hasUserModified, setHasUserModified] = useState(false)
 
   useEffect(() => {
-    setSelectedActionIds(roleActionIds)
+    setSelectedAssignments(roleAssignments)
     setHasUserModified(false)
-  }, [selectedRoleId, roleActionIds])
+  }, [roleAssignments])
 
   const isDirty = useMemo(() => {
     if (!hasUserModified) return false
-    const saved = new Set(roleActionIds)
-    const current = new Set(selectedActionIds)
-    if (saved.size !== current.size) return true
-    return [...saved].some((id) => !current.has(id))
-  }, [roleActionIds, selectedActionIds, hasUserModified])
+    const savedMap = new Map(
+      roleAssignments.map((a) => [a.secured_endpoint_id, a.scope]),
+    )
+    const currentMap = new Map(
+      selectedAssignments.map((a) => [a.secured_endpoint_id, a.scope]),
+    )
+    if (savedMap.size !== currentMap.size) return true
+    for (const [id, scope] of savedMap) {
+      if (!currentMap.has(id) || currentMap.get(id) !== scope) return true
+    }
+    return false
+  }, [roleAssignments, selectedAssignments, hasUserModified])
 
   const addedCount = useMemo(() => {
     if (!hasUserModified) return 0
-    const saved = new Set(roleActionIds)
-    return selectedActionIds.filter((id) => !saved.has(id)).length
-  }, [roleActionIds, selectedActionIds, hasUserModified])
+    const savedIds = new Set(roleAssignments.map((a) => a.secured_endpoint_id))
+    return selectedAssignments.filter(
+      (a) => !savedIds.has(a.secured_endpoint_id),
+    ).length
+  }, [roleAssignments, selectedAssignments, hasUserModified])
 
   const removedCount = useMemo(() => {
     if (!hasUserModified) return 0
-    const current = new Set(selectedActionIds)
-    return roleActionIds.filter((id) => !current.has(id)).length
-  }, [roleActionIds, selectedActionIds, hasUserModified])
+    const currentIds = new Set(
+      selectedAssignments.map((a) => a.secured_endpoint_id),
+    )
+    return roleAssignments.filter((a) => !currentIds.has(a.secured_endpoint_id))
+      .length
+  }, [roleAssignments, selectedAssignments, hasUserModified])
 
-  const toggleAction = (
-    actionId: string,
-    selectAll?: boolean,
-    allIds?: string[],
-  ) => {
+  const toggleAction = (actionId: string) => {
     setHasUserModified(true)
-    if (allIds && selectAll !== undefined) {
-      setSelectedActionIds((current) => {
-        const next = new Set(current)
-        if (selectAll) {
-          allIds.forEach((id) => next.add(id))
-        } else {
-          allIds.forEach((id) => next.delete(id))
-        }
-        return Array.from(next)
-      })
-      return
-    }
+    setSelectedAssignments((current) => {
+      const exists = current.some((a) => a.secured_endpoint_id === actionId)
+      return exists
+        ? current.filter((a) => a.secured_endpoint_id !== actionId)
+        : [...current, { secured_endpoint_id: actionId }]
+    })
+  }
 
-    setSelectedActionIds((current) =>
-      current.includes(actionId)
-        ? current.filter((id) => id !== actionId)
-        : [...current, actionId],
+  const setScope = (endpointId: string, scope: string) => {
+    setHasUserModified(true)
+    setSelectedAssignments((current) =>
+      current.map((a) =>
+        a.secured_endpoint_id === endpointId ? { ...a, scope } : a,
+      ),
     )
   }
 
   return {
-    selectedActionIds,
+    selectedAssignments,
     toggleAction,
+    setScope,
     isDirty,
     addedCount,
     removedCount,

--- a/src/types/securedEndpoints.ts
+++ b/src/types/securedEndpoints.ts
@@ -3,6 +3,7 @@ export type SecuredEndpoint = {
   action: string
   path: string
   description?: string
+  scopes?: string[]
 }
 
 export type SecuredEndpointsPage = {
@@ -13,10 +14,15 @@ export type SecuredEndpointsPage = {
   total_pages: number
 }
 
+export type EndpointAssignment = {
+  secured_endpoint_id: string
+  scope?: string
+}
+
 export type RoleAssignment = {
   role_id: string
   role_name: string
-  secured_endpoint_ids: string[]
+  secured_endpoints: EndpointAssignment[]
 }
 
 export type RoleAssignmentsResponse = {
@@ -24,7 +30,7 @@ export type RoleAssignmentsResponse = {
 }
 
 export type AssignEndpointsRequest = {
-  secured_endpoint_ids: string[]
+  secured_endpoint_assignments: EndpointAssignment[]
 }
 
 export type RoleEndpointAssignmentResponse = {


### PR DESCRIPTION
This PR adds scope selection support for secured endpoint assignments in the role permissions management page.

- Implemented scope radio buttons for each endpoint when scopes are available
- Refactored assignment state management to track full assignment objects instead of plain ID sets
- Updated API request and response types to reflect the actual API assignment shape
- Removed bulk select/deselect functionality from category group headers