### PR TITLE
[ARGO-5584] - Refactor role display across user management views

### DIFF
--- a/src/pages/InvitationReview.tsx
+++ b/src/pages/InvitationReview.tsx
@@ -206,9 +206,7 @@ export const InvitationReview = () => {
                   Role
                 </label>
                 <div className="text-sm text-gray-800 px-3 py-2 bg-surface-muted rounded-md border border-line">
-                  {invitation?.role === 'tenant_admin'
-                    ? 'Tenant Admin'
-                    : 'Member'}
+                  {invitation?.role}
                 </div>
               </div>
 
@@ -242,13 +240,9 @@ export const InvitationReview = () => {
             <div className="mt-4 p-4 bg-brand-subtle border border-blue-200 rounded-lg">
               <p className="m-0 text-sm text-blue-800 leading-relaxed">
                 By accepting this invitation, you will become a{' '}
-                <strong>
-                  {invitation?.role === 'tenant_admin'
-                    ? 'Tenant Admin'
-                    : 'Member'}
-                </strong>{' '}
-                of the <strong>{invitation?.tenant_name}</strong> tenant. You
-                will be able to
+                <strong>{invitation?.role}</strong> of the{' '}
+                <strong>{invitation?.tenant_name}</strong> tenant. You will be
+                able to
                 {invitation?.role === 'tenant_admin'
                   ? ' manage tenant settings, members, and projects.'
                   : ' view tenant information.'}

--- a/src/pages/MyInvitations.tsx
+++ b/src/pages/MyInvitations.tsx
@@ -114,9 +114,7 @@ const MyInvitations = () => {
                               'bg-surface-strong text-muted'
                             }
                           >
-                            {invitation.role === 'tenant_admin'
-                              ? 'Tenant Admin'
-                              : 'Member'}
+                            {invitation.role}
                           </Badge>
                         </td>
                         <td className={tdBase}>

--- a/src/pages/administration/AdminInvitationsTab.tsx
+++ b/src/pages/administration/AdminInvitationsTab.tsx
@@ -215,7 +215,7 @@ const AdminInvitationsTab = ({ isSuperAdmin }: AdminInvitationsProps) => {
                       'bg-surface-strong text-muted'
                     }
                   >
-                    {invitation.role === 'tenant_admin' ? 'Admin' : 'Viewer'}
+                    {invitation.role}
                   </Badge>
                 </td>
                 <td className={tdBase}>

--- a/src/pages/administration/TenantManagementTab.tsx
+++ b/src/pages/administration/TenantManagementTab.tsx
@@ -215,11 +215,7 @@ const TenantManagementTab = () => {
                               <Badge
                                 className={`shrink-0 mt-0.5 ${roleBadgeClass[role.toLowerCase()] ?? 'bg-surface-strong text-muted'}`}
                               >
-                                {role.toLowerCase() === 'tenant_admin'
-                                  ? 'Admin'
-                                  : role.toLowerCase() === 'tenant_viewer'
-                                    ? 'Member'
-                                    : null}
+                                {role}
                               </Badge>
                             ) : null
                           })()}

--- a/src/pages/administration/UsersTab.tsx
+++ b/src/pages/administration/UsersTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import { useAuth } from '@/auth/useAuth'
 import { useGetMembers } from '@/hooks/useTenants'
 import { UserCircleIcon } from '@heroicons/react/16/solid'
@@ -16,7 +16,38 @@ type SortDirection = 'asc' | 'desc'
 const pageSize = 10
 
 const tenantBadgeBase =
-  'inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full whitespace-nowrap'
+  'tooltip inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full max-w-[120px]'
+
+const TenantBadge = ({
+  name,
+  role,
+  colorClass,
+}: {
+  name: string
+  role: string
+  colorClass: string
+}) => {
+  const textRef = useRef<HTMLSpanElement>(null)
+  const [isTruncated, setIsTruncated] = useState(false)
+
+  useEffect(() => {
+    const el = textRef.current
+    if (el) {
+      setIsTruncated(el.scrollWidth > el.clientWidth)
+    }
+  }, [name])
+
+  return (
+    <span
+      className={`${tenantBadgeBase} ${colorClass}`}
+      data-tip={isTruncated ? `${name} (${role})` : role}
+    >
+      <span ref={textRef} className="truncate min-w-0">
+        {name}
+      </span>
+    </span>
+  )
+}
 
 const UsersTab = () => {
   const [searchInput, setSearchInput] = useState('')
@@ -135,7 +166,7 @@ const UsersTab = () => {
                       Last Name
                     </SortableColumnHeader>
                   </th>
-                  <th className={`${thBase} w-[30%]`}>
+                  <th className={`${thBase} w-[25%]`}>
                     <SortableColumnHeader
                       isActive={sortColumn === 'email'}
                       isAscending={sortDirection === 'asc'}
@@ -144,7 +175,7 @@ const UsersTab = () => {
                       Email
                     </SortableColumnHeader>
                   </th>
-                  <th className={`${thBase} w-[20%]`}>
+                  <th className={`${thBase} w-[25%]`}>
                     <SortableColumnHeader
                       isActive={sortColumn === 'tenants'}
                       isAscending={sortDirection === 'asc'}
@@ -187,21 +218,16 @@ const UsersTab = () => {
                       <div className="flex flex-wrap gap-1.5">
                         {user.tenants && user.tenants.length > 0 ? (
                           user.tenants.map((tenant, index) => (
-                            <span
+                            <TenantBadge
                               key={index}
-                              className={`tooltip ${tenantBadgeBase} ${
+                              name={tenant.name}
+                              role={tenant.role}
+                              colorClass={
                                 tenant.role === 'tenant_admin'
                                   ? 'bg-amber-100 text-amber-700'
                                   : 'bg-brand-muted text-blue-800'
-                              }`}
-                              data-tip={
-                                tenant.role === 'tenant_admin'
-                                  ? 'Tenant Admin'
-                                  : 'Tenant Member'
                               }
-                            >
-                              {tenant.name}
-                            </span>
+                            />
                           ))
                         ) : (
                           <span className="text-subtle text-sm italic">

--- a/src/pages/manage-tenant-members/MembersTab.tsx
+++ b/src/pages/manage-tenant-members/MembersTab.tsx
@@ -105,26 +105,25 @@ const MembersTab = ({ tenantId, tenantName }: MembersTabProps) => {
               </thead>
               <tbody className="divide-y divide-gray-100">
                 {membersData?.content && membersData.content.length > 0 ? (
-                  membersData.content.map((member) => {
-                    const tenantInfo = member.tenants?.find(
-                      (t) => t.name === tenantName,
-                    )
-                    return (
-                      <tr key={member.id} className="hover:bg-surface-muted">
+                  membersData.content.flatMap((member) => {
+                    const tenantRoles =
+                      member.tenants?.filter((t) => t.name === tenantName) ?? []
+                    return tenantRoles.map((tenantInfo) => (
+                      <tr
+                        key={`${member.id}-${tenantInfo.role}`}
+                        className="hover:bg-surface-muted"
+                      >
                         <td className={tdBase}>{member.firstName || '-'}</td>
                         <td className={tdBase}>{member.lastName || '-'}</td>
                         <td className={tdBase}>{member.email}</td>
                         <td className={tdBase}>
                           <Badge
                             className={
-                              roleBadgeClass[
-                                tenantInfo?.role ?? 'tenant_viewer'
-                              ] ?? 'bg-surface-strong text-muted'
+                              roleBadgeClass[tenantInfo.role] ??
+                              'bg-surface-strong text-muted'
                             }
                           >
-                            {tenantInfo?.role === 'tenant_admin'
-                              ? 'Tenant Admin'
-                              : 'Member'}
+                            {tenantInfo.role}
                           </Badge>
                         </td>
                         <td className={`${tdBase} px-6`}>
@@ -135,14 +134,14 @@ const MembersTab = ({ tenantId, tenantName }: MembersTabProps) => {
                               handleRemoveClick(
                                 member.id,
                                 member.email,
-                                tenantInfo?.role ?? '',
+                                tenantInfo.role,
                               )
                             }
                             className="text-red-500 hover:bg-red-50"
                           />
                         </td>
                       </tr>
-                    )
+                    ))
                   })
                 ) : (
                   <tr>
@@ -182,12 +181,13 @@ const MembersTab = ({ tenantId, tenantName }: MembersTabProps) => {
         message={
           memberToRemove ? (
             <>
-              Are you sure you want to remove user with email{' '}
-              <strong>{memberToRemove.email}</strong> from tenant{' '}
+              Are you sure you want to revoke the{' '}
+              <strong>{memberToRemove.role}</strong> role from{' '}
+              <strong>{memberToRemove.email}</strong> in tenant{' '}
               <strong>{tenantName}</strong>?
               <br />
               <span className="text-amber-600 font-medium">
-                The user will lose access to this tenant.
+                The user will lose all permissions associated with this role.
               </span>
             </>
           ) : (

--- a/src/pages/manage-tenant-members/TenantInvitations.tsx
+++ b/src/pages/manage-tenant-members/TenantInvitations.tsx
@@ -92,9 +92,7 @@ const TenantInvitations = ({
                           'bg-surface-strong text-muted'
                         }
                       >
-                        {invitation.role === 'tenant_admin'
-                          ? 'Tenant Admin'
-                          : 'Member'}
+                        {invitation.role}
                       </Badge>
                     </td>
                     <td className={tdBase}>


### PR DESCRIPTION
This PR improves role display across user management views to show API role values directly instead of mapped labels.

- Removed hardcoded friendly label mappings for role values across invitation and member views
- Refactored the tenant members table to render one row per role, supporting users with multiple roles in the same tenant
- Updated the remove confirmation dialog to reference the specific role being revoked
- Improved the tenant badges in the users table to truncate long names with a tooltip showing full details