### PR TITLE
[ARGO-5598] - Fix issue when creating a tenant with topology feed configuration

### DIFF
--- a/src/pages/create-tenant/CreateTenant.tsx
+++ b/src/pages/create-tenant/CreateTenant.tsx
@@ -4,11 +4,8 @@ import {
   useCreateTenantMutation,
   useGetUserTenantById,
   useUpdateUserTenantMutation,
-  useGetTopologyFeedQuery,
-  useUpdateTopologyFeedMutation,
 } from '@/hooks/useTenants'
-import type { Metadata, TopologyFeed } from '@/types/tenants'
-import type { TopologyFeedFormState } from './InfrastructureMetadata'
+import type { Metadata } from '@/types/tenants'
 import { toast } from 'sonner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import Button from '@/components/Button'
@@ -20,27 +17,6 @@ import Tabs from '@/components/Tabs'
 import TenantBasicInfoTab from './TenantBasicInfoTab'
 
 const BACKEND_API = import.meta.env.VITE_BACKEND_URI
-
-const buildFeedPayload = (feed: TopologyFeedFormState): TopologyFeed => {
-  if (feed.type === 'CSV') {
-    return {
-      type: feed.type,
-      feed_url: feed.feed_url,
-      paginated: 'false',
-      fetch_type: ['ServiceGroups'],
-      uid_endpoints: '',
-    }
-  }
-  if (feed.type === 'eosc-service-catalog') {
-    return {
-      type: feed.type,
-      feed_service_groups: feed.feed_service_groups,
-      feed_service_endpoints: feed.feed_service_endpoints,
-      feed_service_endpoints_extensions: feed.feed_service_endpoints_extensions,
-    }
-  }
-  return { type: feed.type }
-}
 
 const CreateTenant = () => {
   const { id: tenantId } = useParams<{ id?: string }>()
@@ -58,9 +34,6 @@ const CreateTenant = () => {
   const [metadata, setMetadata] = useState({
     ui_url: '',
     poem_url: '',
-    topology_type: '',
-    topology_url: '',
-    topology_feed: '',
     internalLists: [{ email: '', type: '' }],
     auth_name: '',
     auth_url: '',
@@ -75,13 +48,6 @@ const CreateTenant = () => {
     useState(false)
   const [hasMetadataValidationError, setHasMetadataValidationError] =
     useState(false)
-  const [topologyFeed, setTopologyFeed] = useState<TopologyFeedFormState>({
-    type: '',
-    feed_url: '',
-    feed_service_groups: '',
-    feed_service_endpoints: '',
-    feed_service_endpoints_extensions: '',
-  })
 
   const navigateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -93,16 +59,12 @@ const CreateTenant = () => {
 
   const createMutation = useCreateTenantMutation()
   const updateMutation = useUpdateUserTenantMutation()
-  const updateTopologyFeedMutation = useUpdateTopologyFeedMutation()
 
   const {
     data: tenantData,
     isLoading: isTenantLoading,
     error: tenantError,
   } = useGetUserTenantById(tenantId || '')
-
-  const { data: topologyFeedData, isLoading: topologyFeedLoading } =
-    useGetTopologyFeedQuery(tenantId || '', isEditMode)
 
   useEffect(() => {
     if (isEditMode && tenantData) {
@@ -144,9 +106,6 @@ const CreateTenant = () => {
         setMetadata({
           ui_url: tenantData.metadata.instance?.ui_url || '',
           poem_url: tenantData.metadata.instance?.poem_url || '',
-          topology_type: tenantData.metadata.instance?.topology?.type || '',
-          topology_url: tenantData.metadata.instance?.topology?.url || '',
-          topology_feed: tenantData.metadata.instance?.topology?.feed || '',
           internalLists: loadedInternalLists,
           auth_name: tenantData.metadata.auth_metadata?.auth_name || '',
           auth_url: tenantData.metadata.auth_metadata?.auth_url || '',
@@ -154,19 +113,6 @@ const CreateTenant = () => {
       }
     }
   }, [isEditMode, tenantData])
-
-  useEffect(() => {
-    if (isEditMode && topologyFeedData) {
-      setTopologyFeed({
-        type: topologyFeedData.type || '',
-        feed_url: topologyFeedData.feed_url || '',
-        feed_service_groups: topologyFeedData.feed_service_groups || '',
-        feed_service_endpoints: topologyFeedData.feed_service_endpoints || '',
-        feed_service_endpoints_extensions:
-          topologyFeedData.feed_service_endpoints_extensions || '',
-      })
-    }
-  }, [isEditMode, topologyFeedData])
 
   const hasTenantDetailsErrors = () => {
     return (
@@ -207,12 +153,7 @@ const CreateTenant = () => {
 
     const metadataObj: Metadata = {}
 
-    const hasInstanceData =
-      metadata.ui_url.trim() ||
-      metadata.poem_url.trim() ||
-      metadata.topology_type.trim() ||
-      metadata.topology_url.trim() ||
-      metadata.topology_feed.trim()
+    const hasInstanceData = metadata.ui_url.trim() || metadata.poem_url.trim()
 
     if (hasInstanceData) {
       metadataObj.instance = {}
@@ -220,21 +161,6 @@ const CreateTenant = () => {
       if (metadata.ui_url.trim()) metadataObj.instance.ui_url = metadata.ui_url
       if (metadata.poem_url.trim())
         metadataObj.instance.poem_url = metadata.poem_url
-
-      const hasTopologyData =
-        metadata.topology_type.trim() ||
-        metadata.topology_url.trim() ||
-        metadata.topology_feed.trim()
-
-      if (hasTopologyData) {
-        metadataObj.instance.topology = {}
-        if (metadata.topology_type.trim())
-          metadataObj.instance.topology.type = metadata.topology_type
-        if (metadata.topology_url.trim())
-          metadataObj.instance.topology.url = metadata.topology_url
-        if (metadata.topology_feed.trim())
-          metadataObj.instance.topology.feed = metadata.topology_feed
-      }
     }
 
     const internalListsData = metadata.internalLists
@@ -270,8 +196,6 @@ const CreateTenant = () => {
       }
     }
 
-    const feedPayload = buildFeedPayload(topologyFeed)
-
     if (isEditMode && tenantId) {
       updateMutation.mutate(
         {
@@ -284,18 +208,10 @@ const CreateTenant = () => {
         },
         {
           onSuccess: () => {
-            updateTopologyFeedMutation.mutate(
-              { tenantId, data: feedPayload },
-              {
-                onSuccess: () => {
-                  toast.success('Tenant updated successfully!')
-                  navigateTimerRef.current = setTimeout(
-                    () => navigate(`/tenants/${tenantId}/details`),
-                    2000,
-                  )
-                },
-                onError,
-              },
+            toast.success('Tenant updated successfully!')
+            navigateTimerRef.current = setTimeout(
+              () => navigate(`/tenants/${tenantId}/details`),
+              2000,
             )
           },
           onError,
@@ -306,27 +222,16 @@ const CreateTenant = () => {
         { info: submitData, contacts: contactsData, metadata: metadataObj },
         {
           onSuccess: (createdTenant) => {
-            if (createdTenant.id) {
-              updateTopologyFeedMutation.mutate(
-                { tenantId: createdTenant.id, data: feedPayload },
-                {
-                  onSuccess: () => {
-                    toast.success('Tenant created successfully!')
-                    navigateTimerRef.current = setTimeout(
-                      () => navigate(`/administration#tenants`),
-                      2000,
-                    )
-                  },
-                  onError,
-                },
-              )
-            } else {
-              toast.success('Tenant created successfully!')
-              navigateTimerRef.current = setTimeout(
-                () => navigate(`/administration#tenants`),
-                2000,
-              )
-            }
+            toast.success('Tenant created successfully!')
+            navigateTimerRef.current = setTimeout(
+              () =>
+                navigate(
+                  createdTenant.id
+                    ? `/tenants/${createdTenant.id}/details`
+                    : `/administration#tenants`,
+                ),
+              2000,
+            )
           },
           onError,
         },
@@ -336,7 +241,7 @@ const CreateTenant = () => {
 
   return (
     <div className="page-container">
-      {isEditMode && (isTenantLoading || topologyFeedLoading) ? (
+      {isEditMode && isTenantLoading ? (
         <div className="loading-container">
           <LoadingSpinner />
         </div>
@@ -382,7 +287,6 @@ const CreateTenant = () => {
               disabled={
                 createMutation.isPending ||
                 updateMutation.isPending ||
-                updateTopologyFeedMutation.isPending ||
                 !!errors.name ||
                 !!errors.email ||
                 !!errors.website ||
@@ -396,13 +300,10 @@ const CreateTenant = () => {
                     contact.type.trim(),
                 ) ||
                 hasContactValidationError ||
-                hasMetadataValidationError ||
-                !topologyFeed.type
+                hasMetadataValidationError
               }
             >
-              {createMutation.isPending ||
-              updateMutation.isPending ||
-              updateTopologyFeedMutation.isPending
+              {createMutation.isPending || updateMutation.isPending
                 ? 'Saving...'
                 : isEditMode
                   ? 'Update'
@@ -426,7 +327,7 @@ const CreateTenant = () => {
                 {
                   id: 'metadata',
                   label: 'Infrastructure Settings',
-                  hasError: hasMetadataValidationError || !topologyFeed.type,
+                  hasError: hasMetadataValidationError,
                 },
               ]}
               activeTab={activeTab}
@@ -462,8 +363,6 @@ const CreateTenant = () => {
               <InfrastructureMetadata
                 metadata={metadata}
                 onMetadataChange={setMetadata}
-                topologyFeed={topologyFeed}
-                onTopologyFeedChange={setTopologyFeed}
                 onValidationChange={setHasMetadataValidationError}
               />
             </div>

--- a/src/pages/create-tenant/InfrastructureMetadata.tsx
+++ b/src/pages/create-tenant/InfrastructureMetadata.tsx
@@ -18,28 +18,10 @@ const iconButtonDangerClass =
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const urlRegex = /^https?:\/\/.+\..+/
 
-const FEED_TYPE_OPTIONS = [
-  { value: 'internal', label: 'Internal' },
-  { value: 'CSV', label: 'CSV' },
-  { value: 'eosc-service-catalog', label: 'EOSC Service Catalog' },
-  { value: 'external', label: 'External' },
-]
-
-export type TopologyFeedFormState = {
-  type: string
-  feed_url: string
-  feed_service_groups: string
-  feed_service_endpoints: string
-  feed_service_endpoints_extensions: string
-}
-
 interface InfrastructureMetadataProps {
   metadata: {
     ui_url: string
     poem_url: string
-    topology_type: string
-    topology_url: string
-    topology_feed: string
     internalLists: Array<{ email: string; type: string }>
     auth_name: string
     auth_url: string
@@ -47,23 +29,16 @@ interface InfrastructureMetadataProps {
   onMetadataChange: (metadata: {
     ui_url: string
     poem_url: string
-    topology_type: string
-    topology_url: string
-    topology_feed: string
     internalLists: Array<{ email: string; type: string }>
     auth_name: string
     auth_url: string
   }) => void
-  topologyFeed: TopologyFeedFormState
-  onTopologyFeedChange: (feed: TopologyFeedFormState) => void
   onValidationChange?: (hasError: boolean) => void
 }
 
 const InfrastructureMetadata = ({
   metadata,
   onMetadataChange,
-  topologyFeed,
-  onTopologyFeedChange,
   onValidationChange,
 }: InfrastructureMetadataProps) => {
   const [errors, setErrors] = useState(() => ({
@@ -77,23 +52,6 @@ const InfrastructureMetadata = ({
 
   const urlErrorMessage =
     'Please enter a valid URL (must start with http:// or https://)'
-
-  const handleFeedTypeChange = (value: string) => {
-    onTopologyFeedChange({
-      type: value,
-      feed_url: '',
-      feed_service_groups: '',
-      feed_service_endpoints: '',
-      feed_service_endpoints_extensions: '',
-    })
-  }
-
-  const handleFeedFieldChange = (
-    field: keyof Omit<TopologyFeedFormState, 'type'>,
-    value: string,
-  ) => {
-    onTopologyFeedChange({ ...topologyFeed, [field]: value })
-  }
 
   const handleInternalListTypeChange = (index: number, value: string) => {
     const updatedLists = [...metadata.internalLists]
@@ -253,83 +211,6 @@ const InfrastructureMetadata = ({
               error={errors.poemUrl}
             />
           </div>
-        </div>
-      </div>
-
-      <div className={sectionClass}>
-        <div className="pt-2 pl-2">
-          <h2 className="section-title">Topology Feed</h2>
-          <p className="section-description">
-            Feed configuration for topology data
-          </p>
-        </div>
-
-        <div className={sectionContentClass}>
-          <div className={fieldGridClass}>
-            <div className="flex flex-col">
-              <label className="text-sm font-medium text-body mb-1">
-                Type <span className="required">*</span>
-              </label>
-              <SelectDropdown
-                value={topologyFeed.type}
-                onChange={handleFeedTypeChange}
-                options={FEED_TYPE_OPTIONS}
-                placeholder="Select feed type"
-              />
-            </div>
-          </div>
-
-          {topologyFeed.type === 'CSV' && (
-            <div className={fieldGridClass}>
-              <FormField
-                label="URL"
-                type="url"
-                value={topologyFeed.feed_url}
-                onChange={(e) =>
-                  handleFeedFieldChange('feed_url', e.target.value)
-                }
-                placeholder="Enter feed URL"
-              />
-            </div>
-          )}
-
-          {topologyFeed.type === 'eosc-service-catalog' && (
-            <div className={fieldGridClass}>
-              <FormField
-                label="Service Groups URL"
-                type="url"
-                value={topologyFeed.feed_service_groups}
-                onChange={(e) =>
-                  handleFeedFieldChange('feed_service_groups', e.target.value)
-                }
-                placeholder="Enter service groups feed URL"
-              />
-              <FormField
-                label="Service Endpoints URL"
-                type="url"
-                value={topologyFeed.feed_service_endpoints}
-                onChange={(e) =>
-                  handleFeedFieldChange(
-                    'feed_service_endpoints',
-                    e.target.value,
-                  )
-                }
-                placeholder="Enter service endpoints feed URL"
-              />
-              <FormField
-                label="Service Endpoint Extensions URL"
-                type="url"
-                value={topologyFeed.feed_service_endpoints_extensions}
-                onChange={(e) =>
-                  handleFeedFieldChange(
-                    'feed_service_endpoints_extensions',
-                    e.target.value,
-                  )
-                }
-                placeholder="Enter service endpoint extensions feed URL"
-              />
-            </div>
-          )}
         </div>
       </div>
 

--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -6,6 +6,7 @@ import Tabs from '@/components/Tabs'
 import TopologyEndpoints from './TopologyEndpoints'
 import TopologyGroups from './TopologyGroups'
 import TopologyDocumentation from './TopologyDocumentation'
+import TopologyFeed from './TopologyFeed'
 import CreateTopologyEndpoint from './CreateTopologyEndpoint'
 import CreateTopologyGroup from './CreateTopologyGroup'
 import type { EndpointTopologyItem, GroupTopologyItem } from '@/types/topology'
@@ -13,6 +14,7 @@ import type { EndpointTopologyItem, GroupTopologyItem } from '@/types/topology'
 const tabs = [
   { id: 'endpoints', label: 'Endpoints' },
   { id: 'groups', label: 'Groups' },
+  { id: 'feed-configuration', label: 'Feed configuration' },
   { id: 'documentation', label: 'Documentation' },
 ]
 
@@ -24,13 +26,15 @@ const TenantTopology = () => {
 
   const location = useLocation()
   const [activeTab, setActiveTab] = useState<
-    'endpoints' | 'groups' | 'documentation'
+    'endpoints' | 'groups' | 'feed-configuration' | 'documentation'
   >('endpoints')
 
   useEffect(() => {
     const hash = location.hash
     if (hash.startsWith('#groups')) {
       setActiveTab('groups')
+    } else if (hash.startsWith('#feed-configuration')) {
+      setActiveTab('feed-configuration')
     } else if (hash.startsWith('#documentation')) {
       setActiveTab('documentation')
     } else {
@@ -81,7 +85,13 @@ const TenantTopology = () => {
         tabs={tabs}
         activeTab={activeTab}
         onChange={(id) => {
-          setActiveTab(id as 'endpoints' | 'groups' | 'documentation')
+          setActiveTab(
+            id as
+              | 'endpoints'
+              | 'groups'
+              | 'feed-configuration'
+              | 'documentation',
+          )
           window.location.hash = id
         }}
         className="mb-4"
@@ -93,6 +103,10 @@ const TenantTopology = () => {
 
       <div className={activeTab === 'groups' ? 'block' : 'hidden'}>
         <TopologyGroups tenantId={tenantId} onEdit={setEditingGroup} />
+      </div>
+
+      <div className={activeTab === 'feed-configuration' ? 'block' : 'hidden'}>
+        <TopologyFeed tenantId={tenantId} />
       </div>
 
       <div className={activeTab === 'documentation' ? 'block' : 'hidden'}>

--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -57,7 +57,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
     dateInput,
     committedDate,
     showActions,
-    isExternal,
+    isInternal,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,
@@ -147,7 +147,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           placeholder="Search by service, hostname, URL or group..."
           className="!mb-0 flex-1 max-w-xs xl:max-w-none"
         />
-        {!isExternal && (
+        {isInternal && (
           <Button
             variant="primary"
             size="md"

--- a/src/pages/tenant-topology/TopologyFeed.tsx
+++ b/src/pages/tenant-topology/TopologyFeed.tsx
@@ -1,0 +1,252 @@
+import { useState, useEffect } from 'react'
+import {
+  useGetTopologyFeedQuery,
+  useUpdateTopologyFeedMutation,
+} from '@/hooks/useTenants'
+import type { TopologyFeed as TopologyFeedPayload } from '@/types/tenants'
+import { toast } from 'sonner'
+import SelectDropdown from '@/components/SelectDropdown'
+import Button from '@/components/Button'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+type TopologyFeedFormState = {
+  type: string
+  feed_url: string
+  feed_service_groups: string
+  feed_service_endpoints: string
+  feed_service_endpoints_extensions: string
+}
+
+const FEED_TYPE_OPTIONS = [
+  { value: 'internal', label: 'Internal' },
+  { value: 'CSV', label: 'CSV' },
+  { value: 'eosc-service-catalog', label: 'EOSC Service Catalog' },
+  { value: 'external', label: 'External' },
+]
+
+const NONE_OPTION = { value: '', label: 'None' }
+
+const emptyForm: TopologyFeedFormState = {
+  type: '',
+  feed_url: '',
+  feed_service_groups: '',
+  feed_service_endpoints: '',
+  feed_service_endpoints_extensions: '',
+}
+
+const buildFeedPayload = (feed: TopologyFeedFormState): TopologyFeedPayload => {
+  if (feed.type === 'CSV') {
+    return {
+      type: feed.type,
+      feed_url: feed.feed_url,
+      paginated: 'false',
+      fetch_type: ['ServiceGroups'],
+      uid_endpoints: '',
+    }
+  }
+  if (feed.type === 'eosc-service-catalog') {
+    return {
+      type: feed.type,
+      feed_service_groups: feed.feed_service_groups,
+      feed_service_endpoints: feed.feed_service_endpoints,
+      feed_service_endpoints_extensions: feed.feed_service_endpoints_extensions,
+    }
+  }
+  return { type: feed.type }
+}
+
+const sectionClass =
+  'grid grid-cols-1 lg:grid-cols-[360px_1fr] gap-2 lg:gap-8 mb-6 animate-fade-in'
+const sectionContentClass =
+  'bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-2'
+const labelClass = 'text-sm font-medium text-body mb-1'
+const fieldGridClass =
+  'grid grid-cols-[repeat(auto-fit,minmax(250px,1fr))] gap-3'
+
+interface TopologyFeedProps {
+  tenantId: string
+}
+
+const TopologyFeed = ({ tenantId }: TopologyFeedProps) => {
+  const [form, setForm] = useState<TopologyFeedFormState>(emptyForm)
+  const [originalForm, setOriginalForm] =
+    useState<TopologyFeedFormState>(emptyForm)
+
+  const { data: feedData, isLoading } = useGetTopologyFeedQuery(
+    tenantId,
+    !!tenantId,
+  )
+  const updateMutation = useUpdateTopologyFeedMutation()
+
+  useEffect(() => {
+    if (feedData) {
+      const loaded: TopologyFeedFormState = {
+        type: feedData.type || '',
+        feed_url: feedData.feed_url || '',
+        feed_service_groups: feedData.feed_service_groups || '',
+        feed_service_endpoints: feedData.feed_service_endpoints || '',
+        feed_service_endpoints_extensions:
+          feedData.feed_service_endpoints_extensions || '',
+      }
+      setForm(loaded)
+      setOriginalForm(loaded)
+    }
+  }, [feedData])
+
+  const isDirty = JSON.stringify(form) !== JSON.stringify(originalForm)
+
+  const handleTypeChange = (value: string) => {
+    setForm({
+      type: value,
+      feed_url: '',
+      feed_service_groups: '',
+      feed_service_endpoints: '',
+      feed_service_endpoints_extensions: '',
+    })
+  }
+
+  const handleFieldChange = (
+    field: keyof Omit<TopologyFeedFormState, 'type'>,
+    value: string,
+  ) => {
+    setForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleSubmit = () => {
+    const submittedForm = form
+    updateMutation.mutate(
+      { tenantId, data: buildFeedPayload(submittedForm) },
+      {
+        onSuccess: () => {
+          setOriginalForm(submittedForm)
+          toast.success('Topology feed updated successfully!')
+        },
+        onError: (err) => {
+          toast.error(`Failed to update topology feed: ${err.message}`)
+        },
+      },
+    )
+  }
+
+  return (
+    <div>
+      <div className="flex justify-end mb-3">
+        <Button
+          variant="primary"
+          size="md"
+          onClick={handleSubmit}
+          disabled={
+            updateMutation.isPending || isLoading || !form.type || !isDirty
+          }
+        >
+          {updateMutation.isPending ? (
+            <>
+              <LoadingSpinner size="xs" />
+              Saving...
+            </>
+          ) : (
+            'Save'
+          )}
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="loading-container">
+          <LoadingSpinner size="md" />
+        </div>
+      ) : (
+        <div className={sectionClass}>
+          <div>
+            <p className="section-title">Topology Feed</p>
+            <p className="section-description">
+              Feed configuration for topology data
+            </p>
+          </div>
+          <div className={sectionContentClass}>
+            <div className={fieldGridClass}>
+              <div className="flex flex-col">
+                <label className={labelClass}>
+                  Type <span className="required">*</span>
+                </label>
+                <SelectDropdown
+                  value={form.type}
+                  onChange={handleTypeChange}
+                  options={
+                    originalForm.type
+                      ? FEED_TYPE_OPTIONS
+                      : [NONE_OPTION, ...FEED_TYPE_OPTIONS]
+                  }
+                  placeholder="Select feed type"
+                />
+              </div>
+            </div>
+
+            {form.type === 'CSV' && (
+              <div className={fieldGridClass}>
+                <div className="flex flex-col">
+                  <label className={labelClass}>URL</label>
+                  <input
+                    type="url"
+                    value={form.feed_url}
+                    onChange={(e) =>
+                      handleFieldChange('feed_url', e.target.value)
+                    }
+                    placeholder="Enter feed URL"
+                  />
+                </div>
+              </div>
+            )}
+
+            {form.type === 'eosc-service-catalog' && (
+              <div className={fieldGridClass}>
+                <div className="flex flex-col">
+                  <label className={labelClass}>Service Groups URL</label>
+                  <input
+                    type="url"
+                    value={form.feed_service_groups}
+                    onChange={(e) =>
+                      handleFieldChange('feed_service_groups', e.target.value)
+                    }
+                    placeholder="Enter service groups feed URL"
+                  />
+                </div>
+                <div className="flex flex-col">
+                  <label className={labelClass}>Service Endpoints URL</label>
+                  <input
+                    type="url"
+                    value={form.feed_service_endpoints}
+                    onChange={(e) =>
+                      handleFieldChange(
+                        'feed_service_endpoints',
+                        e.target.value,
+                      )
+                    }
+                    placeholder="Enter service endpoints feed URL"
+                  />
+                </div>
+                <div className="flex flex-col">
+                  <label className={labelClass}>
+                    Service Endpoint Extensions URL
+                  </label>
+                  <input
+                    type="url"
+                    value={form.feed_service_endpoints_extensions}
+                    onChange={(e) =>
+                      handleFieldChange(
+                        'feed_service_endpoints_extensions',
+                        e.target.value,
+                      )
+                    }
+                    placeholder="Enter service endpoint extensions feed URL"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default TopologyFeed

--- a/src/pages/tenant-topology/TopologyGroups.tsx
+++ b/src/pages/tenant-topology/TopologyGroups.tsx
@@ -53,7 +53,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
     dateInput,
     committedDate,
     showActions,
-    isExternal,
+    isInternal,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,
@@ -149,7 +149,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
             ]}
             className="w-36"
           />
-          {!isExternal && (
+          {isInternal && (
             <Button
               size="md"
               variant="primary"

--- a/src/pages/tenant-topology/hooks/useTopologyListState.ts
+++ b/src/pages/tenant-topology/hooks/useTopologyListState.ts
@@ -40,10 +40,10 @@ export const useTopologyListState = <TSort extends string>({
     tenant?.id ?? '',
     !!tenant?.id,
   )
-  const isExternal = topologyFeedData?.type === 'external'
+  const isInternal = topologyFeedData?.type === 'internal'
 
   const showActions =
-    !isExternal &&
+    isInternal &&
     (dateMode === 'latest' ||
       (dateMode === 'custom' && committedDate === latestDate && !!latestDate))
 
@@ -88,7 +88,7 @@ export const useTopologyListState = <TSort extends string>({
     dateInput,
     committedDate,
     showActions,
-    isExternal,
+    isInternal,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,


### PR DESCRIPTION
This PR handles the case where topology feed configuration was sent before the tenant was fully initialized by moving it out of the tenant creation form into a dedicated tab on the Topology page.

- Moved topology feed configuration out of the tenant creation form into a dedicated tab on the Topology page
- Restricted endpoint and group actions to tenants with internal feed type only