### PR TITLE
[ARGO-5608] - Add Topology Feed shortcut and improve feed configuration layout

### DIFF
--- a/src/pages/create-tenant/CreateTenant.tsx
+++ b/src/pages/create-tenant/CreateTenant.tsx
@@ -353,6 +353,8 @@ const CreateTenant = () => {
                 metadata={metadata}
                 onMetadataChange={setMetadata}
                 onValidationChange={setHasMetadataValidationError}
+                isEditMode={isEditMode}
+                tenantId={tenantId}
               />
             </div>
           </form>

--- a/src/pages/create-tenant/InfrastructureMetadata.tsx
+++ b/src/pages/create-tenant/InfrastructureMetadata.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import { useGetUserContactTypes } from '@/hooks/useTenants'
 import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid'
+import { Link } from 'react-router-dom'
+import { Info } from 'lucide-react'
 import SelectDropdown from '@/components/SelectDropdown'
 import FormField from './FormField'
 
@@ -30,12 +32,16 @@ interface InfrastructureMetadataProps {
     internalLists: Array<{ email: string; type: string }>
   }) => void
   onValidationChange?: (hasError: boolean) => void
+  isEditMode?: boolean
+  tenantId?: string
 }
 
 const InfrastructureMetadata = ({
   metadata,
   onMetadataChange,
   onValidationChange,
+  isEditMode,
+  tenantId,
 }: InfrastructureMetadataProps) => {
   const [errors, setErrors] = useState(() => ({
     uiUrl: '',
@@ -271,6 +277,32 @@ const InfrastructureMetadata = ({
           ))}
         </div>
       </div>
+
+      {isEditMode && tenantId && (
+        <div className={sectionClass}>
+          <div className="pt-2 pl-2">
+            <h2 className="section-title">Topology Feed</h2>
+            <p className="section-description">
+              Topology data source configuration
+            </p>
+          </div>
+          <div className={sectionContentClass}>
+            <div className="flex items-center gap-1.5">
+              <Info className="size-4.5 text-muted flex-shrink-0" />
+              <p className="text-sm text-muted m-0">
+                The topology feed can be configured on the{' '}
+                <Link
+                  to={`/tenants/${tenantId}/topology#feed-configuration`}
+                  className="text-brand font-medium hover:text-brand-strong hover:underline"
+                >
+                  Configure Topology Feed
+                </Link>{' '}
+                page.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   )
 }

--- a/src/pages/tenant-topology/TopologyFeed.tsx
+++ b/src/pages/tenant-topology/TopologyFeed.tsx
@@ -60,8 +60,6 @@ const sectionClass =
 const sectionContentClass =
   'bg-surface-muted border border-line rounded-lg px-5 py-3 flex flex-col gap-2'
 const labelClass = 'text-sm font-medium text-body mb-1'
-const fieldGridClass =
-  'grid grid-cols-[repeat(auto-fit,minmax(250px,1fr))] gap-3'
 
 interface TopologyFeedProps {
   tenantId: string
@@ -163,42 +161,38 @@ const TopologyFeed = ({ tenantId }: TopologyFeedProps) => {
             </p>
           </div>
           <div className={sectionContentClass}>
-            <div className={fieldGridClass}>
-              <div className="flex flex-col">
-                <label className={labelClass}>
-                  Type <span className="required">*</span>
-                </label>
-                <SelectDropdown
-                  value={form.type}
-                  onChange={handleTypeChange}
-                  options={
-                    originalForm.type
-                      ? FEED_TYPE_OPTIONS
-                      : [NONE_OPTION, ...FEED_TYPE_OPTIONS]
-                  }
-                  placeholder="Select feed type"
-                />
-              </div>
+            <div className="flex flex-col">
+              <label className={labelClass}>
+                Type <span className="required">*</span>
+              </label>
+              <SelectDropdown
+                value={form.type}
+                onChange={handleTypeChange}
+                options={
+                  originalForm.type
+                    ? FEED_TYPE_OPTIONS
+                    : [NONE_OPTION, ...FEED_TYPE_OPTIONS]
+                }
+                placeholder="Select feed type"
+              />
             </div>
 
             {form.type === 'CSV' && (
-              <div className={fieldGridClass}>
-                <div className="flex flex-col">
-                  <label className={labelClass}>URL</label>
-                  <input
-                    type="url"
-                    value={form.feed_url}
-                    onChange={(e) =>
-                      handleFieldChange('feed_url', e.target.value)
-                    }
-                    placeholder="Enter feed URL"
-                  />
-                </div>
+              <div className="flex flex-col">
+                <label className={labelClass}>URL</label>
+                <input
+                  type="url"
+                  value={form.feed_url}
+                  onChange={(e) =>
+                    handleFieldChange('feed_url', e.target.value)
+                  }
+                  placeholder="Enter feed URL"
+                />
               </div>
             )}
 
             {form.type === 'eosc-service-catalog' && (
-              <div className={fieldGridClass}>
+              <>
                 <div className="flex flex-col">
                   <label className={labelClass}>Service Groups URL</label>
                   <input
@@ -240,7 +234,7 @@ const TopologyFeed = ({ tenantId }: TopologyFeedProps) => {
                     placeholder="Enter service endpoint extensions feed URL"
                   />
                 </div>
-              </div>
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
This PR adds a Topology Feed shortcut to the tenant edit form and improves the feed configuration input layout.

- Added Topology Feed section in edit mode with a direct link to the Feed Configuration page
- Updated topology feed input fields to full-width single column layout