### PR TITLE
[ARGO-5615] - Handle and display tenant errors when a tenant is unavailable

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -4,14 +4,17 @@ import { useAuth } from './auth/useAuth'
 import { useSelectedTenant } from '@/contexts/selected-tenant'
 import { SelectedTenantProvider } from '@/contexts/selected-tenant'
 import LoginPrompt from './components/LoginPrompt'
+import ErrorDisplay from '@/components/ErrorDisplay'
 import Sidebar from '@/components/sidebar/Sidebar'
 import MobileMenuToggle from '@/components/sidebar/MobileMenuToggle'
 
 function LayoutContent() {
   const { authenticated, isSuperAdmin, profile, logout } = useAuth()
-  const { effectiveTenantId, tenants, isTenantAdmin } = useSelectedTenant()
+  const { effectiveTenantId, tenants, isTenantAdmin, tenant } =
+    useSelectedTenant()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const tDetsRoute = useMatch('/tenants/:id/details')
+  const tenantRoute = useMatch('/tenants/:id/*')
 
   return (
     <div className="h-screen flex overflow-hidden">
@@ -35,9 +38,15 @@ function LayoutContent() {
 
       <main className="flex-1 bg-white overflow-auto">
         <div
-          className={`${tDetsRoute ? '' : 'container mx-2 md:mx-auto py-2 px-4 md:px-6'}`}
+          className={`${tDetsRoute && !tenant?.error ? '' : 'container mx-2 md:mx-auto py-2 px-4 md:px-6'}`}
         >
-          <Outlet />
+          {tenantRoute && tenant?.error ? (
+            <div className="py-6 px-16 md:px-24">
+              <ErrorDisplay error={new Error(tenant.error)} context="tenant" />
+            </div>
+          ) : (
+            <Outlet />
+          )}
         </div>
       </main>
     </div>

--- a/src/components/sidebar/TenantPicker.tsx
+++ b/src/components/sidebar/TenantPicker.tsx
@@ -88,7 +88,12 @@ export default function TenantPicker({
                 image={tenant.info.image}
                 size="sm"
               />
-              <span className="truncate">{tenant.info.name}</span>
+              <span className="truncate flex-1 min-w-0">
+                {tenant.info.name}
+              </span>
+              {tenant.error && (
+                <span className="size-2 rounded-full bg-red-500 flex-shrink-0" />
+              )}
             </Link>
           ))
         )}

--- a/src/types/tenants.ts
+++ b/src/types/tenants.ts
@@ -84,6 +84,7 @@ export type Tenant = {
   status?: TenantStatus
   node?: boolean
   ['group-status']?: 'UNKNOWN' | 'NOT_FOUND' | 'EXISTS'
+  error?: string
 }
 
 export type TenantList = {


### PR DESCRIPTION
This PR handles tenant errors returned by the backend and displays them across the UI when a tenant is currently unavailable.

- Added red dot indicator next to errored tenants in the sidebar tenant selector dropdown
- Replaced page content with the API error message for all tenant-related pages when an unavailable tenant is selected
- Added error field to the Tenant type to support the optional error from the API response