### PR TITLE
[ARGO-5617] - Make deletion confirmation prompt for tenant more safeguarded

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import { XMarkIcon } from '@heroicons/react/16/solid'
 import Button from '@/components/Button'
 
@@ -7,6 +8,9 @@ type ConfirmDialogProps = {
   message: string | React.ReactNode
   confirmLabel?: string
   cancelLabel?: string
+  typeToConfirm?: string
+  confirmSuffix?: string
+  closeOnClickOutside?: boolean
   onConfirm: () => void
   onCancel: () => void
 }
@@ -17,15 +21,27 @@ const ConfirmDialog = ({
   message,
   confirmLabel = 'Yes',
   cancelLabel = 'No',
+  typeToConfirm,
+  confirmSuffix = 'to confirm:',
+  closeOnClickOutside = true,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) => {
+  const [typedValue, setTypedValue] = useState('')
+
+  useEffect(() => {
+    if (!isOpen) setTypedValue('')
+  }, [isOpen])
+
   if (!isOpen) return null
+
+  const isConfirmDisabled =
+    typeToConfirm !== undefined && typedValue !== typeToConfirm
 
   return (
     <div
       className="fixed inset-0 bg-black/50 flex items-center justify-center z-[1000] p-4"
-      onClick={onCancel}
+      onClick={closeOnClickOutside ? onCancel : undefined}
     >
       <div
         className="bg-white rounded-lg shadow-xl max-w-[30rem] w-full overflow-hidden mb-32"
@@ -52,13 +68,32 @@ const ConfirmDialog = ({
               {message}
             </div>
           )}
+
+          {typeToConfirm && (
+            <div className="mt-3">
+              <p className="text-sm text-muted mb-1.5">
+                Type <strong>{typeToConfirm}</strong> {confirmSuffix}
+              </p>
+              <input
+                type="text"
+                value={typedValue}
+                onChange={(e) => setTypedValue(e.target.value)}
+                autoFocus
+              />
+            </div>
+          )}
         </div>
 
         <div className="flex justify-between gap-6 px-5 py-3 mt-2 bg-surface-muted border-t border-line">
           <Button onClick={onCancel} size="sm" variant="outline-secondary">
             {cancelLabel}
           </Button>
-          <Button onClick={onConfirm} size="sm" variant="primary">
+          <Button
+            onClick={onConfirm}
+            size="sm"
+            variant="primary"
+            disabled={isConfirmDisabled}
+          >
             {confirmLabel}
           </Button>
         </div>

--- a/src/pages/administration/TenantManagementTab.tsx
+++ b/src/pages/administration/TenantManagementTab.tsx
@@ -132,7 +132,8 @@ const TenantManagementTab = () => {
           tenantToDelete ? (
             <>
               Are you sure you want to delete tenant{' '}
-              <strong>{tenantToDelete.name}</strong> ?
+              <strong>{tenantToDelete.name}</strong>
+              ?
               <br />
               <span className="text-amber-600 font-medium">
                 This action cannot be undone.
@@ -144,6 +145,9 @@ const TenantManagementTab = () => {
         }
         confirmLabel="Delete"
         cancelLabel="Cancel"
+        typeToConfirm={tenantToDelete?.name}
+        confirmSuffix="to confirm the deletion of this tenant:"
+        closeOnClickOutside={false}
         onConfirm={handleDeleteConfirm}
         onCancel={handleDeleteCancel}
       />


### PR DESCRIPTION
This PR makes the tenant deletion flow safer by requiring the admin to type the tenant name in a confirmation input before the deletion can proceed.

- Added a name confirmation step to the delete dialog that keeps the confirm button disabled until the correct tenant name is entered
- Extended the confirm dialog component with new props to support confirmation input
