### PR TITLE
[ARGO-5630] - Add error indicator to tenant cards in Administration panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ function App() {
                   }
                 />
                 <Route
-                  path="tenants/edit/:id"
+                  path="tenants/:id/edit"
                   element={
                     <AuthProtected>
                       <CreateTenant />

--- a/src/index.css
+++ b/src/index.css
@@ -24,8 +24,8 @@
 
   /* Custom animations */
   --animate-fade-in: fade-in 0.3s ease;
-  --animate-pulse-ring: pulse-ring 3s cubic-bezier(0.3, 0, 0.5, 1) infinite;
-  --animate-pulse-dot: pulse-dot 3s cubic-bezier(0.3, 0, 0.5, 1) infinite;
+  --animate-pulse-ring: pulse-ring 2.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+  --animate-pulse-dot: pulse-dot 2.5s cubic-bezier(0, 0, 0.2, 1) infinite;
 }
 
 /* Global element defaults */
@@ -152,25 +152,24 @@
 }
 
 @keyframes pulse-ring {
-  0%,
-  100% {
-    box-shadow: 0 0 0 6px
-      color-mix(in srgb, var(--color-brand) 15%, transparent);
+  0% {
+    transform: scale(1.1);
+    opacity: 0.5;
   }
-  50% {
-    box-shadow: 0 0 0 10px
-      color-mix(in srgb, var(--color-brand) 20%, transparent);
+  100% {
+    transform: scale(2);
+    opacity: 0.2;
   }
 }
 
 @keyframes pulse-dot {
-  0%,
-  100% {
+  0% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1);
-  }
-  50% {
-    opacity: 0.7;
     transform: translate(-50%, -50%) scale(1.2);
+  }
+  75%,
+  100% {
+    opacity: 0.8;
+    transform: translate(-50%, -50%) scale(1);
   }
 }

--- a/src/pages/administration/TenantCardFooter.tsx
+++ b/src/pages/administration/TenantCardFooter.tsx
@@ -36,7 +36,7 @@ const TenantCardFooter = ({
       <IconButton
         label="Edit Tenant"
         icon={<PencilSquareIcon className={actionIconClass} />}
-        href={`/tenants/edit/${tenantId}`}
+        href={`/tenants/${tenantId}/edit`}
         className="text-muted hover:bg-gray-200"
       />
     )}

--- a/src/pages/administration/TenantManagementTab.tsx
+++ b/src/pages/administration/TenantManagementTab.tsx
@@ -86,6 +86,7 @@ const TenantManagementTab = () => {
         ...tenant?.info,
         id: tenant?.id,
         status: tenant?.status,
+        error: tenant?.error,
       }))) ||
     []
 
@@ -213,6 +214,18 @@ const TenantManagementTab = () => {
                           >
                             {tenant.name}
                           </h3>
+                          {tenant.error && (
+                            <span
+                              tabIndex={0}
+                              className="tooltip tooltip-bottom shrink-0 before:whitespace-normal before:max-w-[200px] before:text-left"
+                              data-tip={tenant.error}
+                              aria-label={`Unavailable: ${tenant.error}`}
+                            >
+                              <Badge className="bg-amber-100 text-amber-700">
+                                Unavailable
+                              </Badge>
+                            </span>
+                          )}
                           {(() => {
                             const role = getRoleForTenant(tenant.name)
                             return role ? (

--- a/src/pages/tenant-details/TenantDetails.tsx
+++ b/src/pages/tenant-details/TenantDetails.tsx
@@ -192,7 +192,7 @@ const TenantDetails = () => {
             )}
 
             <Button
-              href={`/tenants/edit/${tenantId}`}
+              href={`/tenants/${tenantId}/edit`}
               size="sm"
               variant="primary"
               className="whitespace-nowrap flex-shrink-0 ml-auto self-start"

--- a/src/pages/tenant-details/TenantStatusTab.tsx
+++ b/src/pages/tenant-details/TenantStatusTab.tsx
@@ -270,7 +270,7 @@ const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
                 <div className="flex items-center gap-2">
                   <Badge
                     size="lg"
-                    className={`capitalize ${JOB_STATUS_BADGE_CLASS[job.status] ?? 'bg-surface-strong text-muted'}`}
+                    className={`capitalize shadow-sm ${JOB_STATUS_BADGE_CLASS[job.status] ?? 'bg-surface-strong text-muted'}`}
                   >
                     {job.status?.toLowerCase()}
                   </Badge>
@@ -294,7 +294,7 @@ const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
                               <div
                                 className={`w-7 h-7 rounded-full border-2 transition-all relative flex items-center justify-center ${
                                   stepStatus === 'active'
-                                    ? 'border-blue-500 bg-blue-500 animate-pulse-ring'
+                                    ? 'border-blue-500 bg-blue-500'
                                     : stepStatus === 'completed'
                                       ? 'border-emerald-500 bg-emerald-500'
                                       : stepStatus === 'failed'
@@ -303,7 +303,10 @@ const TenantStatusTab = ({ tenantId }: TenantStatusTabProps) => {
                                 }`}
                               >
                                 {stepStatus === 'active' && (
-                                  <span className="absolute top-1/2 left-1/2 w-2 h-2 bg-white rounded-full animate-pulse-dot" />
+                                  <>
+                                    <span className="absolute inset-0 rounded-full bg-blue-500 animate-pulse-ring pointer-events-none" />
+                                    <span className="absolute top-1/2 left-1/2 w-2 h-2 bg-white rounded-full animate-pulse-dot" />
+                                  </>
                                 )}
                                 {stepStatus === 'completed' && (
                                   <span className="text-white text-sm font-bold leading-none">


### PR DESCRIPTION
This PR adds a visual indicator on tenant cards in the Administration panel when a tenant is in an error state. It also includes a minor animation improvement and a route rename.

- Added an error indicator badge to tenant cards when a tenant has an error, with a tooltip showing the full error message on hover
- Improved the pulse ring animation in the tenant status progress indicator for a more consistent visual effect
- Renamed the edit tenant route to follow the standard nested resource URL pattern (/tenants/:id/edit)