### PR TITLE
[ARGO-5642] - Improve topology tables UI and date filter controls

### DIFF
--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -58,6 +58,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
     committedDate,
     showActions,
     isInternal,
+    isExternal,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,
@@ -156,8 +157,20 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
             Add Endpoint
           </Button>
         )}
-        <div className="flex items-center gap-2 w-full xl:w-auto">
+        <div className="flex items-center gap-1.5 w-full xl:w-auto">
           <div className="hidden xl:block h-8 w-px bg-line-strong me-1" />
+          <SelectDropdown
+            value={dateMode}
+            onChange={handleDateModeChange}
+            options={[
+              {
+                value: 'latest',
+                label: latestDate ? `Latest (${latestDate})` : 'Latest',
+              },
+              { value: 'custom', label: 'Select date' },
+            ]}
+            className="w-46 shrink-0"
+          />
           {dateMode === 'custom' && (
             <input
               type="date"
@@ -167,15 +180,6 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
               className="text-sm"
             />
           )}
-          <SelectDropdown
-            value={dateMode}
-            onChange={handleDateModeChange}
-            options={[
-              { value: 'latest', label: 'Latest' },
-              { value: 'custom', label: 'Select date' },
-            ]}
-            className="w-36"
-          />
           <SelectDropdown
             value={monitoredFilter}
             onChange={(value) => {
@@ -195,7 +199,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
       <DataTable>
         <thead className="bg-surface-strong border-b border-line">
           <tr>
-            <th className={`${thBase} min-w-28`}>
+            <th className={`${thBase} w-[22%]`}>
               <SortableColumnHeader
                 isActive={sortColumn === 'service'}
                 isAscending={sortAsc}
@@ -204,8 +208,9 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
                 Service
               </SortableColumnHeader>
             </th>
-            <th className={`${thBase} min-w-40`}>URL</th>
-            <th className={`${thBase} min-w-24`}>
+            {isExternal && <th className={thBase}>Hostname</th>}
+            <th className={thBase}>URL</th>
+            <th className={`${thBase} w-[22%]`}>
               <SortableColumnHeader
                 isActive={sortColumn === 'group'}
                 isAscending={sortAsc}
@@ -214,7 +219,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
                 Group
               </SortableColumnHeader>
             </th>
-            <th className={`${thBase} min-w-24`}>
+            <th className={`${thBase} w-40`}>
               <SortableColumnHeader
                 isActive={sortColumn === 'tags.monitored'}
                 isAscending={sortAsc}
@@ -223,14 +228,16 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
                 Monitored
               </SortableColumnHeader>
             </th>
-            <th className={`${thBase} min-w-28`}>Date</th>
             {showActions && <th className={`${thBase} w-24`}>Actions</th>}
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
           {isLoading || isFetching ? (
             <tr>
-              <td colSpan={showActions ? 6 : 5} className="py-12">
+              <td
+                colSpan={4 + (isExternal ? 1 : 0) + (showActions ? 1 : 0)}
+                className="py-12"
+              >
                 <div className="flex justify-center">
                   <LoadingSpinner size="md" />
                 </div>
@@ -238,14 +245,17 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
             </tr>
           ) : error ? (
             <tr>
-              <td colSpan={showActions ? 6 : 5} className="py-6 px-12">
+              <td
+                colSpan={4 + (isExternal ? 1 : 0) + (showActions ? 1 : 0)}
+                className="py-6 px-12"
+              >
                 <ErrorDisplay error={error} context="topology endpoints" />
               </td>
             </tr>
           ) : !endpoints?.length ? (
             <tr>
               <td
-                colSpan={showActions ? 6 : 5}
+                colSpan={4 + (isExternal ? 1 : 0) + (showActions ? 1 : 0)}
                 className="text-center text-sm text-subtle italic py-6 px-12"
               >
                 No topology endpoints found
@@ -254,7 +264,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           ) : !paginated.length ? (
             <tr>
               <td
-                colSpan={showActions ? 6 : 5}
+                colSpan={4 + (isExternal ? 1 : 0) + (showActions ? 1 : 0)}
                 className="text-center text-sm text-subtle italic py-6 px-12"
               >
                 No endpoints match your filters
@@ -267,6 +277,13 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
                 className="hover:bg-surface-muted transition-colors"
               >
                 <td className={tdBase}>{endpoint.service}</td>
+                {isExternal && (
+                  <td className={`${tdBase} font-mono text-xs break-all`}>
+                    {endpoint.hostname || (
+                      <span className="pl-2 text-subtle">-</span>
+                    )}
+                  </td>
+                )}
                 <td className={`${tdBase} font-mono text-xs break-all`}>
                   {endpoint.tags?.info_URL || (
                     <span className="pl-2 text-subtle">-</span>
@@ -289,7 +306,6 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
                     </Badge>
                   ) : null}
                 </td>
-                <td className={tdBase}>{endpoint.date}</td>
                 {showActions && (
                   <td className={`${tdBase} whitespace-nowrap`}>
                     <div className="flex items-center gap-1">

--- a/src/pages/tenant-topology/TopologyGroups.tsx
+++ b/src/pages/tenant-topology/TopologyGroups.tsx
@@ -130,7 +130,19 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
             className="!mb-0 w-full"
           />
         </div>
-        <div className="flex items-center gap-3 shrink-0">
+        <div className="flex items-center gap-1.5 shrink-0">
+          <SelectDropdown
+            value={dateMode}
+            onChange={handleDateModeChange}
+            options={[
+              {
+                value: 'latest',
+                label: latestDate ? `Latest (${latestDate})` : 'Latest',
+              },
+              { value: 'custom', label: 'Select date' },
+            ]}
+            className="w-46 shrink-0"
+          />
           {dateMode === 'custom' && (
             <input
               type="date"
@@ -140,15 +152,6 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
               className="text-sm"
             />
           )}
-          <SelectDropdown
-            value={dateMode}
-            onChange={handleDateModeChange}
-            options={[
-              { value: 'latest', label: 'Latest' },
-              { value: 'custom', label: 'Select date' },
-            ]}
-            className="w-36"
-          />
           {isInternal && (
             <Button
               size="md"
@@ -175,14 +178,13 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
               </SortableColumnHeader>
             </th>
             <th className={`${thBase}`}>Contacts</th>
-            <th className={`${thBase} w-44`}>Date</th>
             {showActions && <th className={`${thBase} w-30`}>Actions</th>}
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
           {isLoading || isFetching ? (
             <tr>
-              <td colSpan={showActions ? 4 : 3} className="py-12">
+              <td colSpan={showActions ? 3 : 2} className="py-12">
                 <div className="flex justify-center">
                   <LoadingSpinner size="md" />
                 </div>
@@ -190,14 +192,14 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
             </tr>
           ) : error ? (
             <tr>
-              <td colSpan={showActions ? 4 : 3} className="py-6 px-12">
+              <td colSpan={showActions ? 3 : 2} className="py-6 px-12">
                 <ErrorDisplay error={error} context="topology groups" />
               </td>
             </tr>
           ) : !groups?.length ? (
             <tr>
               <td
-                colSpan={showActions ? 4 : 3}
+                colSpan={showActions ? 3 : 2}
                 className="text-center text-sm text-subtle italic py-6 px-12"
               >
                 No topology groups found
@@ -206,7 +208,7 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
           ) : !paginated.length ? (
             <tr>
               <td
-                colSpan={showActions ? 4 : 3}
+                colSpan={showActions ? 3 : 2}
                 className="text-center text-sm text-subtle italic py-6 px-12"
               >
                 No groups match your filters
@@ -233,7 +235,6 @@ const TopologyGroups = ({ tenantId, onEdit }: TopologyGroupsProps) => {
                     <span className="ms-7">-</span>
                   )}
                 </td>
-                <td className={tdBase}>{group.date}</td>
                 {showActions && (
                   <td className={`${tdBase} whitespace-nowrap`}>
                     <div className="flex items-center gap-1">

--- a/src/pages/tenant-topology/hooks/useTopologyListState.ts
+++ b/src/pages/tenant-topology/hooks/useTopologyListState.ts
@@ -41,6 +41,7 @@ export const useTopologyListState = <TSort extends string>({
     !!tenant?.id,
   )
   const isInternal = topologyFeedData?.type === 'internal'
+  const isExternal = topologyFeedData?.type === 'external'
 
   const showActions =
     isInternal &&
@@ -89,6 +90,7 @@ export const useTopologyListState = <TSort extends string>({
     committedDate,
     showActions,
     isInternal,
+    isExternal,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,


### PR DESCRIPTION
This PR improves the topology endpoints and groups tables with UI updates to the date filtering controls and table layout.

- Removed the date column from both topology tables and moved the latest date value into the date mode dropdown
- Added a hostname column to the endpoints table when the feed type is external