### PR TITLE
[ARGO-5634] - Refresh topology caches when topology feed is changed

### DIFF
--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -728,6 +728,15 @@ export const useUpdateTopologyFeedMutation = () => {
       queryClient.invalidateQueries({
         queryKey: ['topology-feed', variables.tenantId],
       })
+      queryClient.invalidateQueries({
+        queryKey: ['topology-endpoints', variables.tenantId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['topology-groups', variables.tenantId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['user-tenant-status', variables.tenantId],
+      })
     },
     onError: (error) => {
       console.error('Update topology feed error:', error)


### PR DESCRIPTION
This PR fixes a stale UI issue where topology data was not refreshing after a feed type change.