### PR TITLE
WIP - [ARGO-5639] - Display structured memberships in member management views

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -40,7 +40,7 @@ const tenantNavItems: TenantNavItem[] = [
     path: 'topology',
     label: 'Topology',
     icon: ChartNetwork,
-    requiredRoles: ['admin'],
+    requiredRoles: ['tenant_admin'],
   },
   { path: 'status-pages', label: 'Status Pages', icon: RectangleStackIcon },
   { path: 'reports', label: 'Reports', icon: DocumentChartBarIcon },
@@ -49,7 +49,7 @@ const tenantNavItems: TenantNavItem[] = [
     path: 'members',
     label: 'Members',
     icon: UsersIcon,
-    requiredRoles: ['admin'],
+    requiredRoles: ['tenant_admin'],
   },
 ]
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -145,7 +145,7 @@ export const Profile = () => {
     : profile?.email || 'Not available'
 
   const currentGroups = isViewingOtherUser
-    ? displayProfile?.tenants || []
+    ? displayProfile?.memberships || []
     : profile?.groups || []
 
   const filteredGroups = currentGroups.filter(

--- a/src/pages/administration/TenantManagementTab.tsx
+++ b/src/pages/administration/TenantManagementTab.tsx
@@ -67,7 +67,7 @@ const TenantManagementTab = () => {
     const group = userProfileData?.groups?.find(
       (g: UserGroup) => g?.name === tenantName,
     )
-    return group?.role === 'admin'
+    return group?.role === 'tenant_admin'
   }
 
   useEffect(() => {

--- a/src/pages/administration/UsersTab.tsx
+++ b/src/pages/administration/UsersTab.tsx
@@ -10,7 +10,12 @@ import Pagination from '@/components/Pagination'
 import IconButton from '@/components/IconButton'
 import { squishEmail } from '@/utils/profile'
 
-type SortColumn = 'username' | 'firstName' | 'lastName' | 'email' | 'tenants'
+type SortColumn =
+  | 'username'
+  | 'firstName'
+  | 'lastName'
+  | 'email'
+  | 'memberships'
 type SortDirection = 'asc' | 'desc'
 
 const pageSize = 10
@@ -84,9 +89,9 @@ const UsersTab = () => {
         let aValue: string | number
         let bValue: string | number
 
-        if (sortColumn === 'tenants') {
-          aValue = a.tenants?.length || 0
-          bValue = b.tenants?.length || 0
+        if (sortColumn === 'memberships') {
+          aValue = a.memberships?.length || 0
+          bValue = b.memberships?.length || 0
         } else {
           aValue = a[sortColumn]?.toLowerCase() || ''
           bValue = b[sortColumn]?.toLowerCase() || ''
@@ -177,9 +182,9 @@ const UsersTab = () => {
                   </th>
                   <th className={`${thBase} w-[25%]`}>
                     <SortableColumnHeader
-                      isActive={sortColumn === 'tenants'}
+                      isActive={sortColumn === 'memberships'}
                       isAscending={sortDirection === 'asc'}
-                      onClick={() => handleSort('tenants')}
+                      onClick={() => handleSort('memberships')}
                     >
                       Tenants
                     </SortableColumnHeader>
@@ -216,8 +221,8 @@ const UsersTab = () => {
                     </td>
                     <td className="px-4 py-3 break-words text-sm">
                       <div className="flex flex-wrap gap-1.5">
-                        {user.tenants && user.tenants.length > 0 ? (
-                          user.tenants.map((tenant, index) => (
+                        {user.memberships && user.memberships.length > 0 ? (
+                          user.memberships.map((tenant, index) => (
                             <TenantBadge
                               key={index}
                               name={tenant.name}

--- a/src/pages/manage-tenant-members/MembersTab.tsx
+++ b/src/pages/manage-tenant-members/MembersTab.tsx
@@ -107,7 +107,9 @@ const MembersTab = ({ tenantId, tenantName }: MembersTabProps) => {
                 {membersData?.content && membersData.content.length > 0 ? (
                   membersData.content.flatMap((member) => {
                     const tenantRoles =
-                      member.tenants?.filter((t) => t.name === tenantName) ?? []
+                      member.memberships?.filter(
+                        (t) => t.name === tenantName,
+                      ) ?? []
                     return tenantRoles.map((tenantInfo) => (
                       <tr
                         key={`${member.id}-${tenantInfo.role}`}

--- a/src/pages/tenant-capabilities/TenantCapabilities.tsx
+++ b/src/pages/tenant-capabilities/TenantCapabilities.tsx
@@ -14,7 +14,8 @@ const TenantCapabilities = () => {
   const { isSuperAdmin } = useAuth()
   const { tenant, isTenantLoading, tenantError, roleInSelectedTenant } =
     useSelectedTenant()
-  const canConfigureNode = isSuperAdmin || roleInSelectedTenant === 'admin'
+  const canConfigureNode =
+    isSuperAdmin || roleInSelectedTenant === 'tenant_admin'
 
   const {
     data: reports,

--- a/src/types/tenants.ts
+++ b/src/types/tenants.ts
@@ -111,7 +111,7 @@ export type Member = {
   firstName: string
   lastName: string
   email: string
-  tenants?: TenantMembership[]
+  memberships?: TenantMembership[]
 }
 
 export type PaginatedMembersResponse = {
@@ -132,6 +132,8 @@ export type ReportListItem = {
   updated_at: string
   node_report?: boolean
 }
+
+export type PublicReportItem = { id: string; name: string }
 
 export type ReportProfile = {
   id: string


### PR DESCRIPTION
This PR aligns with the memberships field rename in the /v1/admin/members and /v1/tenants/{id}/members API responses.

- Updated the Member type to use memberships instead of tenants for the array of tenant role assignments
- Updated all consumer pages (user administration, tenant members tab, user profile) to reference the renamed field
