### PR TITLE
[ARGO-5641] - Support public dashboards for tenants that have public reports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,10 +24,11 @@ import {
   CreateTopologyEndpoint,
   CreateTopologyGroup,
 } from './pages/tenant-topology'
+import PrivateDashboardContainer from './pages/dashboard'
+import PublicDashboard from './pages/public-dashboard'
 import { AuthProvider } from './auth/AuthProvider'
 import NotFound from './pages/NotFound'
 import { Toaster } from 'sonner'
-import Dashboard from '@/pages/Dashboard'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -66,6 +67,10 @@ function App() {
         <BrowserRouter>
           <Routes>
             <Route path="status/:slug" element={<PublicStatusPage />} />
+            <Route
+              path="public/tenants/:tenantName/dashboard"
+              element={<PublicDashboard />}
+            />
             <Route element={<AuthLayout />}>
               <Route path="invitation/:id" element={<InvitationReview />} />
               <Route element={<Layout />}>
@@ -114,7 +119,7 @@ function App() {
                   path="tenants/:id/dashboard"
                   element={
                     <AuthProtected>
-                      <Dashboard />
+                      <PrivateDashboardContainer />
                     </AuthProtected>
                   }
                 />

--- a/src/api/data.ts
+++ b/src/api/data.ts
@@ -30,8 +30,8 @@ export const fetchGroupsApi = async (
 }
 
 export const fetchResultsGroups = async (
-  tenantId: string,
-  token: string,
+  tenantIdentifier: string,
+  token: string | undefined,
   report?: string,
   item?: string,
   period?: string,
@@ -41,14 +41,18 @@ export const fetchResultsGroups = async (
   if (period) params.set('period', period)
 
   const query = params.toString()
+  const base = token
+    ? `${BACKEND_API}/v1/tenants/${tenantIdentifier}/results/groups`
+    : `${BACKEND_API}/v1/public/tenants/${tenantIdentifier}/results/groups`
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+
   const response = await fetch(
-    `${BACKEND_API}/v1/tenants/${tenantId}/results/groups${item ? `/${item}` : ''}${query ? `?${query}` : ''}`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-    },
+    `${base}${item ? `/${item}` : ''}${query ? `?${query}` : ''}`,
+    { headers },
   )
 
   if (!response.ok) {
@@ -62,21 +66,23 @@ export const fetchResultsGroups = async (
 }
 
 export const fetchStatusGroups = async (
-  tenantId: string,
+  tenantIdentifier: string,
   report: string,
-  token: string,
+  token: string | undefined,
   item?: string,
 ): Promise<GroupStatusResponse> => {
+  const base = token
+    ? `${BACKEND_API}/v1/tenants/${tenantIdentifier}/status/groups`
+    : `${BACKEND_API}/v1/public/tenants/${tenantIdentifier}/status/groups`
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+
   const response = await fetch(
-    `${BACKEND_API}/v1/tenants/${tenantId}/status/groups${
-      item ? `/${item}` : ''
-    }?report=${report}`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-    },
+    `${base}${item ? `/${item}` : ''}?report=${report}`,
+    { headers },
   )
 
   if (!response.ok) {

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -5,6 +5,7 @@ import type {
   TenantList,
   PaginatedMembersResponse,
   ReportListItem,
+  PublicReportItem,
   ReportDetail,
   MetricProfileResponse,
   TenantReadinessResponse,
@@ -372,10 +373,16 @@ export const fetchTenantReports = async (
   tenantId: string,
   token: string,
   search?: string,
+  isPublic?: boolean,
 ): Promise<ReportListItem[]> => {
-  const searchParam = search ? `?search=${encodeURIComponent(search)}` : ''
+  const params = new URLSearchParams()
+  if (search) params.set('search', search)
+  if (isPublic === true || isPublic === false)
+    params.set('public', String(isPublic))
+  const queryString = params.toString() ? `?${params.toString()}` : ''
+
   const response = await fetch(
-    `${BACKEND_API}/v1/tenants/${tenantId}/reports${searchParam}`,
+    `${BACKEND_API}/v1/tenants/${tenantId}/reports${queryString}`,
     {
       method: 'GET',
       headers: {
@@ -393,6 +400,72 @@ export const fetchTenantReports = async (
   }
 
   return response.json()
+}
+
+export const fetchPublicTenantReports = async (
+  tenantName: string,
+): Promise<PublicReportItem[]> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/public/tenants/${tenantName}/reports/public`,
+    {
+      headers: { 'Content-Type': 'application/json' },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchSetReportPublic = async (
+  tenantId: string,
+  reportId: string,
+  token: string,
+): Promise<string> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/reports/${reportId}/set-public`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    throw new Error(data.message || `HTTP error! status: ${response.status}`)
+  }
+  return data.status?.message ?? ''
+}
+
+export const fetchSetReportPrivate = async (
+  tenantId: string,
+  reportId: string,
+  token: string,
+): Promise<string> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/reports/${reportId}/set-private`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    throw new Error(data.message || `HTTP error! status: ${response.status}`)
+  }
+  return data.status?.message ?? ''
 }
 
 export const fetchTenantReportById = async (

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -25,8 +25,8 @@ const ErrorDisplay = ({ error, context = 'data' }: ErrorDisplayProps) => {
 
   if (isNotFound) {
     return (
-      <div className="text-center px-8 py-3 bg-surface-muted rounded-lg">
-        <p className="text-muted text-sm italic">No {context} found</p>
+      <div className="text-center px-8 py-5 bg-surface-muted rounded-lg">
+        <p className="text-muted text-base italic">No {context} found</p>
       </div>
     )
   }

--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -16,6 +16,7 @@ import type { KeyboardEvent } from 'react'
 export interface SelectOption {
   value: string
   label: string
+  disabled?: boolean
 }
 
 interface SelectDropdownProps {
@@ -136,9 +137,21 @@ const SelectDropdown = ({
     setIsOpen(true)
   }
 
-  const handleSelect = (optionValue: string) => {
-    onChange(optionValue)
+  const handleSelect = (option: SelectOption) => {
+    if (option.disabled) return
+    onChange(option.value)
     handleClose()
+  }
+
+  const findNextEnabledIndex = (from: number, direction: 1 | -1): number => {
+    let index = from + direction
+    while (index >= 0 && index < filteredOptions.length) {
+      if (!filteredOptions[index].disabled) {
+        return index
+      }
+      index += direction
+    }
+    return from
   }
 
   const handleToggle = () => {
@@ -157,7 +170,7 @@ const SelectDropdown = ({
     if (disabled) return
     const handleActivate = () => {
       if (isOpen && activeIndexRef.current >= 0) {
-        handleSelect(filteredOptions[activeIndexRef.current].value)
+        handleSelect(filteredOptions[activeIndexRef.current])
       } else if (!isOpen) {
         openMenu()
       }
@@ -181,15 +194,13 @@ const SelectDropdown = ({
         if (!isOpen) {
           openMenu()
         } else {
-          setActiveIndex((prev) =>
-            Math.min(prev + 1, filteredOptions.length - 1),
-          )
+          setActiveIndex((prev) => findNextEnabledIndex(prev, 1))
         }
         break
       case 'ArrowUp':
         e.preventDefault()
         if (isOpen) {
-          setActiveIndex((prev) => Math.max(prev - 1, 0))
+          setActiveIndex((prev) => findNextEnabledIndex(prev, -1))
         }
         break
     }
@@ -254,22 +265,32 @@ const SelectDropdown = ({
                   No results found
                 </li>
               ) : (
-                filteredOptions.map((option, index) => (
-                  <li
-                    id={`${listboxId}-option-${index}`}
-                    key={option.value}
-                    role="option"
-                    aria-selected={option.value === value}
-                    onClick={() => handleSelect(option.value)}
-                    className={`px-4 py-1.5 mb-px last:mb-0 rounded-md text-sm cursor-pointer transition-colors ${
-                      option.value === value || index === activeIndex
-                        ? 'bg-brand-subtle text-brand font-medium'
-                        : 'text-foreground hover:bg-surface-muted'
-                    }`}
-                  >
-                    {option.label}
-                  </li>
-                ))
+                filteredOptions.map((option, index) =>
+                  option.disabled ? (
+                    <li
+                      key={option.value}
+                      role="presentation"
+                      className="px-3 pt-2.5 pb-0.5 text-xs font-semibold uppercase tracking-wider text-muted select-none cursor-default"
+                    >
+                      {option.label}
+                    </li>
+                  ) : (
+                    <li
+                      id={`${listboxId}-option-${index}`}
+                      key={option.value}
+                      role="option"
+                      aria-selected={option.value === value}
+                      onClick={() => handleSelect(option)}
+                      className={`px-4 py-1.5 mb-px last:mb-0 rounded-md text-sm cursor-pointer transition-colors ${
+                        option.value === value || index === activeIndex
+                          ? 'bg-brand-subtle text-brand font-medium'
+                          : 'text-foreground hover:bg-surface-muted'
+                      }`}
+                    >
+                      {option.label}
+                    </li>
+                  ),
+                )
               )}
             </ul>
           </div>,

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -13,7 +13,7 @@ export const useGetResultsGroups = (
   const { token } = useAuth()
 
   return useQuery<GroupResultsResponse, Error>({
-    queryKey: ['results-groups', tenantId, report, item],
+    queryKey: ['results-groups', tenantId, report, item, period],
     queryFn: () => {
       if (!token) throw new Error('No authentication token available')
       if (!tenantId) throw new Error('Tenant ID is required')
@@ -41,5 +41,40 @@ export const useGetStatusGroups = (
     },
     retry: false,
     enabled: enabled && !!token && !!tenantId,
+  })
+}
+
+export const useGetPublicResultsGroups = (
+  tenantName: string,
+  report?: string,
+  item?: string,
+  period?: string,
+  enabled: boolean = true,
+) => {
+  return useQuery<GroupResultsResponse, Error>({
+    queryKey: ['public-results-groups', tenantName, report, item, period],
+    queryFn: () => {
+      if (!tenantName) throw new Error('Tenant name is required')
+      return fetchResultsGroups(tenantName, undefined, report, item, period)
+    },
+    retry: false,
+    enabled: enabled && !!tenantName,
+  })
+}
+
+export const useGetPublicStatusGroups = (
+  tenantName: string,
+  report: string = '',
+  item?: string,
+  enabled: boolean = true,
+) => {
+  return useQuery<GroupStatusResponse, Error>({
+    queryKey: ['public-status-groups', tenantName, report, item],
+    queryFn: () => {
+      if (!tenantName) throw new Error('Tenant name is required')
+      return fetchStatusGroups(tenantName, report, undefined, item)
+    },
+    retry: false,
+    enabled: enabled && !!tenantName,
   })
 }

--- a/src/hooks/useTenants.ts
+++ b/src/hooks/useTenants.ts
@@ -21,7 +21,10 @@ import {
   removeMemberFromTenant,
   revokeInvitation,
   fetchTenantReports,
+  fetchPublicTenantReports,
   fetchTenantReportById,
+  fetchSetReportPublic,
+  fetchSetReportPrivate,
   fetchTenantMetricProfile,
   fetchTenantReadiness,
   notifyAmsCheckReadiness,
@@ -42,6 +45,7 @@ import type {
   Member,
   PaginatedMembersResponse,
   ReportListItem,
+  PublicReportItem,
   ReportDetail,
   MetricProfileResponse,
   TenantReadinessResponse,
@@ -465,12 +469,13 @@ export const useRevokeInvitation = () => {
 export const useGetTenantReports = (
   tenantId: string,
   search?: string,
+  isPublic?: boolean,
   enabled: boolean = true,
 ) => {
   const { token } = useAuth()
 
   return useQuery<ReportListItem[], Error>({
-    queryKey: ['tenant-reports', tenantId, search],
+    queryKey: ['tenant-reports', tenantId, search, isPublic],
     queryFn: () => {
       if (!token) {
         throw new Error('No authentication token available')
@@ -478,10 +483,69 @@ export const useGetTenantReports = (
       if (!tenantId) {
         throw new Error('Tenant ID is required')
       }
-      return fetchTenantReports(tenantId, token, search)
+      return fetchTenantReports(tenantId, token, search, isPublic)
     },
     retry: false,
     enabled: enabled && !!token && !!tenantId,
+  })
+}
+
+export const useGetPublicTenantReports = (
+  tenantName: string,
+  enabled: boolean = true,
+) => {
+  return useQuery<PublicReportItem[], Error>({
+    queryKey: ['public-tenant-reports', tenantName],
+    queryFn: () => {
+      if (!tenantName) throw new Error('Tenant name is required')
+      return fetchPublicTenantReports(tenantName)
+    },
+    retry: false,
+    enabled: enabled && !!tenantName,
+  })
+}
+
+export const useSetReportPublicMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<string, Error, { tenantId: string; reportId: string }>({
+    mutationFn: ({ tenantId, reportId }) => {
+      if (!token) throw new Error('No authentication token available')
+      if (!tenantId) throw new Error('Tenant ID is required')
+      if (!reportId) throw new Error('Report ID is required')
+      return fetchSetReportPublic(tenantId, reportId, token)
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['tenant-reports', variables.tenantId],
+      })
+    },
+    onError: (error) => {
+      console.error('Set report public error:', error)
+    },
+  })
+}
+
+export const useSetReportPrivateMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<string, Error, { tenantId: string; reportId: string }>({
+    mutationFn: ({ tenantId, reportId }) => {
+      if (!token) throw new Error('No authentication token available')
+      if (!tenantId) throw new Error('Tenant ID is required')
+      if (!reportId) throw new Error('Report ID is required')
+      return fetchSetReportPrivate(tenantId, reportId, token)
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['tenant-reports', variables.tenantId],
+      })
+    },
+    onError: (error) => {
+      console.error('Set report private error:', error)
+    },
   })
 }
 

--- a/src/pages/build-status-page/BuildStatusPage.tsx
+++ b/src/pages/build-status-page/BuildStatusPage.tsx
@@ -68,6 +68,7 @@ const BuildStatusPage = () => {
   const { data: reportsData, isLoading: reportsLoading } = useGetTenantReports(
     tenantId,
     undefined,
+    undefined,
     !!tenantId,
   )
   const {

--- a/src/pages/create-tenant/ContactInformation.tsx
+++ b/src/pages/create-tenant/ContactInformation.tsx
@@ -74,7 +74,7 @@ const ContactInformation = ({
   }
 
   const handleAddContact = () => {
-    if (contacts.length < 5) {
+    if (contacts.length < 10) {
       onContactsChange([...contacts, { name: '', email: '', type: '' }])
       setErrors([...errors, { email: '' }])
     }
@@ -109,7 +109,7 @@ const ContactInformation = ({
                 Contact {index + 1}
               </span>
               <div className="flex gap-2">
-                {index === contacts.length - 1 && contacts.length < 5 && (
+                {index === contacts.length - 1 && contacts.length < 10 && (
                   <button
                     type="button"
                     onClick={handleAddContact}

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useMemo, useRef, useState, useEffect, type ReactNode } from 'react'
 import {
   Activity,
   AlertOctagon,
   AlertTriangle,
+  ArrowUpRightFromSquare,
   Check,
   CheckCircle2,
   Copy,
@@ -13,12 +13,37 @@ import {
   ShieldCheck,
   type LucideIcon,
 } from 'lucide-react'
-import { useGetResultsGroups, useGetStatusGroups } from '@/hooks/useData'
-import { useGetTenantReports } from '@/hooks/useTenants'
-import { useSelectedTenant } from '@/contexts/selected-tenant/useSelectedTenant'
 import PageHeader from '@/components/PageHeader'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
+import SelectDropdown from '@/components/SelectDropdown'
+import type { SelectOption } from '@/components/SelectDropdown'
+import type { GroupResultsResponse, GroupStatusResponse } from '@/types/data'
+
+const buildReportOptions = (
+  reports: Array<{ name: string; isPublic?: boolean }> | undefined,
+): SelectOption[] => {
+  if (!reports) return []
+  const hasVisibility = reports.some((r) => r.isPublic !== undefined)
+  if (!hasVisibility)
+    return reports.map((r) => ({ value: r.name, label: r.name }))
+
+  const options: SelectOption[] = []
+  const privateReports = reports.filter((r) => r.isPublic === false)
+  const publicReports = reports.filter((r) => r.isPublic === true)
+
+  if (privateReports.length > 0) {
+    options.push({ value: 'group_private', label: 'Private', disabled: true })
+    privateReports.forEach((r) =>
+      options.push({ value: r.name, label: r.name }),
+    )
+  }
+  if (publicReports.length > 0) {
+    options.push({ value: 'group_public', label: 'Public', disabled: true })
+    publicReports.forEach((r) => options.push({ value: r.name, label: r.name }))
+  }
+  return options
+}
 
 type ServiceStatus = 'healthy' | 'degraded' | 'critical'
 
@@ -129,10 +154,10 @@ interface NowItemProps {
   icon: LucideIcon
   label: string
   last?: boolean
-  children: React.ReactNode
+  children: ReactNode
 }
 
-function NowItem({ icon: Icon, label, last, children }: NowItemProps) {
+const NowItem = ({ icon: Icon, label, last, children }: NowItemProps) => {
   return (
     <div
       className={`flex-1 min-w-[120px] px-4 py-2 ${
@@ -150,7 +175,7 @@ function NowItem({ icon: Icon, label, last, children }: NowItemProps) {
   )
 }
 
-function SectionLabel({ children }: { children: React.ReactNode }) {
+const SectionLabel = ({ children }: { children: ReactNode }) => {
   return (
     <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.08em] text-neutral-400">
       {children}
@@ -164,7 +189,7 @@ interface WeekBarProps {
   fullDate: string
 }
 
-function WeekBar({ value, day, fullDate }: WeekBarProps) {
+const WeekBar = ({ value, day, fullDate }: WeekBarProps) => {
   const h = Math.max(8, ((value - 98) / 2) * 100)
   return (
     <div
@@ -185,7 +210,7 @@ function WeekBar({ value, day, fullDate }: WeekBarProps) {
   )
 }
 
-function MiniBars({ daily, dates }: { daily: number[]; dates: string[] }) {
+const MiniBars = ({ daily, dates }: { daily: number[]; dates: string[] }) => {
   return (
     <div
       className="grid gap-[2px]"
@@ -204,14 +229,39 @@ function MiniBars({ daily, dates }: { daily: number[]; dates: string[] }) {
   )
 }
 
-export default function Dashboard() {
-  const { tenant } = useSelectedTenant()
-  const tenantName = tenant?.info?.name ?? ''
+export interface DashboardProps {
+  tenantName: string
+  tenantId?: string
+  reports: Array<{ name: string; isPublic?: boolean }> | undefined
+  reportsLoading: boolean
+  reportsError: Error | null
+  resultsData: GroupResultsResponse | undefined
+  resultsLoading: boolean
+  resultsError: Error | null
+  statusData: GroupStatusResponse | undefined
+  statusLoading: boolean
+  statusError: Error | null
+  selectedReport: string
+  onReportChange: (name: string) => void
+}
 
-  const { id: tenantId } = useParams<{ id: string }>()
+const Dashboard = ({
+  tenantName,
+  tenantId,
+  reports,
+  reportsLoading,
+  reportsError,
+  resultsData,
+  resultsLoading,
+  resultsError,
+  statusData,
+  statusLoading,
+  statusError,
+  selectedReport,
+  onReportChange,
+}: DashboardProps) => {
   const [filter, setFilter] = useState<FilterId>('all')
   const [search, setSearch] = useState('')
-  const [selectedReport, setSelectedReport] = useState('')
   const [copied, setCopied] = useState(false)
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -223,41 +273,12 @@ export default function Dashboard() {
     }
   }, [])
 
-  const {
-    data: reports,
-    isLoading: reportsLoading,
-    error: reportsError,
-  } = useGetTenantReports(tenantId ?? '')
-
-  // Pick the first report once it loads; reset if the current one disappears.
-  useEffect(() => {
-    if (!reports || reports.length === 0) return
-    const stillValid = reports.some((r) => r.name === selectedReport)
-    if (!stillValid) setSelectedReport(reports[0].name)
-  }, [reports, selectedReport])
-
-  const {
-    data: resultsData,
-    isLoading: resultsLoading,
-    error: resultsError,
-  } = useGetResultsGroups(
-    tenantId ?? '',
-    selectedReport,
-    undefined,
-    '1w',
-    !!selectedReport,
-  )
-
-  const {
-    data: statusData,
-    isLoading: statusLoading,
-    error: statusError,
-  } = useGetStatusGroups(
-    tenantId ?? '',
-    selectedReport,
-    undefined,
-    !!selectedReport,
-  )
+  const handleCopyTenantId = () => {
+    if (!tenantId) return
+    void navigator.clipboard?.writeText(tenantId)
+    setCopied(true)
+    copyTimerRef.current = setTimeout(() => setCopied(false), 1500)
+  }
 
   const services = useMemo<Service[]>(() => {
     if (!resultsData?.data) return []
@@ -376,16 +397,10 @@ export default function Dashboard() {
     { id: 'healthy', label: 'Healthy', count: null },
   ]
 
-  if (!tenantId) {
-    return (
-      <div className="page-container">
-        <p className="text-sm text-muted">No tenant selected.</p>
-      </div>
-    )
-  }
-
   const noData =
-    !reports?.length || !resultsData?.data?.length || !statusData?.data?.length
+    !reportsLoading &&
+    (!reports?.length ||
+      (!resultsData?.data?.length && !statusData?.data?.length))
 
   return (
     <div className="page-container">
@@ -393,58 +408,68 @@ export default function Dashboard() {
         title="Dashboard"
         subtitle={
           tenantName ? (
-            <span className="inline-flex items-center gap-2 flex-wrap">
+            <span className="inline-flex items-center gap-x-2 gap-y-0.5 flex-wrap">
               <span>
                 Overview for <strong>{tenantName}</strong>
+                {reports?.length === 1 && selectedReport && (
+                  <>
+                    {' · '}
+                    <strong>{selectedReport}</strong> report
+                  </>
+                )}
               </span>
-              <span className="inline-flex items-center gap-1 font-mono text-xs text-subtle">
-                <span title={tenantId}>{tenantId}</span>
-                <button
-                  type="button"
-                  onClick={() => {
-                    void navigator.clipboard?.writeText(tenantId)
-                    setCopied(true)
-                    copyTimerRef.current = setTimeout(
-                      () => setCopied(false),
-                      1500,
-                    )
-                  }}
-                  className={`flex-shrink-0 rounded p-0.5 transition-colors ${
-                    copied
-                      ? 'bg-emerald-100 text-emerald-700'
-                      : 'text-subtle hover:bg-surface-strong hover:text-body'
-                  }`}
-                  aria-label={copied ? 'Copied' : 'Copy tenant ID'}
-                  title={copied ? 'Copied!' : 'Copy tenant ID'}
-                >
-                  {copied ? (
-                    <Check className="h-3 w-3" strokeWidth={2.5} />
-                  ) : (
-                    <Copy className="h-3 w-3" strokeWidth={2} />
-                  )}
-                </button>
-              </span>
+              {tenantId && (
+                <span className="inline-flex items-center gap-1 font-mono text-xs text-subtle">
+                  <span title={tenantId}>{tenantId}</span>
+                  <button
+                    type="button"
+                    onClick={handleCopyTenantId}
+                    className={`flex-shrink-0 rounded p-0.5 transition-colors ${
+                      copied
+                        ? 'bg-emerald-100 text-emerald-700'
+                        : 'text-subtle hover:bg-surface-strong hover:text-body'
+                    }`}
+                    aria-label={copied ? 'Copied' : 'Copy tenant ID'}
+                    title={copied ? 'Copied!' : 'Copy tenant ID'}
+                  >
+                    {copied ? (
+                      <Check className="h-3 w-3" strokeWidth={2.5} />
+                    ) : (
+                      <Copy className="h-3 w-3" strokeWidth={2} />
+                    )}
+                  </button>
+                </span>
+              )}
             </span>
           ) : undefined
         }
-        className="mb-2"
+        className="items-start mb-4"
       >
         {hasMultipleReports && (
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-semibold text-body">
-              Select a report:
-            </span>
-            <select
-              value={selectedReport}
-              onChange={(e) => setSelectedReport(e.target.value)}
-              className="max-w-[220px] truncate rounded-md border border-line-strong bg-white py-2 pl-3 pr-8 text-sm font-medium text-foreground shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand-subtle"
-            >
-              {reports?.map((r) => (
-                <option key={r.name} value={r.name}>
-                  {r.name}
-                </option>
-              ))}
-            </select>
+          <div className="flex flex-col items-stretch gap-1">
+            <div className="flex items-center gap-2">
+              <span className="text-[15px] font-semibold text-body">
+                Select a report:
+              </span>
+              <SelectDropdown
+                value={selectedReport}
+                onChange={onReportChange}
+                options={buildReportOptions(reports)}
+                className="w-[220px]"
+              />
+            </div>
+            {reports?.find((r) => r.name === selectedReport)?.isPublic ===
+              true && (
+              <a
+                href={`/public/tenants/${encodeURIComponent(tenantName)}/dashboard#${encodeURIComponent(selectedReport)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="self-end inline-flex items-center gap-0.5 text-sm text-brand no-underline transition-colors hover:text-brand-strong hover:underline"
+              >
+                View public dashboard
+                <ArrowUpRightFromSquare className="size-3 flex-shrink-0" />
+              </a>
+            )}
           </div>
         )}
       </PageHeader>
@@ -454,10 +479,12 @@ export default function Dashboard() {
           <LoadingSpinner size="md" />
         </div>
       ) : error ? (
-        <ErrorDisplay error={error} context={errorContext} />
+        <div className="my-12">
+          <ErrorDisplay error={error} context={errorContext} />
+        </div>
       ) : noData ? (
         <div className="flex flex-col items-center justify-center rounded-xl border border-neutral-200 bg-white px-12 py-4 mt-8 text-center shadow-sm">
-          <div className="mb-1 flex h-11 w-11 items-center justify-center rounded-full bg-blue-50">
+          <div className="mb-1 flex h-11 w-11 items-center justify-center rounded-full bg-brand-subtle">
             <Info className="h-6 w-6 text-brand" />
           </div>
           <h3 className="mb-1 text-lg font-medium text-neutral-900">
@@ -654,3 +681,5 @@ export default function Dashboard() {
     </div>
   )
 }
+
+export default Dashboard

--- a/src/pages/dashboard/PrivateDashboardContainer.tsx
+++ b/src/pages/dashboard/PrivateDashboardContainer.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState, useMemo } from 'react'
+import { useGetTenantReports } from '@/hooks/useTenants'
+import { useGetResultsGroups, useGetStatusGroups } from '@/hooks/useData'
+import { useSelectedTenant } from '@/contexts/selected-tenant/useSelectedTenant'
+import { useParams } from 'react-router-dom'
+import Dashboard from './Dashboard'
+
+const PrivateDashboardContainer = () => {
+  const { id: tenantId } = useParams<{ id: string }>()
+  const { tenant } = useSelectedTenant()
+  const tenantName = tenant?.info?.name ?? ''
+
+  const [selectedReport, setSelectedReport] = useState('')
+
+  const {
+    data: privateReports,
+    isLoading: privateReportsLoading,
+    error: privateReportsError,
+  } = useGetTenantReports(tenantId ?? '', undefined, false)
+
+  const {
+    data: publicReports,
+    isLoading: publicReportsLoading,
+    error: publicReportsError,
+  } = useGetTenantReports(tenantId ?? '', undefined, true)
+
+  const reports = useMemo(() => {
+    const merged = [
+      ...(privateReports ?? []).map((r) => ({ ...r, isPublic: false })),
+      ...(publicReports ?? []).map((r) => ({ ...r, isPublic: true })),
+    ]
+    const visitedReportIds = new Set<string>()
+    return merged.filter((report) => {
+      if (visitedReportIds.has(report.id)) return false
+      visitedReportIds.add(report.id)
+      return true
+    })
+  }, [privateReports, publicReports])
+
+  const reportsLoading = privateReportsLoading || publicReportsLoading
+  const reportsError = privateReportsError || publicReportsError
+
+  useEffect(() => {
+    if (!reports || reports.length === 0) return
+    if (!reports.some((r) => r.name === selectedReport)) {
+      setSelectedReport(reports[0].name)
+    }
+  }, [reports, selectedReport])
+
+  const {
+    data: resultsData,
+    isLoading: resultsLoading,
+    error: resultsError,
+  } = useGetResultsGroups(
+    tenantId ?? '',
+    selectedReport,
+    undefined,
+    '1w',
+    !!selectedReport,
+  )
+
+  const {
+    data: statusData,
+    isLoading: statusLoading,
+    error: statusError,
+  } = useGetStatusGroups(
+    tenantId ?? '',
+    selectedReport,
+    undefined,
+    !!selectedReport,
+  )
+
+  if (!tenantId) {
+    return (
+      <div className="page-container">
+        <p className="text-sm text-muted">No tenant selected.</p>
+      </div>
+    )
+  }
+
+  return (
+    <Dashboard
+      tenantName={tenantName}
+      tenantId={tenantId}
+      reports={reports}
+      reportsLoading={reportsLoading}
+      reportsError={reportsError ?? null}
+      resultsData={resultsData}
+      resultsLoading={resultsLoading}
+      resultsError={resultsError ?? null}
+      statusData={statusData}
+      statusLoading={statusLoading}
+      statusError={statusError ?? null}
+      selectedReport={selectedReport}
+      onReportChange={setSelectedReport}
+    />
+  )
+}
+
+export default PrivateDashboardContainer

--- a/src/pages/dashboard/index.ts
+++ b/src/pages/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PrivateDashboardContainer'

--- a/src/pages/public-dashboard/PublicDashboardContainer.tsx
+++ b/src/pages/public-dashboard/PublicDashboardContainer.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react'
+import { useGetPublicTenantReports } from '@/hooks/useTenants'
+import {
+  useGetPublicResultsGroups,
+  useGetPublicStatusGroups,
+} from '@/hooks/useData'
+import { useParams, useLocation } from 'react-router-dom'
+import { BuildingOffice2Icon, CircleStackIcon } from '@heroicons/react/16/solid'
+import Dashboard from '@/pages/dashboard/Dashboard'
+import MobileMenuToggle from '@/components/sidebar/MobileMenuToggle'
+import SidebarHeader from '@/components/sidebar/SidebarHeader'
+import SidebarNavItem from '@/components/sidebar/SidebarNavItem'
+import TenantAvatar from '@/components/sidebar/TenantAvatar'
+
+const PublicDashboardContainer = () => {
+  const { tenantName = '' } = useParams<{ tenantName: string }>()
+  const { hash } = useLocation()
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const [selectedReport, setSelectedReport] = useState('')
+
+  const {
+    data: reports,
+    isLoading: reportsLoading,
+    error: reportsError,
+  } = useGetPublicTenantReports(tenantName)
+
+  useEffect(() => {
+    if (!reports || reports.length === 0) return
+    const hashReport = hash ? decodeURIComponent(hash.slice(1)) : ''
+    const target =
+      hashReport && reports.some((r) => r.name === hashReport)
+        ? hashReport
+        : reports[0].name
+    setSelectedReport(target)
+  }, [reports, hash])
+
+  const {
+    data: resultsData,
+    isLoading: resultsLoading,
+    error: resultsError,
+  } = useGetPublicResultsGroups(
+    tenantName,
+    selectedReport,
+    undefined,
+    '1w',
+    !!selectedReport,
+  )
+
+  const {
+    data: statusData,
+    isLoading: statusLoading,
+    error: statusError,
+  } = useGetPublicStatusGroups(
+    tenantName,
+    selectedReport,
+    undefined,
+    !!selectedReport,
+  )
+
+  return (
+    <div className="h-screen flex overflow-hidden">
+      <MobileMenuToggle
+        isOpen={isMobileMenuOpen}
+        onOpen={() => setIsMobileMenuOpen(true)}
+        onClose={() => setIsMobileMenuOpen(false)}
+      />
+
+      <aside
+        className={`w-56 md:w-60 xl:w-68 2xl:w-72 bg-surface-muted border-r border-line flex flex-col fixed md:static inset-y-0 left-0 z-40 transform transition-transform duration-300 ease-in-out ${
+          isMobileMenuOpen
+            ? 'translate-x-0'
+            : '-translate-x-full md:translate-x-0'
+        }`}
+      >
+        <SidebarHeader onCloseMobileMenu={() => setIsMobileMenuOpen(false)} />
+
+        <nav className="flex flex-col overflow-y-auto min-h-0">
+          <p className="px-4 pt-4 pb-1 text-[0.65rem] font-semibold tracking-widest uppercase text-subtle select-none">
+            Tenant
+          </p>
+
+          <div className="mx-2 flex items-center gap-2.5 p-2 rounded-lg">
+            {tenantName ? (
+              <TenantAvatar name={tenantName} />
+            ) : (
+              <BuildingOffice2Icon className="size-8 text-muted flex-shrink-0" />
+            )}
+            <span className="text-sm font-semibold text-foreground truncate flex-1 min-w-0">
+              {tenantName || 'Public Dashboard'}
+            </span>
+          </div>
+
+          <SidebarNavItem
+            to={`/public/tenants/${tenantName}/dashboard`}
+            onClick={() => setIsMobileMenuOpen(false)}
+          >
+            <CircleStackIcon className="size-4" aria-hidden />
+            Dashboard
+          </SidebarNavItem>
+        </nav>
+      </aside>
+
+      <main className="flex-1 bg-white overflow-auto">
+        <div className="container mx-2 md:mx-auto py-2 px-4 md:px-6">
+          <Dashboard
+            tenantName={tenantName}
+            reports={reports}
+            reportsLoading={reportsLoading}
+            reportsError={reportsError ?? null}
+            resultsData={resultsData}
+            resultsLoading={resultsLoading}
+            resultsError={resultsError ?? null}
+            statusData={statusData}
+            statusLoading={statusLoading}
+            statusError={statusError ?? null}
+            selectedReport={selectedReport}
+            onReportChange={setSelectedReport}
+          />
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export default PublicDashboardContainer

--- a/src/pages/public-dashboard/index.ts
+++ b/src/pages/public-dashboard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PublicDashboardContainer'

--- a/src/pages/tenant-capabilities/TenantCapabilities.tsx
+++ b/src/pages/tenant-capabilities/TenantCapabilities.tsx
@@ -21,7 +21,7 @@ const TenantCapabilities = () => {
     data: reports,
     isLoading: isReportsLoading,
     error: reportsError,
-  } = useGetTenantReports(tenant?.id || '', undefined, !!tenant?.id)
+  } = useGetTenantReports(tenant?.id || '', undefined, undefined, !!tenant?.id)
 
   const isNodeEnabled = !!tenant?.node
   const hasNodeReport = reports?.some((report) => !!report.node_report)

--- a/src/pages/tenant-reports/TenantReports.tsx
+++ b/src/pages/tenant-reports/TenantReports.tsx
@@ -21,7 +21,10 @@ const TenantReports = () => {
         }
         className="pb-2 mb-4"
       />
-      <TenantReportsContent tenantId={id || ''} />
+      <TenantReportsContent
+        tenantId={id || ''}
+        tenantName={tenantData?.info.name || ''}
+      />
     </div>
   )
 }

--- a/src/pages/tenant-reports/TenantReportsContent.tsx
+++ b/src/pages/tenant-reports/TenantReportsContent.tsx
@@ -1,9 +1,26 @@
-import { useState, useEffect } from 'react'
-import { useGetTenantReports, useGetTenantReportById } from '@/hooks/useTenants'
-import LoadingSpinner from '@/components/LoadingSpinner'
-import ErrorDisplay from '@/components/ErrorDisplay'
-import MetricProfileItem from '@/pages/tenant-reports/MetricProfileItem'
+import { useState, useEffect, useMemo } from 'react'
+import {
+  useGetTenantReports,
+  useGetTenantReportById,
+  useSetReportPublicMutation,
+  useSetReportPrivateMutation,
+} from '@/hooks/useTenants'
+import { useAuth } from '@/auth/useAuth'
+import {
+  CheckCircleIcon,
+  GlobeAltIcon,
+  LockClosedIcon,
+  XCircleIcon,
+} from '@heroicons/react/16/solid'
+import { toast } from 'sonner'
 import Badge from '@/components/Badge'
+import Button from '@/components/Button'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import MetricProfileItem from '@/pages/tenant-reports/MetricProfileItem'
+import type { ReportListItem } from '@/types/tenants'
+
+type ReportWithVisibility = ReportListItem & { isPublic: boolean }
 
 const cardClass =
   'bg-white border border-line rounded-lg px-4 py-3 flex flex-col gap-2'
@@ -12,17 +29,58 @@ const simpleItemClass =
 const simpleItemTitleClass =
   'text-sm font-semibold text-body leading-[1.4] flex-1 break-words'
 
-const TenantReportsTab = ({ tenantId }: { tenantId: string }) => {
+interface TenantReportsTabProps {
+  tenantId: string
+  tenantName: string
+}
+
+const TenantReportsTab = ({ tenantId, tenantName }: TenantReportsTabProps) => {
   const [selectedReportId, setSelectedReportId] = useState<string | null>(null)
   const [expandedServices, setExpandedServices] = useState<
     Record<string, Set<string>>
   >({})
+  const [pendingReportId, setPendingReportId] = useState<string | null>(null)
+
+  const { isSuperAdmin, profile } = useAuth()
+
+  const canManageVisibility =
+    isSuperAdmin ||
+    (!!tenantName &&
+      profile?.groups?.some(
+        (g) => g.name === tenantName && g.role === 'tenant_admin',
+      ) === true)
 
   const {
-    data: reportsData,
-    isLoading: reportsLoading,
-    error: reportsError,
+    data: publicReports,
+    isLoading: publicLoading,
+    error: publicError,
   } = useGetTenantReports(tenantId, undefined, true)
+
+  const {
+    data: privateReports,
+    isLoading: privateLoading,
+    error: privateError,
+  } = useGetTenantReports(tenantId, undefined, false)
+
+  const reports = useMemo<ReportWithVisibility[]>(() => {
+    const finalPublicReports = (publicReports ?? []).map((report) => ({
+      ...report,
+      isPublic: true,
+    }))
+    const finalPrivateReports = (privateReports ?? []).map((report) => ({
+      ...report,
+      isPublic: false,
+    }))
+    const visitedReportIds = new Set<string>()
+    return [...finalPublicReports, ...finalPrivateReports].filter((report) => {
+      if (visitedReportIds.has(report.id)) return false
+      visitedReportIds.add(report.id)
+      return true
+    })
+  }, [publicReports, privateReports])
+
+  const reportsLoading = publicLoading || privateLoading
+  const reportsError = publicError || privateError
 
   const {
     data: reportDetail,
@@ -34,12 +92,14 @@ const TenantReportsTab = ({ tenantId }: { tenantId: string }) => {
     !!selectedReportId,
   )
 
-  // Auto-select first report when reports data loads
+  const setPublicMutation = useSetReportPublicMutation()
+  const setPrivateMutation = useSetReportPrivateMutation()
+
   useEffect(() => {
-    if (reportsData && reportsData.length > 0 && !selectedReportId) {
-      setSelectedReportId(reportsData[0].id)
+    if (reports.length > 0 && !selectedReportId) {
+      setSelectedReportId(reports[0].id)
     }
-  }, [reportsData, selectedReportId])
+  }, [reports, selectedReportId])
 
   const toggleService = (profileId: string, serviceName: string) => {
     setExpandedServices((prev) => {
@@ -65,6 +125,26 @@ const TenantReportsTab = ({ tenantId }: { tenantId: string }) => {
     }))
   }
 
+  const handleVisibilityClick = (report: ReportWithVisibility) => {
+    const mutation = report.isPublic ? setPrivateMutation : setPublicMutation
+    setPendingReportId(report.id)
+    mutation.mutate(
+      { tenantId, reportId: report.id },
+      {
+        onSuccess: (message) => {
+          setPendingReportId(null)
+          toast.success(message)
+        },
+        onError: (error) => {
+          setPendingReportId(null)
+          toast.error(error.message || 'Failed to update report visibility')
+        },
+      },
+    )
+  }
+
+  const selectedReport = reports.find((r) => r.id === selectedReportId)
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6 lg:gap-10 lg:min-h-[500px]">
       <div className="bg-surface-muted rounded-lg p-4 h-fit max-h-[400px] lg:max-h-[calc(100vh-300px)] overflow-y-auto">
@@ -77,9 +157,9 @@ const TenantReportsTab = ({ tenantId }: { tenantId: string }) => {
           <div className="flex justify-center py-8">
             <LoadingSpinner size="sm" />
           </div>
-        ) : reportsData && reportsData.length > 0 ? (
+        ) : reports.length > 0 ? (
           <ul className="flex flex-col gap-2">
-            {reportsData.map((report) => (
+            {reports.map((report) => (
               <li
                 key={report.id}
                 className={`p-3 bg-white border rounded-md cursor-pointer transition-all ${
@@ -89,19 +169,33 @@ const TenantReportsTab = ({ tenantId }: { tenantId: string }) => {
                 }`}
                 onClick={() => setSelectedReportId(report.id)}
               >
-                <div className="flex justify-between items-start gap-4">
-                  <span className="text-sm font-semibold text-foreground break-words">
-                    {report.name}
-                  </span>
-                  {report.disabled ? (
-                    <Badge className="bg-red-100 text-red-800 border border-red-300">
-                      Inactive
-                    </Badge>
-                  ) : (
-                    <Badge className="bg-emerald-100 text-emerald-800 border border-emerald-300">
-                      Active
-                    </Badge>
-                  )}
+                <div className="flex justify-between items-center gap-2">
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <span
+                      className="tooltip tooltip-right shrink-0"
+                      data-tip={
+                        report.disabled ? 'Report disabled' : 'Report enabled'
+                      }
+                    >
+                      {report.disabled ? (
+                        <XCircleIcon className="size-4 text-red-400" />
+                      ) : (
+                        <CheckCircleIcon className="size-4 text-emerald-500" />
+                      )}
+                    </span>
+                    <span className="text-sm font-semibold text-foreground break-words">
+                      {report.name}
+                    </span>
+                  </div>
+                  <Badge
+                    className={
+                      report.isPublic
+                        ? 'bg-brand-muted text-brand border border-blue-300'
+                        : 'bg-surface-strong text-subtle border border-line-strong'
+                    }
+                  >
+                    {report.isPublic ? 'Public' : 'Private'}
+                  </Badge>
                 </div>
                 {report.description && (
                   <p className="text-xs text-muted leading-[1.4]">
@@ -129,16 +223,44 @@ const TenantReportsTab = ({ tenantId }: { tenantId: string }) => {
           <>
             {/* Info Header */}
             <div className="mb-1 pb-1">
-              <h1 className="text-xl font-bold text-foreground leading-[1.3]">
-                {reportDetail.info.name}
-              </h1>
-              <p className="text-base text-muted mb-2.5 leading-normal">
-                {reportDetail.info.description || (
-                  <span className="text-sm text-subtle italic">
-                    No description available
-                  </span>
+              <div className="flex justify-between items-start gap-4 mb-2.5">
+                <div className="min-w-0">
+                  <h1 className="text-xl font-bold text-foreground leading-[1.3]">
+                    {reportDetail.info.name}
+                  </h1>
+                  <p className="text-base text-muted leading-normal">
+                    {reportDetail.info.description || (
+                      <span className="text-sm text-subtle italic">
+                        No description available
+                      </span>
+                    )}
+                  </p>
+                </div>
+                {canManageVisibility && selectedReport && (
+                  <div className="flex flex-col items-end gap-0.5 shrink-0">
+                    <span className="text-sm font-medium text-muted">
+                      Set report visibility:
+                    </span>
+                    <Button
+                      variant={
+                        selectedReport.isPublic
+                          ? 'outline-secondary'
+                          : 'outline-primary'
+                      }
+                      size="sm"
+                      onClick={() => handleVisibilityClick(selectedReport)}
+                      disabled={pendingReportId === selectedReport.id}
+                    >
+                      {selectedReport.isPublic ? (
+                        <LockClosedIcon className="size-4" />
+                      ) : (
+                        <GlobeAltIcon className="size-4" />
+                      )}
+                      {selectedReport.isPublic ? 'Make private' : 'Make public'}
+                    </Button>
+                  </div>
                 )}
-              </p>
+              </div>
               <div className="flex flex-wrap gap-y-2 gap-x-4 items-center">
                 <div className="flex items-center gap-1.5">
                   <span className="text-sm font-semibold text-muted">
@@ -467,8 +589,8 @@ const TenantReportsTab = ({ tenantId }: { tenantId: string }) => {
           <div className={cardClass}>
             <p className="text-sm text-subtle italic text-center">
               {selectedReportId
-                ? 'Select a report from the list'
-                : 'No report selected'}
+                ? 'No details available'
+                : 'Select a report from the list'}
             </p>
           </div>
         )}


### PR DESCRIPTION
This PR adds a public unauthenticated dashboard page accessible at /public/tenants/:tenantName/dashboard and report visibility management for tenant reports.

- Added an unauthenticated public dashboard page accessible via a shareable URL
- Refactored the existing private dashboard into a presentational component and smart containers, separating data fetching from rendering
- Added unauthenticated API functions for fetching public reports, results, and status data
- Added hash-based report pre-selection on the public dashboard so that linking to a specific report opens it directly
- Updated the dashboard header to group reports by visibility and show a public dashboard link when a public report is selected
- Added report visibility management to the Reports page, with a public/private badge per report and a toggle button to can change it
- Added API functions and hooks for setting a report as public or private