### PR TITLE
ARGO-5648 Support custom domains that map to specific public tenants

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,0 @@
-VITE_KEYCLOAK_URL=http://localhost:58080
-VITE_KEYCLOAK_REALM=quarkus
-VITE_KEYCLOAK_CLIENT_ID=frontend-service
-VITE_KEYCLOAK_SCOPE="openid voperson_id email profile entitlements"
-VITE_REDIRECT_URI=http://localhost:5173
-VITE_BACKEND_URI=http://localhost:8080

--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,5 @@ VITE_KEYCLOAK_CLIENT_ID=frontend-service
 VITE_KEYCLOAK_SCOPE="openid voperson_id email profile entitlements"
 VITE_REDIRECT_URI=http://localhost:5173
 VITE_BACKEND_URI=http://localhost:8080
-
+VITE_PLATFORM_HOSTNAMES=localhost,argo-mon.test,status.test
+VITE_DOMAINS_URL=/domains.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 build
 npm-debug.log
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -1,69 +1,70 @@
-# React + TypeScript + Vite
+# Status Pages UI
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project is a React and TypeScript application built with Vite. It relies on two backend services:
 
-Currently, two official plugins are available:
+- argo-web-api
+- api-status-mon-api
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Local Environment Setup
 
-## Expanding the ESLint configuration
+Before running the project locally, ensure you have a working Docker environment set up.
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+### Step 1: Run argo-web-api locally
 
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+To begin issue:
 
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```
+git clone https://github.com/argoeu/argo-web-api -b devel
+cd argo-web-api/docker
+docker-compose up --build
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+### Step 2: Run argo-status-mon-api locally
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+Dependencies:
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+- Java 17
+- Apache Maven 3.9.15
+
+To begin issue:
+
+```
+git clone https://github.com/argoeu/argo-mon-status-api
+cd argo-mon-status-api
+```
+
+Add your GitHub credentials to your Maven settings.xml so that Maven can pull the quarkus-auth dependency from the GitHub Packages repository:
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <servers>
+    <server>
+      <id>github</id>
+      <username>your-github-username-here</username>
+      <password>your-github-access-key-here</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Then issue:
+
+```
+mvn clean && mvn quarkus:dev
+```
+
+### Step 3: Run the status-ui React app
+
+Depedencies:
+
+- Node 20.x
+
+To begin issue:
+
+```
+git clone https://github.com/argoeu/status-ui -b devel
+cd status-ui
+Copy .env.example to .env and use it as is, or modify it to suit your needs.
+npm install
+npm run dev
 ```

--- a/localenv/domains.json
+++ b/localenv/domains.json
@@ -1,0 +1,4 @@
+{
+  "tenant-b.test": "TENANTB",
+  "tenant-test.test": "TENANT-TEST"
+}

--- a/localenv/hosts.md
+++ b/localenv/hosts.md
@@ -1,0 +1,8 @@
+Add the following lines to your local `/etc/hosts` file:
+
+```
+127.0.0.1 argo-mon.test
+127.0.0.1 status.test
+127.0.0.1 tenant-b.test
+127.0.0.1 tenant-test.test
+```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import PublicDashboard from './pages/public-dashboard'
 import { AuthProvider } from './auth/AuthProvider'
 import NotFound from './pages/NotFound'
 import { Toaster } from 'sonner'
+import { isPlatformDomain } from './utils/domains'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -59,202 +60,218 @@ export function AuthLayout() {
   )
 }
 
+function PlatformRoutes() {
+  return (
+    <Routes>
+      <Route path="status/:slug" element={<PublicStatusPage />} />
+      <Route
+        path="public/tenants/:tenantName/dashboard"
+        element={<PublicDashboard />}
+      />
+      <Route element={<AuthLayout />}>
+        <Route path="invitation/:id" element={<InvitationReview />} />
+        <Route element={<Layout />}>
+          <Route index element={<Home />} />
+          <Route
+            path="tenants/:id/details"
+            element={
+              <AuthProtected>
+                <TenantDetails />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/create"
+            element={
+              <ProtectedRoute requiredRoles={['super_admin']}>
+                <CreateTenant />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="tenants/:id/edit"
+            element={
+              <AuthProtected>
+                <CreateTenant />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/projects/assign"
+            element={
+              <AuthProtected>
+                <AssignProjects />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/members"
+            element={
+              <AuthProtected>
+                <ManageTenantMembers />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/dashboard"
+            element={
+              <AuthProtected>
+                <PrivateDashboardContainer />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/reports"
+            element={
+              <AuthProtected>
+                <TenantReports />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/capabilities"
+            element={
+              <AuthProtected>
+                <TenantCapabilities />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="projects/create"
+            element={
+              <ProtectedRoute requiredRoles={['super_admin']}>
+                <CreateProject />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="projects/edit/:id"
+            element={
+              <ProtectedRoute requiredRoles={['super_admin']}>
+                <CreateProject />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="administration"
+            element={
+              <ProtectedRoute requiredRoles={['super_admin']}>
+                <Administration />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="administration/users/:username"
+            element={
+              <ProtectedRoute requiredRoles={['super_admin']}>
+                <Profile />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="endpoints-access"
+            element={
+              <ProtectedRoute requiredRoles={['super_admin']}>
+                <EndpointsAccess />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="my-invitations"
+            element={
+              <AuthProtected>
+                <MyInvitations />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="profile"
+            element={
+              <AuthProtected>
+                <Profile />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="status-pages/tenants/:tenantId/pages/:pageId"
+            element={
+              <AuthProtected>
+                <BuildStatusPage />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="status-pages/tenants/:tenantId/build"
+            element={
+              <AuthProtected>
+                <BuildStatusPage />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="status-pages/build"
+            element={
+              <AuthProtected>
+                <BuildStatusPage />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/status-pages"
+            element={
+              <AuthProtected>
+                <TenantStatusPages />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/topology"
+            element={
+              <AuthProtected>
+                <TenantTopology />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/topology/groups/create"
+            element={
+              <AuthProtected>
+                <CreateTopologyGroup />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/topology/create"
+            element={
+              <AuthProtected>
+                <CreateTopologyEndpoint />
+              </AuthProtected>
+            }
+          />
+          <Route path="*" element={<NotFound />} />
+        </Route>
+      </Route>
+    </Routes>
+  )
+}
+
+function CustomDomainRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<PublicDashboard />} />
+      <Route path="/dashboard" element={<PublicDashboard />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  )
+}
+
 function App() {
   return (
     <>
       <Toaster richColors position="top-center" duration={2000} />
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
-          <Routes>
-            <Route path="status/:slug" element={<PublicStatusPage />} />
-            <Route
-              path="public/tenants/:tenantName/dashboard"
-              element={<PublicDashboard />}
-            />
-            <Route element={<AuthLayout />}>
-              <Route path="invitation/:id" element={<InvitationReview />} />
-              <Route element={<Layout />}>
-                <Route index element={<Home />} />
-                <Route
-                  path="tenants/:id/details"
-                  element={
-                    <AuthProtected>
-                      <TenantDetails />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/create"
-                  element={
-                    <ProtectedRoute requiredRoles={['super_admin']}>
-                      <CreateTenant />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="tenants/:id/edit"
-                  element={
-                    <AuthProtected>
-                      <CreateTenant />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/:id/projects/assign"
-                  element={
-                    <AuthProtected>
-                      <AssignProjects />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/:id/members"
-                  element={
-                    <AuthProtected>
-                      <ManageTenantMembers />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/:id/dashboard"
-                  element={
-                    <AuthProtected>
-                      <PrivateDashboardContainer />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/:id/reports"
-                  element={
-                    <AuthProtected>
-                      <TenantReports />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/:id/capabilities"
-                  element={
-                    <AuthProtected>
-                      <TenantCapabilities />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="projects/create"
-                  element={
-                    <ProtectedRoute requiredRoles={['super_admin']}>
-                      <CreateProject />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="projects/edit/:id"
-                  element={
-                    <ProtectedRoute requiredRoles={['super_admin']}>
-                      <CreateProject />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="administration"
-                  element={
-                    <ProtectedRoute requiredRoles={['super_admin']}>
-                      <Administration />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="administration/users/:username"
-                  element={
-                    <ProtectedRoute requiredRoles={['super_admin']}>
-                      <Profile />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="endpoints-access"
-                  element={
-                    <ProtectedRoute requiredRoles={['super_admin']}>
-                      <EndpointsAccess />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="my-invitations"
-                  element={
-                    <AuthProtected>
-                      <MyInvitations />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="profile"
-                  element={
-                    <AuthProtected>
-                      <Profile />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="status-pages/tenants/:tenantId/pages/:pageId"
-                  element={
-                    <AuthProtected>
-                      <BuildStatusPage />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="status-pages/tenants/:tenantId/build"
-                  element={
-                    <AuthProtected>
-                      <BuildStatusPage />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="status-pages/build"
-                  element={
-                    <AuthProtected>
-                      <BuildStatusPage />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/:id/status-pages"
-                  element={
-                    <AuthProtected>
-                      <TenantStatusPages />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/:id/topology"
-                  element={
-                    <AuthProtected>
-                      <TenantTopology />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/:id/topology/groups/create"
-                  element={
-                    <AuthProtected>
-                      <CreateTopologyGroup />
-                    </AuthProtected>
-                  }
-                />
-                <Route
-                  path="tenants/:id/topology/create"
-                  element={
-                    <AuthProtected>
-                      <CreateTopologyEndpoint />
-                    </AuthProtected>
-                  }
-                />
-                <Route path="*" element={<NotFound />} />
-              </Route>
-            </Route>
-          </Routes>
+          {isPlatformDomain() ? <PlatformRoutes /> : <CustomDomainRoutes />}
         </BrowserRouter>
       </QueryClientProvider>
     </>

--- a/src/hooks/useTenantName.ts
+++ b/src/hooks/useTenantName.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+const DOMAINS_URL = import.meta.env.VITE_DOMAINS_URL ?? '/domains.json'
+
+interface TenantNameResult {
+  tenantName: string | null
+  loading: boolean
+}
+
+export function useTenantName(): TenantNameResult {
+  const { tenantName: tenantFromParam } = useParams<{ tenantName?: string }>()
+  const [resolved, setResolved] = useState<string | null>(null)
+  const [loading, setLoading] = useState(!tenantFromParam)
+
+  useEffect(() => {
+    if (tenantFromParam) return // came straight from the URL, nothing to resolve
+
+    fetch(DOMAINS_URL)
+      .then((res) => res.json())
+      .then((domains: Record<string, string>) => {
+        setResolved(domains[window.location.hostname] ?? null)
+      })
+      .catch(() => setResolved(null))
+      .finally(() => setLoading(false))
+  }, [tenantFromParam])
+
+  return {
+    tenantName: tenantFromParam ?? resolved,
+    loading: tenantFromParam ? false : loading,
+  }
+}

--- a/src/pages/public-dashboard/PublicDashboardContainer.tsx
+++ b/src/pages/public-dashboard/PublicDashboardContainer.tsx
@@ -4,16 +4,19 @@ import {
   useGetPublicResultsGroups,
   useGetPublicStatusGroups,
 } from '@/hooks/useData'
-import { useParams, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import { BuildingOffice2Icon, CircleStackIcon } from '@heroicons/react/16/solid'
 import Dashboard from '@/pages/dashboard/Dashboard'
 import MobileMenuToggle from '@/components/sidebar/MobileMenuToggle'
 import SidebarHeader from '@/components/sidebar/SidebarHeader'
 import SidebarNavItem from '@/components/sidebar/SidebarNavItem'
 import TenantAvatar from '@/components/sidebar/TenantAvatar'
+import NotFound from '../NotFound'
+import { isPlatformDomain } from '@/utils/domains'
+import { useTenantName } from '@/hooks/useTenantName'
 
 const PublicDashboardContainer = () => {
-  const { tenantName = '' } = useParams<{ tenantName: string }>()
+  const { tenantName, loading: tenantLoading } = useTenantName()
   const { hash } = useLocation()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const [selectedReport, setSelectedReport] = useState('')
@@ -22,7 +25,7 @@ const PublicDashboardContainer = () => {
     data: reports,
     isLoading: reportsLoading,
     error: reportsError,
-  } = useGetPublicTenantReports(tenantName)
+  } = useGetPublicTenantReports(tenantName ?? '')
 
   useEffect(() => {
     if (!reports || reports.length === 0) return
@@ -39,7 +42,7 @@ const PublicDashboardContainer = () => {
     isLoading: resultsLoading,
     error: resultsError,
   } = useGetPublicResultsGroups(
-    tenantName,
+    tenantName ?? '',
     selectedReport,
     undefined,
     '1w',
@@ -51,11 +54,27 @@ const PublicDashboardContainer = () => {
     isLoading: statusLoading,
     error: statusError,
   } = useGetPublicStatusGroups(
-    tenantName,
+    tenantName ?? '',
     selectedReport,
     undefined,
     !!selectedReport,
   )
+
+  if (tenantLoading) {
+    return (
+      <div className="h-screen flex items-center justify-center text-subtle">
+        Loading…
+      </div>
+    )
+  }
+
+  if (!tenantName) {
+    return <NotFound />
+  }
+
+  const dashboardPath = isPlatformDomain()
+    ? `/public/tenants/${tenantName}/dashboard`
+    : '/dashboard'
 
   return (
     <div className="h-screen flex overflow-hidden">
@@ -91,7 +110,7 @@ const PublicDashboardContainer = () => {
           </div>
 
           <SidebarNavItem
-            to={`/public/tenants/${tenantName}/dashboard`}
+            to={dashboardPath}
             onClick={() => setIsMobileMenuOpen(false)}
           >
             <CircleStackIcon className="size-4" aria-hidden />

--- a/src/utils/domains.ts
+++ b/src/utils/domains.ts
@@ -1,0 +1,7 @@
+const PLATFORM_HOSTNAMES = (
+  import.meta.env.VITE_PLATFORM_HOSTNAMES ?? ''
+).split(',')
+
+export function isPlatformDomain(): boolean {
+  return PLATFORM_HOSTNAMES.includes(window.location.hostname)
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,10 +22,8 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,13 +2,37 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath, URL } from 'node:url'
+import fs from 'fs'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    {
+      name: 'serve-local-domains',
+      configureServer(server) {
+        server.middlewares.use('/domains.json', (_, res) => {
+          const filePath = path.resolve(__dirname, 'localenv/domains.json')
+          res.setHeader('Content-Type', 'application/json')
+          res.end(fs.readFileSync(filePath, 'utf-8'))
+        })
+      },
+    },
+  ],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
+  },
+  server: {
+    host: '127.0.0.1',
+    allowedHosts: [
+      'status.test',
+      'argo-mon.test',
+      'tenant-b.test',
+      'tenant-test.test',
+    ],
   },
 })


### PR DESCRIPTION

# Goal
We want to access the react app from different domain names (hostnames). Some of them will be the main platform domains where the user can login and have the full functionality of our app. Other domains are considered custom and are mapped to specific public tenants. When user uses them to access our app she/he lands on the corresponding tenant's dashboard

# Implementation
Extend configuration to support two additional env vars:
```
VITE_PLATFORM_HOSTNAMES=localhost,argo-mon.test,status.test
VITE_DOMAINS_URL=/domains.json
```
**Platform hostnames** is used as a comma separated list to designate domains that represent our main monitoring platform. 
**Vite domains url** is the url which returns the response of the custom domains mapping. The response looks like:
```
{
    "tenant-b.test": "TENANTB",
    "tenant-test.test": "TENANT-TEST"
}
```
Which maps custom domains to tenant names

## Dynamic routing based on hostname 
React router dom employs two routing strategies one for the main platform (when the hostname matches one of the platform hostnames) and one for the public tenant based on the custom domain. 

### add utility function: isPlatformDomain
This function checks if the current hostname is one of the designated hostnames that represent the main platform app. Based on this the react-router-dom component chooses the routing strategy later in App.tsx

### update react routes in App.tsx
We've created two sets of Routes:
- PlatformRoutes for the main App
- CustomDomainRoutes for the public tenants under custom domains

The router checks the hostname and chooses routes accordingly

### added hook: useTenantName
The `useTenantName` hook gets the tenant name either by the url path (if on the main platform) or either by the request to `VITE_DOMAINS_URL` (default=/domains.json) where it gets a map of custom domains and the associated tenant names

## Micro clean ups
Removed the .env file and re-added the .env ignore rule to .gitignore. This was set up intentionally from the start to prevent accidentally committing .env secrets while experimenting in a local environment. An .env.example file is provided, which each developer can copy to create their own .env.




