### PR TITLE
[ARGO-5651] - Restrict status page create, edit and delete actions from tenant viewer role

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -26,7 +26,7 @@ interface TenantNavItem {
   label: string
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>
   requiredRoles?: string[]
-  end?: boolean
+  exactPathMatch?: boolean
 }
 
 const tenantNavItems: TenantNavItem[] = [
@@ -35,7 +35,7 @@ const tenantNavItems: TenantNavItem[] = [
     label: 'Dashboard',
     icon: CircleStackIcon,
   },
-  { path: 'details', label: 'Overview', icon: HomeIcon, end: true },
+  { path: 'details', label: 'Overview', icon: HomeIcon },
   {
     path: 'topology',
     label: 'Topology',
@@ -44,7 +44,12 @@ const tenantNavItems: TenantNavItem[] = [
   },
   { path: 'status-pages', label: 'Status Pages', icon: RectangleStackIcon },
   { path: 'reports', label: 'Reports', icon: DocumentChartBarIcon },
-  { path: 'capabilities', label: 'Capabilities', icon: ShieldCheckIcon },
+  {
+    path: 'capabilities',
+    label: 'Capabilities',
+    icon: ShieldCheckIcon,
+    requiredRoles: ['tenant_admin'],
+  },
   {
     path: 'members',
     label: 'Members',
@@ -146,7 +151,7 @@ function Sidebar({
                   <SidebarNavItem
                     key={item.path}
                     to={`/tenants/${effectiveTenantId}/${item.path}`}
-                    end={item.end}
+                    exactPathMatch={item.exactPathMatch}
                     onClick={onCloseMobileMenu}
                   >
                     <item.icon className="size-4" aria-hidden />

--- a/src/components/sidebar/SidebarNavItem.tsx
+++ b/src/components/sidebar/SidebarNavItem.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router'
 
 interface SidebarNavItemProps {
   to: string
-  end?: boolean
+  exactPathMatch?: boolean
   children: React.ReactNode
   onClick?: () => void
 }
@@ -10,13 +10,13 @@ interface SidebarNavItemProps {
 export default function SidebarNavItem({
   to,
   children,
-  end,
+  exactPathMatch,
   onClick,
 }: SidebarNavItemProps) {
   return (
     <NavLink
       to={to}
-      end={end}
+      end={exactPathMatch}
       onClick={onClick}
       className={({ isActive }) =>
         [

--- a/src/pages/administration/StatusPagesManagementTab.tsx
+++ b/src/pages/administration/StatusPagesManagementTab.tsx
@@ -170,6 +170,7 @@ const StatusPagesManagementTab = () => {
           isLoading={isLoading}
           error={error}
           isAllSelected={isAllSelected}
+          canModifyPages
           embedded
           onView={handlePageView}
           onEdit={handlePageEdit}

--- a/src/pages/status-pages/StatusPagesTable.tsx
+++ b/src/pages/status-pages/StatusPagesTable.tsx
@@ -14,10 +14,11 @@ interface StatusPagesTableProps {
   isLoading: boolean
   error: Error | null
   isAllSelected: boolean
+  canModifyPages?: boolean
   embedded?: boolean
   onView: (slug: string) => void
-  onEdit: (id: string | undefined, tenantId: string | undefined) => void
-  onDeleteClick: (
+  onEdit?: (id: string | undefined, tenantId: string | undefined) => void
+  onDeleteClick?: (
     id: string | undefined,
     name: string,
     tenantId: string | undefined,
@@ -29,6 +30,7 @@ const StatusPagesTable = ({
   isLoading,
   error,
   isAllSelected,
+  canModifyPages = false,
   embedded,
   onView,
   onEdit,
@@ -150,20 +152,24 @@ const StatusPagesTable = ({
                   onClick={() => onView(item.slug)}
                   className="text-blue-600 hover:bg-brand-subtle"
                 />
-                <IconButton
-                  icon={<PencilSquareIcon className="size-4 md:size-5" />}
-                  label="Edit Page"
-                  onClick={() => onEdit(item.id, item.tenant_id)}
-                  className="text-muted hover:bg-surface-strong"
-                />
-                <IconButton
-                  icon={<TrashIcon className="size-4 md:size-5" />}
-                  label="Delete Page"
-                  onClick={() =>
-                    onDeleteClick(item.id, item.name, item.tenant_id)
-                  }
-                  className="text-red-600 hover:bg-red-50"
-                />
+                {canModifyPages && (
+                  <IconButton
+                    icon={<PencilSquareIcon className="size-4 md:size-5" />}
+                    label="Edit Page"
+                    onClick={() => onEdit?.(item.id, item.tenant_id)}
+                    className="text-muted hover:bg-surface-strong"
+                  />
+                )}
+                {canModifyPages && (
+                  <IconButton
+                    icon={<TrashIcon className="size-4 md:size-5" />}
+                    label="Delete Page"
+                    onClick={() =>
+                      onDeleteClick?.(item.id, item.name, item.tenant_id)
+                    }
+                    className="text-red-600 hover:bg-red-50"
+                  />
+                )}
               </div>
             </td>
           </tr>

--- a/src/pages/status-pages/TenantStatusPages.tsx
+++ b/src/pages/status-pages/TenantStatusPages.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useSelectedTenant } from '@/contexts/selected-tenant'
 import { useGetTenantPages, useDeletePageMutation } from '@/hooks/usePages'
+import { useAuth } from '@/auth/useAuth'
 import { useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import ConfirmDialog from '@/components/ConfirmDialog'
@@ -15,7 +16,16 @@ const TenantStatusPages = () => {
   const { id: tenantId } = useParams<{ id: string }>()
   const [currentPage, setCurrentPage] = useState(1)
 
-  const { tenant: tenantData } = useSelectedTenant()
+  const { isSuperAdmin } = useAuth()
+  const {
+    tenant: tenantData,
+    roleInSelectedTenant,
+    isTenantLoading,
+  } = useSelectedTenant()
+
+  const canModifyPages =
+    !isTenantLoading &&
+    (isSuperAdmin || roleInSelectedTenant === 'tenant_admin')
 
   const { data, isLoading, error } = useGetTenantPages(
     tenantId ?? '',
@@ -120,19 +130,22 @@ const TenantStatusPages = () => {
           }
           className="pb-1 mb-2 md:mb-4 px-2 md:px-0"
         >
-          <Button
-            variant="primary"
-            size="md"
-            href={`/status-pages/tenants/${tenantId}/build`}
-          >
-            Create Status Page
-          </Button>
+          {canModifyPages && (
+            <Button
+              variant="primary"
+              size="md"
+              href={`/status-pages/tenants/${tenantId}/build`}
+            >
+              Create Status Page
+            </Button>
+          )}
         </PageHeader>
         <StatusPagesTable
           data={data}
           isLoading={isLoading}
           error={error}
           isAllSelected={false}
+          canModifyPages={canModifyPages}
           onView={handlePageView}
           onEdit={handlePageEdit}
           onDeleteClick={handlePageDeleteClick}


### PR DESCRIPTION
This PR removes create, edit and delete access to status pages for tenant viewer role.

- Updated status pages table to hide Edit and Delete actions for tenant viewer
- Hidden the Create Status Page button for tenant viewer
