### PR TITLE
[ARGO-5691] - Improve empty state handling on topology feed and readiness page

### DIFF
--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -761,9 +761,11 @@ export const fetchGetTopologyFeed = async (
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}))
-    throw new Error(
+    const error = new Error(
       errorData.message || `HTTP error! status: ${response.status}`,
-    )
+    ) as Error & { status: number }
+    error.status = response.status
+    throw error
   }
 
   return response.json()

--- a/src/contexts/selected-tenant/SelectedTenantContext.ts
+++ b/src/contexts/selected-tenant/SelectedTenantContext.ts
@@ -8,6 +8,9 @@ export interface SelectedTenantContextValue {
   roleInSelectedTenant: string | null
   effectiveTenantId: string | null
   tenants: Tenant[]
+  topologyFeedType: string | null
+  topologyFeedError: Error | null
+  isTopologyFeedLoading: boolean
 }
 
 export const SelectedTenantContext = createContext<

--- a/src/contexts/selected-tenant/SelectedTenantProvider.tsx
+++ b/src/contexts/selected-tenant/SelectedTenantProvider.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import type { ReactNode } from 'react'
 import { useLocation } from 'react-router'
 import { useAuth } from '@/auth/useAuth'
-import { useGetAllTenants } from '@/hooks/useTenants'
+import { useGetAllTenants, useGetTopologyFeedQuery } from '@/hooks/useTenants'
 import { SelectedTenantContext } from './SelectedTenantContext'
 
 const LAST_TENANT_KEY = 'lastActiveTenantId'
@@ -79,6 +79,12 @@ const SelectedTenantProvider = ({ children }: SelectedTenantProviderProps) => {
 
   const effectiveTenantId = activeTenantId ?? lastActiveTenantId ?? null
 
+  const {
+    data: feedData,
+    isLoading: isTopologyFeedLoading,
+    error: topologyFeedError,
+  } = useGetTopologyFeedQuery(effectiveTenantId ?? '', !!effectiveTenantId)
+
   const selectedTenant = useMemo(
     () => tenants.find((t) => t.id === effectiveTenantId),
     [tenants, effectiveTenantId],
@@ -100,6 +106,9 @@ const SelectedTenantProvider = ({ children }: SelectedTenantProviderProps) => {
         roleInSelectedTenant,
         effectiveTenantId,
         tenants,
+        topologyFeedType: feedData?.type || null,
+        topologyFeedError,
+        isTopologyFeedLoading,
       }}
     >
       {children}

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -20,6 +20,7 @@ export const useGetResultsGroups = (
       return fetchResultsGroups(tenantId, token, report, item, period)
     },
     retry: false,
+    refetchOnMount: 'always',
     enabled: enabled && !!token && !!tenantId,
   })
 }
@@ -40,6 +41,7 @@ export const useGetStatusGroups = (
       return fetchStatusGroups(tenantId, report, token, item)
     },
     retry: false,
+    refetchOnMount: 'always',
     enabled: enabled && !!token && !!tenantId,
   })
 }

--- a/src/hooks/useTopology.ts
+++ b/src/hooks/useTopology.ts
@@ -96,6 +96,12 @@ export const useCreateTopologyGroupsMutation = () => {
       queryClient.invalidateQueries({
         queryKey: ['topology-groups', tenantId],
       })
+      queryClient.invalidateQueries({
+        queryKey: ['results-groups', tenantId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['status-groups', tenantId],
+      })
     },
     onError: (error) => {
       console.error('Topology groups create error:', error)
@@ -126,6 +132,12 @@ export const useCreateTopologyEndpointMutation = () => {
     onSuccess: (_result, { tenantId }) => {
       queryClient.invalidateQueries({
         queryKey: ['topology-endpoints', tenantId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['results-groups', tenantId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['status-groups', tenantId],
       })
     },
     onError: (error) => {

--- a/src/pages/tenant-details/TenantReadinessTab.tsx
+++ b/src/pages/tenant-details/TenantReadinessTab.tsx
@@ -219,7 +219,7 @@ const TenantReadinessTab = ({ tenantId }: TenantReadinessTabProps) => {
         </div>
       )}
 
-      {!hasError && readiness && (
+      {!hasError && readiness && readiness.last_check && (
         <div className="max-w-[1240px] flex flex-col gap-3">
           <div>
             <h2 className="section-title">Readiness Check Results</h2>

--- a/src/pages/tenant-topology/TenantTopology.tsx
+++ b/src/pages/tenant-topology/TenantTopology.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useParams, useLocation } from 'react-router-dom'
 import { useSelectedTenant } from '@/contexts/selected-tenant'
 import PageHeader from '@/components/PageHeader'
@@ -22,7 +22,12 @@ const TenantTopology = () => {
   const { id } = useParams<{ id: string }>()
   const tenantId = id ?? ''
 
-  const { tenant: tenantData } = useSelectedTenant()
+  const {
+    tenant: tenantData,
+    topologyFeedType,
+    topologyFeedError,
+    isTopologyFeedLoading,
+  } = useSelectedTenant()
 
   const location = useLocation()
   const [activeTab, setActiveTab] = useState<
@@ -41,6 +46,34 @@ const TenantTopology = () => {
       setActiveTab('endpoints')
     }
   }, [location.hash])
+
+  const initialRedirectDone = useRef(false)
+
+  useEffect(() => {
+    initialRedirectDone.current = false
+  }, [tenantId])
+
+  useEffect(() => {
+    if (initialRedirectDone.current || isTopologyFeedLoading || location.hash) {
+      return
+    }
+
+    const feedStatus = (
+      topologyFeedError as (Error & { status?: number }) | null
+    )?.status
+    const isFeedClientError =
+      feedStatus !== undefined && feedStatus >= 400 && feedStatus < 500
+
+    if (!topologyFeedType && (!topologyFeedError || isFeedClientError)) {
+      setActiveTab('feed-configuration')
+    }
+    initialRedirectDone.current = true
+  }, [
+    topologyFeedType,
+    topologyFeedError,
+    isTopologyFeedLoading,
+    location.hash,
+  ])
 
   const [editingEndpoint, setEditingEndpoint] =
     useState<EndpointTopologyItem | null>(null)


### PR DESCRIPTION
This PR improves empty state handling on the topology and readiness page.

- Updated the readiness page to hide the results section when no check has been run yet
- Added automatic redirect to the feed configuration tab when the topology feed is unconfigured
- Updated the selected tenant context with topology feed state