### PR TITLE
[ARGO-5695] - Fix capabilities stats computation

### DIFF
--- a/src/pages/public-tenant/PublicCapabilitiesContainer.tsx
+++ b/src/pages/public-tenant/PublicCapabilitiesContainer.tsx
@@ -49,11 +49,11 @@ const PublicCapabilitiesContainer = () => {
   const isLoading = reportsLoading || isAvailabilityLoading || isStatusLoading
 
   const availabilityStats = computeAvailabilityStats(
-    availabilityData?.data?.[0]?.results ?? [],
+    availabilityData?.data?.flatMap((d) => d.results) ?? [],
   )
 
   const { statusStats, statusCounts } = computeStatusStats(
-    statusData?.data?.[0]?.results ?? [],
+    statusData?.data?.flatMap((d) => d.results) ?? [],
   )
 
   return (

--- a/src/pages/tenant-capabilities/PrivateCapabilitiesContainer.tsx
+++ b/src/pages/tenant-capabilities/PrivateCapabilitiesContainer.tsx
@@ -29,11 +29,11 @@ const PrivateCapabilitiesContainer = () => {
   } = useGetTenantCapabilityStatus(tenantData?.id || '')
 
   const availabilityStats = computeAvailabilityStats(
-    availabilityData?.data?.[0]?.results ?? [],
+    availabilityData?.data?.flatMap((d) => d.results) ?? [],
   )
 
   const { statusStats, statusCounts } = computeStatusStats(
-    statusData?.data?.[0]?.results ?? [],
+    statusData?.data?.flatMap((d) => d.results) ?? [],
   )
 
   if (!tenantData) {

--- a/src/utils/capabilityStats.ts
+++ b/src/utils/capabilityStats.ts
@@ -29,15 +29,17 @@ export const computeAvailabilityStats = (
   if (results.length === 0) {
     return undefined
   }
-  const values = results
+  const validValues = results
     .map((r) => parseFloat(r.availability))
-    .filter((v) => !isNaN(v))
-  if (values.length === 0) {
+    .filter((v) => !isNaN(v) && v >= 0)
+
+  if (validValues.length === 0) {
     return undefined
   }
   const avg =
-    Math.round((values.reduce((sum, v) => sum + v, 0) / values.length) * 10) /
-    10
+    Math.round(
+      (validValues.reduce((sum, v) => sum + v, 0) / validValues.length) * 10,
+    ) / 10
   return [{ name: 'Avg Avail', value: avg }]
 }
 


### PR DESCRIPTION
This PR fixes the availability and status statistics displayed on the Capabilities page to correctly compute using all available data and excludes invalid values from the availability average computation.