### PR TITLE
[ARGO-5701] - Implement editing support for role attributes

### DIFF
--- a/src/api/securedEndpoints.ts
+++ b/src/api/securedEndpoints.ts
@@ -3,6 +3,7 @@ import type {
   AssignEndpointsRequest,
   RoleAssignmentsResponse,
   RoleEndpointAssignmentResponse,
+  ApiMessageResponse,
   Role,
   RolesPage,
   CreateRoleRequest,
@@ -147,6 +148,30 @@ export const fetchRoleMetadata = async (
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const updateRoleAttributes = async (
+  roleId: string,
+  attributes: Record<string, string[]>,
+  token: string,
+): Promise<ApiMessageResponse> => {
+  const response = await fetch(`${BACKEND_API}/roles/${roleId}/attributes`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(attributes),
   })
 
   if (!response.ok) {

--- a/src/hooks/useSecuredEndpoints.ts
+++ b/src/hooks/useSecuredEndpoints.ts
@@ -13,12 +13,14 @@ import {
   fetchRoles,
   createRole,
   fetchRoleMetadata,
+  updateRoleAttributes,
 } from '@/api/securedEndpoints'
 import type {
   SecuredEndpointsPage,
   AssignEndpointsRequest,
   RoleAssignmentsResponse,
   RoleEndpointAssignmentResponse,
+  ApiMessageResponse,
   Role,
   RolesPage,
   CreateRoleRequest,
@@ -149,6 +151,35 @@ export const useCreateRoleMutation = () => {
     },
     onError: (error) => {
       console.error('Create role error:', error)
+    },
+  })
+}
+
+export const useUpdateRoleAttributesMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<
+    ApiMessageResponse,
+    Error,
+    { roleId: string; attributes: Record<string, string[]> }
+  >({
+    mutationFn: ({
+      roleId,
+      attributes,
+    }: {
+      roleId: string
+      attributes: Record<string, string[]>
+    }) => {
+      if (!token) throw new Error('No authentication token available')
+      if (!roleId) throw new Error('Role ID is required')
+      return updateRoleAttributes(roleId, attributes, token)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['roles'] })
+    },
+    onError: (error) => {
+      console.error('Update role attributes error:', error)
     },
   })
 }

--- a/src/pages/administration/TenantManagementTab.tsx
+++ b/src/pages/administration/TenantManagementTab.tsx
@@ -12,7 +12,7 @@ import Card from '@/components/Card'
 import TenantCardFooter from '@/pages/administration/TenantCardFooter'
 import Badge from '@/components/Badge'
 import { roleBadgeClass } from '@/utils/badges'
-import { tenantMapper } from '@/utils/roleAssignmentMapper'
+import { useRoleFriendlyName } from '@/hooks/useRoleFriendlyName'
 import { toast } from 'sonner'
 import type { UserGroup } from '@/types/profile'
 import type { Job, JobStatus } from '@/types/tenants'
@@ -42,6 +42,7 @@ const TenantManagementTab = () => {
 
   const { isSuperAdmin } = useAuth()
   const { data: userProfileData } = useGetUserProfile()
+  const getRoleFriendlyName = useRoleFriendlyName()
 
   const { data, isLoading, error } = useGetUserTenants(
     currentPage,
@@ -62,8 +63,7 @@ const TenantManagementTab = () => {
     if (!group?.role) return null
     return {
       role: group.role,
-      displayName:
-        group.attributes?.[tenantMapper.preferred_role_name]?.[0] ?? group.role,
+      displayName: getRoleFriendlyName(group.role),
     }
   }
 

--- a/src/pages/administration/UsersTab.tsx
+++ b/src/pages/administration/UsersTab.tsx
@@ -11,6 +11,7 @@ import IconButton from '@/components/IconButton'
 import { squishEmail } from '@/utils/profile'
 import { TENANT_MEMBERSHIP_ENTITY } from '@/utils/memberships'
 import { tenantMapper } from '@/utils/roleAssignmentMapper'
+import { useRoleFriendlyName } from '@/hooks/useRoleFriendlyName'
 
 type SortColumn =
   | 'username'
@@ -28,16 +29,15 @@ const tenantBadgeBase =
 const TenantBadge = ({
   name,
   role,
-  preferredRoleName,
   colorClass,
 }: {
   name: string
   role: string
-  preferredRoleName?: string
   colorClass: string
 }) => {
   const textRef = useRef<HTMLSpanElement>(null)
   const [isTruncated, setIsTruncated] = useState(false)
+  const getRoleFriendlyName = useRoleFriendlyName()
 
   useEffect(() => {
     const el = textRef.current
@@ -46,7 +46,7 @@ const TenantBadge = ({
     }
   }, [name])
 
-  const displayRole = preferredRoleName ?? role
+  const displayRole = getRoleFriendlyName(role)
 
   return (
     <span
@@ -239,15 +239,10 @@ const UsersTab = () => {
                                   ]?.[0] ?? tenant.name
                                 }
                                 role={tenant.role}
-                                preferredRoleName={
-                                  tenant.attributes?.[
-                                    tenantMapper.preferred_role_name
-                                  ]?.[0]
-                                }
                                 colorClass={
                                   tenant.role === 'tenant_admin'
                                     ? 'bg-amber-100 text-amber-700'
-                                    : 'bg-brand-muted text-blue-800'
+                                    : 'bg-brand-muted text-brand-strong'
                                 }
                               />
                             ),

--- a/src/pages/endpoints-access/EndpointsAccess.tsx
+++ b/src/pages/endpoints-access/EndpointsAccess.tsx
@@ -172,7 +172,7 @@ const EndpointsAccess = () => {
         </div>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-x-8 items-start pb-10">
-          <div className="lg:sticky lg:top-4 bg-surface-muted rounded-lg px-4 pt-2 pb-4 mb-6 lg:mb-0">
+          <div className="lg:sticky lg:top-4 z-20 bg-surface-muted rounded-lg px-4 pt-2 pb-4 mb-6 lg:mb-0">
             <RoleListPanel
               roles={roles}
               selectedRoleId={selectedRoleId}

--- a/src/pages/endpoints-access/RoleForm.tsx
+++ b/src/pages/endpoints-access/RoleForm.tsx
@@ -1,0 +1,230 @@
+import { useState, useMemo } from 'react'
+import {
+  useCreateRoleMutation,
+  useGetRoleMetadata,
+  useUpdateRoleAttributesMutation,
+} from '@/hooks/useSecuredEndpoints'
+import { toast } from 'sonner'
+import Button from '@/components/Button'
+import type { Role } from '@/types/securedEndpoints'
+
+interface RoleFormProps {
+  role?: Role
+  onSuccess: () => void
+}
+
+const RoleForm = ({ role, onSuccess }: RoleFormProps) => {
+  const isEditMode = !!role
+
+  const [roleName, setRoleName] = useState('')
+  const [attributeValues, setAttributeValues] = useState<
+    Record<string, string>
+  >({})
+  const [editForm, setEditForm] = useState({
+    preferred_name: role?.attributes?.preferred_name?.[0] ?? '',
+    description: role?.attributes?.description?.[0] ?? '',
+  })
+
+  const { mutate: createRole, isPending: isCreatePending } =
+    useCreateRoleMutation()
+  const { mutate: updateAttributes, isPending: isUpdatePending } =
+    useUpdateRoleAttributesMutation()
+  const { data: metadataData, isLoading: isMetadataLoading } =
+    useGetRoleMetadata()
+
+  const isPending = isCreatePending || isUpdatePending
+
+  const sortedAttributeEntries = useMemo(() => {
+    if (isEditMode) return []
+    const attrs = metadataData?.attributes ?? []
+    return [...attrs].sort((a, b) =>
+      a.required === b.required ? 0 : a.required ? -1 : 1,
+    )
+  }, [metadataData, isEditMode])
+
+  const isSaveDisabled = isEditMode
+    ? isPending || !editForm.preferred_name.trim()
+    : !roleName.trim() ||
+      isPending ||
+      isMetadataLoading ||
+      sortedAttributeEntries.some(
+        (attr) => attr.required && !attributeValues[attr.key]?.trim(),
+      )
+
+  const handleSave = () => {
+    if (isEditMode) {
+      const attributes: Record<string, string[]> = {
+        ...(role.attributes ?? {}),
+      }
+      attributes.preferred_name = [editForm.preferred_name.trim()]
+      attributes.description = [editForm.description.trim()]
+
+      updateAttributes(
+        { roleId: role.id, attributes },
+        {
+          onSuccess: (data) => {
+            toast.success(data.message || 'Role updated successfully')
+            onSuccess()
+          },
+          onError: (err) => {
+            toast.error(`Failed to update role: ${err.message}`)
+          },
+        },
+      )
+    } else {
+      const name = roleName.trim()
+      if (!name) return
+
+      const attributes: Record<string, string[]> = {}
+      for (const { key } of sortedAttributeEntries) {
+        const value = attributeValues[key]?.trim()
+        if (value) attributes[key] = [value]
+      }
+
+      createRole(
+        {
+          name,
+          ...(Object.keys(attributes).length > 0 ? { attributes } : {}),
+        },
+        {
+          onSuccess: () => {
+            toast.success('Role created successfully')
+            onSuccess()
+          },
+          onError: (err) => {
+            toast.error(`Failed to create role: ${err.message}`)
+          },
+        },
+      )
+    }
+  }
+
+  const handleEditFormChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditForm((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !isSaveDisabled) handleSave()
+    if (e.key === 'Escape') onSuccess()
+  }
+
+  const title = isEditMode
+    ? (role.attributes?.preferred_name?.[0] ?? role.name)
+    : 'Add a new role'
+
+  return (
+    <div className="flex flex-col gap-1.5 px-4 py-2 border border-line rounded-lg bg-white">
+      <p
+        className={`font-semibold text-body truncate ${isEditMode ? 'text-sm mb-1' : 'mb-0.5'}`}
+      >
+        {title}
+      </p>
+
+      {isEditMode ? (
+        <>
+          <div className="flex flex-col gap-0.5">
+            <label className="text-xs font-medium text-muted">Name</label>
+            <input type="text" value={role.name} className="text-xs" disabled />
+          </div>
+
+          <div className="flex flex-col gap-0.5">
+            <label className="text-xs font-medium text-muted">
+              Preferred Name <span className="required">*</span>
+            </label>
+            <input
+              autoFocus
+              type="text"
+              name="preferred_name"
+              value={editForm.preferred_name}
+              onChange={handleEditFormChange}
+              onKeyDown={handleKeyDown}
+              placeholder={role.name}
+              className="text-xs"
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="flex flex-col gap-0.5">
+            <label className="text-xs font-medium text-muted">
+              Description
+            </label>
+            <input
+              type="text"
+              name="description"
+              value={editForm.description}
+              onChange={handleEditFormChange}
+              onKeyDown={handleKeyDown}
+              placeholder="Enter description..."
+              className="text-xs"
+              disabled={isPending}
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex flex-col gap-0.5">
+            <label className="text-sm font-medium text-muted">
+              Name <span className="required">*</span>
+            </label>
+            <input
+              autoFocus
+              type="text"
+              value={roleName}
+              onChange={(e) => setRoleName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Enter role name"
+              className="text-xs"
+              disabled={isPending}
+            />
+          </div>
+
+          {sortedAttributeEntries.map((attr) => (
+            <div key={attr.key} className="flex flex-col gap-0.5">
+              <label className="text-sm font-medium text-muted">
+                {attr.label}
+                {attr.required && <span className="required"> *</span>}
+              </label>
+              <input
+                type="text"
+                value={attributeValues[attr.key] ?? ''}
+                onChange={(e) =>
+                  setAttributeValues((prev) => ({
+                    ...prev,
+                    [attr.key]: e.target.value,
+                  }))
+                }
+                onKeyDown={handleKeyDown}
+                placeholder={`Enter ${attr.label.toLowerCase()}`}
+                className="text-xs"
+                disabled={isPending}
+              />
+            </div>
+          ))}
+        </>
+      )}
+
+      <div
+        className={`flex items-center justify-between mb-1 ${isEditMode ? 'mt-1.5 gap-2' : 'mt-2 gap-3'}`}
+      >
+        <Button
+          variant="outline-secondary"
+          size="xs"
+          onClick={onSuccess}
+          disabled={isPending}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          size="xs"
+          onClick={handleSave}
+          disabled={isSaveDisabled}
+        >
+          {isPending ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default RoleForm

--- a/src/pages/endpoints-access/RoleListPanel.tsx
+++ b/src/pages/endpoints-access/RoleListPanel.tsx
@@ -1,12 +1,9 @@
-import { useState, useMemo } from 'react'
-import {
-  useCreateRoleMutation,
-  useGetRoleMetadata,
-} from '@/hooks/useSecuredEndpoints'
+import { useState } from 'react'
 import { PlusIcon } from '@heroicons/react/20/solid'
-import { toast } from 'sonner'
-import Button from '@/components/Button'
+import { PencilSquareIcon } from '@heroicons/react/16/solid'
 import ErrorDisplay from '@/components/ErrorDisplay'
+import IconButton from '@/components/IconButton'
+import RoleForm from './RoleForm'
 import type { Role } from '@/types/securedEndpoints'
 
 interface RoleListPanelProps {
@@ -25,70 +22,16 @@ const RoleListPanel = ({
   error,
 }: RoleListPanelProps) => {
   const [isAdding, setIsAdding] = useState(false)
-  const [newRoleName, setNewRoleName] = useState('')
-  const [attributeValues, setAttributeValues] = useState<
-    Record<string, string>
-  >({})
+  const [editingRoleId, setEditingRoleId] = useState<string | null>(null)
 
-  const { mutate: createRole, isPending } = useCreateRoleMutation()
-  const { data: metadataData, isLoading: isMetadataLoading } =
-    useGetRoleMetadata()
-
-  const sortedAttributeEntries = useMemo(() => {
-    const attrs = metadataData?.attributes ?? []
-    return [...attrs].sort((a, b) =>
-      a.required === b.required ? 0 : a.required ? -1 : 1,
-    )
-  }, [metadataData])
-
-  const isSaveDisabled =
-    !newRoleName.trim() ||
-    isPending ||
-    isMetadataLoading ||
-    sortedAttributeEntries.some(
-      (attr) => attr.required && !attributeValues[attr.key]?.trim(),
-    )
-
-  const handleSave = () => {
-    const name = newRoleName.trim()
-    if (!name) return
-
-    const attributes: Record<string, string[]> = {}
-    for (const { key } of sortedAttributeEntries) {
-      const value = attributeValues[key]?.trim()
-      if (value) {
-        attributes[key] = [value]
-      }
-    }
-
-    createRole(
-      {
-        name,
-        ...(Object.keys(attributes).length > 0 ? { attributes } : {}),
-      },
-      {
-        onSuccess: () => {
-          setNewRoleName('')
-          setAttributeValues({})
-          setIsAdding(false)
-          toast.success('Role created successfully')
-        },
-        onError: (err) => {
-          toast.error(`Failed to create role: ${err.message}`)
-        },
-      },
-    )
+  const handleStartAdding = () => {
+    setEditingRoleId(null)
+    setIsAdding(true)
   }
 
-  const handleCancel = () => {
-    setNewRoleName('')
-    setAttributeValues({})
+  const handleEditClick = (role: Role) => {
     setIsAdding(false)
-  }
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !isSaveDisabled) handleSave()
-    if (e.key === 'Escape') handleCancel()
+    setEditingRoleId(role.id)
   }
 
   return (
@@ -103,73 +46,13 @@ const RoleListPanel = ({
         <>
           {isAdding ? (
             <>
-              <div className="flex flex-col gap-1.5 px-4 py-2 border border-line rounded-lg bg-white">
-                <p className="font-medium text-body mb-0.5">Add a new role</p>
-
-                <div className="flex flex-col gap-0.5">
-                  <label className="text-sm font-medium text-muted">
-                    Name <span className="required">*</span>
-                  </label>
-                  <input
-                    autoFocus
-                    type="text"
-                    value={newRoleName}
-                    onChange={(e) => setNewRoleName(e.target.value)}
-                    onKeyDown={handleKeyDown}
-                    placeholder="Enter role name"
-                    className="text-xs"
-                    disabled={isPending}
-                  />
-                </div>
-
-                {sortedAttributeEntries.map((attr) => (
-                  <div key={attr.key} className="flex flex-col gap-0.5">
-                    <label className="text-sm font-medium text-muted">
-                      {attr.label}
-                      {attr.required && <span className="required"> *</span>}
-                    </label>
-                    <input
-                      type="text"
-                      value={attributeValues[attr.key] ?? ''}
-                      onChange={(e) =>
-                        setAttributeValues((prev) => ({
-                          ...prev,
-                          [attr.key]: e.target.value,
-                        }))
-                      }
-                      onKeyDown={handleKeyDown}
-                      placeholder={`Enter ${attr.label.toLowerCase()}`}
-                      className="text-xs"
-                      disabled={isPending}
-                    />
-                  </div>
-                ))}
-
-                <div className="flex items-center justify-between gap-3 mt-2 mb-1">
-                  <Button
-                    variant="outline-secondary"
-                    size="xs"
-                    onClick={handleCancel}
-                    disabled={isPending}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="primary"
-                    size="xs"
-                    onClick={handleSave}
-                    disabled={isSaveDisabled}
-                  >
-                    {isPending ? 'Saving...' : 'Save'}
-                  </Button>
-                </div>
-              </div>
+              <RoleForm onSuccess={() => setIsAdding(false)} />
               <hr className="border-line my-1" />
             </>
           ) : (
             <button
               type="button"
-              onClick={() => setIsAdding(true)}
+              onClick={handleStartAdding}
               className="flex items-center gap-1 text-sm text-brand font-medium hover:text-brand-strong transition-colors cursor-pointer"
             >
               <PlusIcon className="size-4" />
@@ -179,42 +62,61 @@ const RoleListPanel = ({
 
           {roles.map((role) => {
             const isSelected = selectedRoleId === role.id
+            const isEditing = editingRoleId === role.id
             const count = actionCounts[role.id] ?? 0
             const displayName =
               role.attributes?.preferred_name?.[0] ?? role.name
             const description = role.attributes?.description?.[0]
+
+            if (isEditing) {
+              return (
+                <RoleForm
+                  key={role.id}
+                  role={role}
+                  onSuccess={() => setEditingRoleId(null)}
+                />
+              )
+            }
+
             return (
-              <button
-                key={role.id}
-                type="button"
-                onClick={() => onSelectRole(role.id)}
-                className={`w-full flex items-center justify-between gap-2 px-4 py-2 text-left cursor-pointer transition-all border rounded-lg ${
-                  isSelected
-                    ? 'bg-brand-subtle border-brand ring-1 ring-brand-strong shadow-sm'
-                    : 'bg-white border-line hover:border-brand-muted hover:shadow-sm'
-                }`}
-              >
-                <div className="flex flex-col min-w-0 flex-1">
-                  <span
-                    className={`font-semibold text-sm ${
-                      isSelected ? 'text-brand-strong' : 'text-foreground'
-                    }`}
-                  >
-                    {displayName}
-                  </span>
-                  {description && (
+              <div key={role.id} className="flex items-center gap-1.5 min-w-0">
+                <button
+                  type="button"
+                  onClick={() => onSelectRole(role.id)}
+                  className={`flex-1 min-w-0 flex items-center justify-between gap-2 px-4 py-2 text-left cursor-pointer transition-all border rounded-lg ${
+                    isSelected
+                      ? 'bg-brand-subtle border-brand ring-1 ring-brand-strong shadow-sm'
+                      : 'bg-white border-line hover:border-brand-muted hover:shadow-sm'
+                  }`}
+                >
+                  <div className="flex flex-col min-w-0 flex-1">
                     <span
-                      className="text-xs text-subtle truncate"
-                      title={description}
+                      className={`font-semibold text-sm ${
+                        isSelected ? 'text-brand-strong' : 'text-foreground'
+                      }`}
                     >
-                      {description}
+                      {displayName}
                     </span>
-                  )}
-                </div>
-                <span className="text-xs font-bold px-1.5 py-0.5 rounded-full bg-surface-strong text-muted border border-line shrink-0">
-                  {count}
-                </span>
-              </button>
+                    {description && (
+                      <span
+                        className="text-xs text-subtle line-clamp-2"
+                        title={description}
+                      >
+                        {description}
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-xs font-bold px-1.5 py-0.5 rounded-full bg-surface-strong text-muted border border-line shrink-0">
+                    {count}
+                  </span>
+                </button>
+                <IconButton
+                  icon={<PencilSquareIcon className="size-4" />}
+                  label="Edit role attributes"
+                  onClick={() => handleEditClick(role)}
+                  className="text-muted shrink-0 !p-0"
+                />
+              </div>
             )
           })}
 

--- a/src/pages/manage-tenant-members/MembersTab.tsx
+++ b/src/pages/manage-tenant-members/MembersTab.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import { useGetTenantMembers } from '@/hooks/useTenants'
 import { useRevokeRoleMutation } from '@/hooks/useResources'
+import { useRoleFriendlyName } from '@/hooks/useRoleFriendlyName'
 import { roleBadgeClass } from '@/utils/badges'
 import { TENANT_MEMBERSHIP_ENTITY } from '@/utils/memberships'
-import { tenantMapper } from '@/utils/roleAssignmentMapper'
 import { UserMinusIcon } from '@heroicons/react/16/solid'
 import { toast } from 'sonner'
 import ConfirmDialog from '@/components/ConfirmDialog'
@@ -29,6 +29,8 @@ const MembersTab = ({ tenantId, tenantName }: MembersTabProps) => {
     role: string
     displayName: string
   } | null>(null)
+
+  const getRoleFriendlyName = useRoleFriendlyName()
 
   const { data: membersData, isLoading } = useGetTenantMembers(
     tenantId,
@@ -134,9 +136,7 @@ const MembersTab = ({ tenantId, tenantName }: MembersTabProps) => {
                         'bg-surface-strong text-muted'
                       }
                     >
-                      {membership.attributes?.[
-                        tenantMapper.preferred_role_name
-                      ]?.[0] ?? membership.role}
+                      {getRoleFriendlyName(membership.role)}
                     </Badge>
                   </td>
                   <td className={`${tdBase} px-6`}>
@@ -148,9 +148,7 @@ const MembersTab = ({ tenantId, tenantName }: MembersTabProps) => {
                           member.id,
                           member.email,
                           membership.role,
-                          membership.attributes?.[
-                            tenantMapper.preferred_role_name
-                          ]?.[0] ?? membership.role,
+                          getRoleFriendlyName(membership.role),
                         )
                       }
                       className="text-red-500 hover:bg-red-50"

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -4,6 +4,7 @@ import {
   useGetTenantByName,
 } from '@/hooks/useTenants'
 import { useRevokeRoleMutation } from '@/hooks/useResources'
+import { useRoleFriendlyName } from '@/hooks/useRoleFriendlyName'
 import { useAuth } from '@/auth/useAuth'
 import { Navigate, useParams } from 'react-router-dom'
 import { UserCircleIcon } from '@heroicons/react/16/solid'
@@ -18,7 +19,6 @@ import AssignRoleToUser from './AssignRoleToUser'
 import { squishEmail } from '@/utils/profile'
 import { roleBadgeClass } from '@/utils/badges'
 import { TENANT_MEMBERSHIP_ENTITY } from '@/utils/memberships'
-import { tenantMapper } from '@/utils/roleAssignmentMapper'
 
 const fieldValueClass = 'text-sm text-gray-800 font-medium'
 const fieldValueUnavailableClass = 'text-sm text-subtle italic'
@@ -44,6 +44,7 @@ const Profile = () => {
     error,
   } = useGetUserProfileByUsername(username || '', !!username && isSuperAdmin)
 
+  const getRoleFriendlyName = useRoleFriendlyName()
   const getTenantByNameMutation = useGetTenantByName()
   const revokeRoleMutation = useRevokeRoleMutation()
 
@@ -333,12 +334,7 @@ const Profile = () => {
                                             roleBadgeClass['tenant_viewer']
                                           }
                                         >
-                                          {role.attributes?.[
-                                            tenantMapper.preferred_role_name
-                                          ]?.[0] ??
-                                            (role.role === 'super_admin'
-                                              ? 'Super Admin'
-                                              : role.role)}
+                                          {getRoleFriendlyName(role.role)}
                                         </Badge>
                                       </div>
 
@@ -351,9 +347,7 @@ const Profile = () => {
                                             entityType,
                                             role.name,
                                             role.role,
-                                            role.attributes?.[
-                                              tenantMapper.preferred_role_name
-                                            ]?.[0] ?? role.role,
+                                            getRoleFriendlyName(role.role),
                                           )
                                         }
                                         title="Revoke this role"
@@ -400,12 +394,7 @@ const Profile = () => {
                                     roleBadgeClass['tenant_viewer']
                                   }
                                 >
-                                  {tenant.attributes?.[
-                                    tenantMapper.preferred_role_name
-                                  ]?.[0] ??
-                                    (tenant.role === 'super_admin'
-                                      ? 'Super Admin'
-                                      : tenant.role)}
+                                  {getRoleFriendlyName(tenant.role)}
                                 </Badge>
                               </div>
                             </div>

--- a/src/types/securedEndpoints.ts
+++ b/src/types/securedEndpoints.ts
@@ -38,6 +38,12 @@ export type RoleEndpointAssignmentResponse = {
   code: string
 }
 
+export type ApiMessageResponse = {
+  message: string
+  code: number
+  errors?: string[]
+}
+
 export type Role = {
   id: string
   name: string


### PR DESCRIPTION
This PR implements the ability to edit role attributes directly from the role list panel.

- Added an edit form on each role item for updating its display name and description, with the original role name shown as read-only
- Extracted role create and edit forms into a shared form component within the role management panel
- Added API function and mutation hook for updating role attributes