### PR TITLE
[ARGO-5463] - Export topology endpoints to CSV file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@formkit/drag-and-drop": "^0.5.3",
         "@heroicons/react": "^2.2.0",
+        "@json2csv/plainjs": "^7.0.6",
+        "@json2csv/transforms": "^7.0.6",
         "@tailwindcss/vite": "^4.1.12",
         "@tanstack/react-query": "^5.85.5",
         "@tanstack/react-query-devtools": "^5.85.5",
@@ -1047,6 +1049,28 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@json2csv/formatters": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/formatters/-/formatters-7.0.6.tgz",
+      "integrity": "sha512-hjIk1H1TR4ydU5ntIENEPgoMGW+Q7mJ+537sDFDbsk+Y3EPl2i4NfFVjw0NJRgT+ihm8X30M67mA8AS6jPidSA==",
+      "license": "MIT"
+    },
+    "node_modules/@json2csv/plainjs": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/plainjs/-/plainjs-7.0.6.tgz",
+      "integrity": "sha512-4Md7RPDCSYpmW1HWIpWBOqCd4vWfIqm53S3e/uzQ62iGi7L3r34fK/8nhOMEe+/eVfCx8+gdSCt1d74SlacQHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@json2csv/formatters": "^7.0.6",
+        "@streamparser/json": "^0.0.20"
+      }
+    },
+    "node_modules/@json2csv/transforms": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/transforms/-/transforms-7.0.6.tgz",
+      "integrity": "sha512-WURhLNL4rNa3PcvXCyy5alvuthnb2Pk9SiC3S7mQZSMbwkMa2E36upoWu9QCbfUpVR6xG1S1vkSdXUAKCjfxcQ==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1364,6 +1388,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.20.tgz",
+      "integrity": "sha512-VqAAkydywPpkw63WQhPVKCD3SdwXuihCUVZbbiY3SfSTGQyHmwRoq27y4dmJdZuJwd5JIlQoMPyGvMbUPY0RKQ==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.12",
@@ -2245,9 +2275,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001736",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001736.tgz",
-      "integrity": "sha512-ImpN5gLEY8gWeqfLUyEF4b7mYWcYoR2Si1VhnrbM4JizRFmfGaAQ12PhNykq6nvI4XvKLrsp8Xde74D5phJOSw==",
+      "version": "1.0.30001780",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
+      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "preview": "vite preview"
@@ -14,6 +15,8 @@
   "dependencies": {
     "@formkit/drag-and-drop": "^0.5.3",
     "@heroicons/react": "^2.2.0",
+    "@json2csv/transforms": "^7.0.6",
+    "@json2csv/plainjs": "^7.0.6",
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-query-devtools": "^5.85.5",

--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -1,10 +1,15 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { PencilSquareIcon, TrashIcon } from '@heroicons/react/16/solid'
+import {
+  ArrowDownTrayIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from '@heroicons/react/16/solid'
 import {
   useGetTopologyEndpoints,
   useCreateTopologyEndpointMutation,
 } from '@/hooks/useTopology'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
 import Button from '@/components/Button'
 import { getLatestTopologyDate } from './utils/topologyDateHelpers'
 import { sortByField } from './utils/topologySortHelpers'
@@ -22,6 +27,7 @@ import Badge from '@/components/Badge'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import SelectDropdown from '@/components/SelectDropdown'
+import { buildCSV, downloadCSV, sanitizeFilename } from '@/utils/csvExport'
 import type { EndpointTopologyItem } from '@/types/topology'
 
 type SortColumn = 'service' | 'group' | 'tags.monitored'
@@ -34,6 +40,7 @@ interface TopologyEndpointsProps {
 }
 
 const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
+  const { tenant } = useSelectedTenant()
   const [monitoredFilter, setMonitoredFilter] = useState<
     'all' | 'monitored' | 'not_monitored'
   >('all')
@@ -59,6 +66,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
     showActions,
     isInternal,
     isExternal,
+    isTopologyTypeLoading,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,
@@ -110,6 +118,16 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
     )
   }
 
+  const handleExport = () => {
+    const tenantName = tenant?.info.name ?? tenantId
+    const datePart = committedDate || latestDate
+
+    downloadCSV(
+      `${sanitizeFilename(tenantName)}${datePart ? `-${datePart}` : ''}-Topology-Endpoints.csv`,
+      buildCSV(sorted),
+    )
+  }
+
   const filtered = (endpoints ?? []).filter((e) => {
     if (monitoredFilter === 'monitored' && e.tags?.monitored !== '1') {
       return false
@@ -139,7 +157,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
 
   return (
     <>
-      <div className="flex flex-wrap xl:flex-nowrap items-center gap-3 mb-3">
+      <div className="flex flex-wrap xl:flex-nowrap items-center gap-x-1.5 gap-y-3 mb-3">
         <SearchInput
           value={searchInput}
           onChange={setSearchInput}
@@ -152,13 +170,13 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
             variant="primary"
             size="md"
             href={`/tenants/${tenantId}/topology/create`}
-            className="shrink-0 xl:order-last ms-auto xl:ms-2"
+            className="shrink-0 ms-auto xl:order-last xl:ms-1"
           >
             Add Endpoint
           </Button>
         )}
-        <div className="flex items-center gap-1.5 w-full xl:w-auto">
-          <div className="hidden xl:block h-8 w-px bg-line-strong me-1" />
+        <div className="flex items-center gap-1 w-full xl:w-auto">
+          <div className="hidden xl:block h-8 w-px bg-line-strong mx-1" />
           <SelectDropdown
             value={dateMode}
             onChange={handleDateModeChange}
@@ -169,7 +187,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
               },
               { value: 'custom', label: 'Select date' },
             ]}
-            className="w-46 shrink-0"
+            className={`${dateMode === 'latest' ? 'w-46' : 'w-36'} shrink-0`}
           />
           {dateMode === 'custom' && (
             <input
@@ -180,6 +198,14 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
               className="text-sm"
             />
           )}
+          <div className="hidden xl:block h-8 w-px bg-line-strong mx-1" />
+          <IconButton
+            icon={<ArrowDownTrayIcon className="size-5.5" />}
+            label="Export as CSV"
+            onClick={handleExport}
+            disabled={!sorted.length || isTopologyTypeLoading}
+            className={`text-body border border-line-strong hover:bg-surface-strong shrink-0 ${!isInternal ? 'tooltip-left' : ''}`}
+          />
           <SelectDropdown
             value={monitoredFilter}
             onChange={(value) => {
@@ -191,7 +217,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
               { value: 'monitored', label: 'Monitored' },
               { value: 'not_monitored', label: 'Not monitored' },
             ]}
-            className="w-40 shrink-0 ms-auto xl:ms-0 xl:order-first"
+            className="w-36 shrink-0 ms-auto xl:ms-0 xl:order-first"
           />
         </div>
       </div>
@@ -273,7 +299,7 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           ) : (
             paginated.map((endpoint) => (
               <tr
-                key={`${endpoint.tags?.info_URL ?? endpoint.hostname}_${endpoint.service}`}
+                key={`${endpoint.tags?.info_URL ?? endpoint.hostname}_${endpoint.service}_${endpoint.group}`}
                 className="hover:bg-surface-muted transition-colors"
               >
                 <td className={tdBase}>{endpoint.service}</td>

--- a/src/pages/tenant-topology/hooks/useTopologyListState.ts
+++ b/src/pages/tenant-topology/hooks/useTopologyListState.ts
@@ -36,12 +36,11 @@ export const useTopologyListState = <TSort extends string>({
   }, [committedDate])
 
   const { tenant } = useSelectedTenant()
-  const { data: topologyFeedData } = useGetTopologyFeedQuery(
-    tenant?.id ?? '',
-    !!tenant?.id,
-  )
+  const { data: topologyFeedData, isFetching: isTopologyFeedFetching } =
+    useGetTopologyFeedQuery(tenant?.id ?? '', !!tenant?.id)
   const isInternal = topologyFeedData?.type === 'internal'
   const isExternal = topologyFeedData?.type === 'external'
+  const isTopologyTypeLoading = !tenant?.id || isTopologyFeedFetching
 
   const showActions =
     isInternal &&
@@ -91,6 +90,7 @@ export const useTopologyListState = <TSort extends string>({
     showActions,
     isInternal,
     isExternal,
+    isTopologyTypeLoading,
     handleDateInputChange,
     handleDateModeChange,
     handleSortChange,

--- a/src/utils/csvExport.ts
+++ b/src/utils/csvExport.ts
@@ -1,0 +1,47 @@
+import { Parser } from '@json2csv/plainjs'
+import { flatten } from '@json2csv/transforms'
+
+export const sanitizeFilename = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+
+const isBlankValue = (value: unknown): boolean =>
+  value === '' || (Array.isArray(value) && value.every((item) => item === ''))
+
+// Recursively turns blank strings and empty-string arrays into undefined, without deleting the key
+const clearBlankValues = (value: unknown): unknown => {
+  if (isBlankValue(value)) {
+    return undefined
+  }
+  if (Array.isArray(value)) {
+    return value
+  }
+  if (value !== null && typeof value === 'object') {
+    const cleaned: Record<string, unknown> = {}
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      cleaned[key] = clearBlankValues(val)
+    }
+    return cleaned
+  }
+  return value
+}
+
+export const buildCSV = <T extends object>(rows: T[]): string => {
+  const parser = new Parser({ transforms: [flatten({ objects: true })] })
+  return parser.parse(rows.map(clearBlankValues) as T[])
+}
+
+export const downloadCSV = (filename: string, csv: string): void => {
+  const blob = new Blob([csv], {
+    type: 'text/csv;charset=utf-8;',
+  })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+
+  document.body.removeChild(link)
+  // Revoking synchronously can race Safari's async download
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}


### PR DESCRIPTION
This PR adds the ability to export the Topology Endpoints table as a CSV file, including every field with its raw value, displaying the current sorted view.

- Integrated a third-party library for CSV generation, handling columns that contain multiple values
- Implemented generic helper functions for building CSV content and downloading it as a file
- Adjusted the layout to fit the new icon button alongside the existing filters