### PR TITLE
[ARGO-5728] - Update the CSV export columns for Topology Endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@formkit/drag-and-drop": "^0.5.3",
         "@heroicons/react": "^2.2.0",
         "@json2csv/plainjs": "^7.0.6",
-        "@json2csv/transforms": "^7.0.6",
         "@tailwindcss/vite": "^4.1.12",
         "@tanstack/react-query": "^5.85.5",
         "@tanstack/react-query-devtools": "^5.85.5",
@@ -1064,12 +1063,6 @@
         "@json2csv/formatters": "^7.0.6",
         "@streamparser/json": "^0.0.20"
       }
-    },
-    "node_modules/@json2csv/transforms": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@json2csv/transforms/-/transforms-7.0.6.tgz",
-      "integrity": "sha512-WURhLNL4rNa3PcvXCyy5alvuthnb2Pk9SiC3S7mQZSMbwkMa2E36upoWu9QCbfUpVR6xG1S1vkSdXUAKCjfxcQ==",
-      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@formkit/drag-and-drop": "^0.5.3",
     "@heroicons/react": "^2.2.0",
-    "@json2csv/transforms": "^7.0.6",
     "@json2csv/plainjs": "^7.0.6",
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.85.5",

--- a/src/pages/tenant-topology/TopologyEndpoints.tsx
+++ b/src/pages/tenant-topology/TopologyEndpoints.tsx
@@ -27,12 +27,23 @@ import Badge from '@/components/Badge'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import SelectDropdown from '@/components/SelectDropdown'
-import { buildCSV, downloadCSV, sanitizeFilename } from '@/utils/csvExport'
+import {
+  buildCSV,
+  downloadCSV,
+  sanitizeFilename,
+  type CsvField,
+} from '@/utils/csvExport'
 import type { EndpointTopologyItem } from '@/types/topology'
 
 type SortColumn = 'service' | 'group' | 'tags.monitored'
 
 const pageSize = 15
+
+const toBooleanFlag = (value: string | undefined): boolean | undefined => {
+  if (value === '1') return true
+  if (value === '0') return false
+  return undefined
+}
 
 interface TopologyEndpointsProps {
   tenantId: string
@@ -119,12 +130,68 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
   }
 
   const handleExport = () => {
+    const knownTagKeys = new Set([
+      'hostname',
+      'info_ID',
+      'info_URL',
+      'monitored',
+      'production',
+      'scope',
+    ])
+    const extraTagKeys = Array.from(
+      new Set(sorted.flatMap((endpoint) => Object.keys(endpoint.tags ?? {}))),
+    )
+      .filter((key) => !knownTagKeys.has(key))
+      .sort()
+
+    const fields: CsvField<EndpointTopologyItem>[] = [
+      { label: 'Date', value: 'date' },
+      { label: 'Group', value: 'group' },
+      { label: 'Type', value: 'type' },
+      { label: 'Service', value: 'service' },
+      ...(isExternal
+        ? [
+            {
+              label: 'Hostname',
+              value: (endpoint: EndpointTopologyItem) =>
+                endpoint.tags?.hostname || endpoint.hostname,
+            },
+          ]
+        : []),
+      { label: 'URL', value: 'tags.info_URL' },
+      { label: 'Service_ID', value: 'tags.info_ID' },
+      {
+        label: 'Monitored',
+        value: (endpoint: EndpointTopologyItem) =>
+          toBooleanFlag(endpoint.tags?.monitored),
+      },
+      {
+        label: 'Contacts_to_notify',
+        value: (endpoint: EndpointTopologyItem) =>
+          (endpoint.notifications?.contacts ?? [])
+            .filter((email: string) => email !== '')
+            .join('; '),
+      },
+      { label: 'Notifications.enabled', value: 'notifications.enabled' },
+      ...extraTagKeys.map(
+        (key): CsvField<EndpointTopologyItem> => ({
+          label: key,
+          value: (endpoint: EndpointTopologyItem) => endpoint.tags?.[key] ?? '',
+        }),
+      ),
+      {
+        label: 'In_production',
+        value: (endpoint: EndpointTopologyItem) =>
+          toBooleanFlag(endpoint.tags?.production),
+      },
+    ]
+
     const tenantName = tenant?.info.name ?? tenantId
     const datePart = committedDate || latestDate
 
     downloadCSV(
       `${sanitizeFilename(tenantName)}${datePart ? `-${datePart}` : ''}-Topology-Endpoints.csv`,
-      buildCSV(sorted),
+      buildCSV(sorted, fields),
     )
   }
 
@@ -165,12 +232,20 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
           placeholder="Search by service, URL or group..."
           className="!mb-0 flex-1 max-w-xs xl:max-w-none"
         />
+        <div className="hidden xl:block h-8 w-px bg-line-strong mx-1 xl:order-last" />
+        <IconButton
+          icon={<ArrowDownTrayIcon className="size-5.5" />}
+          label="Export as CSV"
+          onClick={handleExport}
+          disabled={!sorted.length || isTopologyTypeLoading}
+          className={`text-body border border-line-strong hover:bg-surface-strong shrink-0 ms-auto xl:order-last ${!isInternal ? 'tooltip-left' : ''}`}
+        />
         {isInternal && (
           <Button
             variant="primary"
             size="md"
             href={`/tenants/${tenantId}/topology/create`}
-            className="shrink-0 ms-auto xl:order-last xl:ms-1"
+            className="shrink-0 xl:order-last xl:ms-1"
           >
             Add Endpoint
           </Button>
@@ -198,14 +273,6 @@ const TopologyEndpoints = ({ tenantId, onEdit }: TopologyEndpointsProps) => {
               className="text-sm"
             />
           )}
-          <div className="hidden xl:block h-8 w-px bg-line-strong mx-1" />
-          <IconButton
-            icon={<ArrowDownTrayIcon className="size-5.5" />}
-            label="Export as CSV"
-            onClick={handleExport}
-            disabled={!sorted.length || isTopologyTypeLoading}
-            className={`text-body border border-line-strong hover:bg-surface-strong shrink-0 ${!isInternal ? 'tooltip-left' : ''}`}
-          />
           <SelectDropdown
             value={monitoredFilter}
             onChange={(value) => {

--- a/src/utils/csvExport.ts
+++ b/src/utils/csvExport.ts
@@ -1,33 +1,45 @@
-import { Parser } from '@json2csv/plainjs'
-import { flatten } from '@json2csv/transforms'
+import { Parser, type FieldInfo } from '@json2csv/plainjs'
+
+export type CsvField<T> = FieldInfo<T, unknown>
 
 export const sanitizeFilename = (value: string): string =>
   value.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-+|-+$/g, '')
 
-const isBlankValue = (value: unknown): boolean =>
-  value === '' || (Array.isArray(value) && value.every((item) => item === ''))
+const isEmptyValue = (value: unknown): boolean =>
+  value === undefined || value === null || value === ''
 
-// Recursively turns blank strings and empty-string arrays into undefined, without deleting the key
-const clearBlankValues = (value: unknown): unknown => {
-  if (isBlankValue(value)) {
-    return undefined
+// Used to detect empty columns before parsing
+const previewFieldValue = <T>(row: T, field: CsvField<T>): unknown => {
+  if (typeof field.value !== 'string') {
+    return field.value(row, {
+      label: field.label ?? '',
+      default: field.default,
+    })
   }
-  if (Array.isArray(value)) {
-    return value
-  }
-  if (value !== null && typeof value === 'object') {
-    const cleaned: Record<string, unknown> = {}
-    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      cleaned[key] = clearBlankValues(val)
+
+  let current: unknown = row
+  for (const key of field.value.split('.')) {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== 'object'
+    ) {
+      return undefined
     }
-    return cleaned
+    current = (current as Record<string, unknown>)[key]
   }
-  return value
+  return current
 }
 
-export const buildCSV = <T extends object>(rows: T[]): string => {
-  const parser = new Parser({ transforms: [flatten({ objects: true })] })
-  return parser.parse(rows.map(clearBlankValues) as T[])
+export const buildCSV = <T extends object>(
+  rows: T[],
+  fields: CsvField<T>[],
+): string => {
+  const nonEmptyFields = fields.filter((field) =>
+    rows.some((row) => !isEmptyValue(previewFieldValue(row, field))),
+  )
+  const parser = new Parser<T, T>({ fields: nonEmptyFields })
+  return parser.parse(rows)
 }
 
 export const downloadCSV = (filename: string, csv: string): void => {


### PR DESCRIPTION
This PR updates the Topology Endpoints CSV export with clearer column labels, consistent true/false, plain text formatting for values and a clearer column selection so only meaningful data is included.

- Updated boolean values to export as true/false instead of 0/1
- Formatted notification contacts as a plain list of emails instead of a raw array
- Limited the Hostname column to endpoints with 'external' topology feed type
- Renamed columns to more descriptive labels so the exported file is easier to read
- Removed the Scope column
- Excluded columns that have no data at all
