### PR TITLE
[ARGO-5723] - Add configuration settings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import {
   Outlet,
   Route,
   Routes,
+  useLocation,
 } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import Layout from './Layout'
@@ -21,6 +22,7 @@ import AssignProjects from './pages/AssignProjects'
 import CreateProject from './pages/CreateProject'
 import Administration from './pages/administration'
 import EndpointsAccess from './pages/endpoints-access'
+import { Settings, PerformanceSettings } from './pages/configuration-settings'
 import ManageTenantMembers from './pages/manage-tenant-members'
 import MyInvitations from './pages/MyInvitations'
 import { InvitationReview } from './pages/InvitationReview'
@@ -189,6 +191,22 @@ function PlatformRoutes() {
             }
           />
           <Route
+            path="settings"
+            element={
+              <ProtectedRoute requiredRoles={['super_admin']}>
+                <Settings />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="settings/:id"
+            element={
+              <ProtectedRoute requiredRoles={['super_admin']}>
+                <PerformanceSettings />
+              </ProtectedRoute>
+            }
+          />
+          <Route
             path="my-invitations"
             element={
               <AuthProtected>
@@ -268,10 +286,24 @@ function PlatformRoutes() {
 }
 
 function CustomDomainRoutes() {
+  const location = useLocation()
+
   return (
     <Routes>
       <Route element={<PublicTenantLayout />}>
-        <Route path="/" element={<PublicDashboardContainer />} />
+        <Route
+          index
+          element={
+            <Navigate
+              to={{
+                pathname: '/dashboard',
+                search: location.search,
+                hash: location.hash,
+              }}
+              replace
+            />
+          }
+        />
         <Route path="/dashboard" element={<PublicDashboardContainer />} />
         <Route path="/capabilities" element={<PublicCapabilitiesContainer />} />
       </Route>

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -1,0 +1,70 @@
+import type { Setting, SettingUpdateRequest } from '@/types/settings'
+
+const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+export const fetchSettings = async (token: string): Promise<Setting[]> => {
+  const response = await fetch(`${BACKEND_API}/v1/admin/settings`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const fetchSettingById = async (
+  id: string,
+  token: string,
+): Promise<Setting> => {
+  const response = await fetch(`${BACKEND_API}/v1/admin/settings/${id}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
+export const updateSetting = async (
+  id: string,
+  data: SettingUpdateRequest,
+  token: string,
+): Promise<Setting> => {
+  const response = await fetch(`${BACKEND_API}/v1/admin/settings/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    const error = new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    ) as Error & { errors?: string[] }
+    error.errors = errorData.errors || []
+    throw error
+  }
+
+  return response.json()
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   ServerStackIcon,
   CircleStackIcon,
   LockClosedIcon,
+  Cog6ToothIcon,
 } from '@heroicons/react/16/solid'
 import { ChartNetwork } from 'lucide-react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -192,6 +193,10 @@ function Sidebar({
               >
                 <LockClosedIcon className="size-4" aria-hidden />
                 Endpoints Access
+              </SidebarNavItem>
+              <SidebarNavItem to="/settings" onClick={onCloseMobileMenu}>
+                <Cog6ToothIcon className="size-4" aria-hidden />
+                Settings
               </SidebarNavItem>
             </div>
           )}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,0 +1,57 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAuth } from '@/auth/useAuth'
+import { fetchSettings, fetchSettingById, updateSetting } from '@/api/settings'
+import type { Setting, SettingUpdateRequest } from '@/types/settings'
+
+export const useGetSettings = (enabled: boolean = true) => {
+  const { token } = useAuth()
+
+  return useQuery<Setting[], Error>({
+    queryKey: ['settings'],
+    queryFn: () => {
+      if (!token) throw new Error('No authentication token available')
+      return fetchSettings(token)
+    },
+    retry: false,
+    enabled: enabled && !!token,
+  })
+}
+
+export const useGetSettingById = (id: string, enabled: boolean = true) => {
+  const { token } = useAuth()
+
+  return useQuery<Setting, Error>({
+    queryKey: ['setting', id],
+    queryFn: () => {
+      if (!token) throw new Error('No authentication token available')
+      if (!id) throw new Error('Setting ID is required')
+      return fetchSettingById(id, token)
+    },
+    retry: false,
+    enabled: enabled && !!token && !!id,
+  })
+}
+
+export const useUpdateSettingMutation = () => {
+  const queryClient = useQueryClient()
+  const { token } = useAuth()
+
+  return useMutation<
+    Setting,
+    Error,
+    { id: string; payload: SettingUpdateRequest }
+  >({
+    mutationFn: ({ id, payload }) => {
+      if (!token) throw new Error('No authentication token available')
+      if (!id) throw new Error('Setting ID is required')
+      return updateSetting(id, payload, token)
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] })
+      queryClient.invalidateQueries({ queryKey: ['setting', variables.id] })
+    },
+    onError: (error) => {
+      console.error('Setting update error:', error)
+    },
+  })
+}

--- a/src/pages/configuration-settings/PerformanceSettings.tsx
+++ b/src/pages/configuration-settings/PerformanceSettings.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect, useRef } from 'react'
+import {
+  useGetSettingById,
+  useUpdateSettingMutation,
+} from '@/hooks/useSettings'
+import { useParams } from 'react-router-dom'
+import { toast } from 'sonner'
+import Button from '@/components/Button'
+import PageHeader from '@/components/PageHeader'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
+
+const sectionClass =
+  'grid grid-cols-1 md:grid-cols-[300px_1fr] gap-4 md:gap-8 mb-6 animate-fade-in'
+const sectionContentClass =
+  'bg-surface-muted border border-line rounded-lg px-6 py-4 flex flex-col gap-3'
+
+const urlRegex = /^https?:\/\/.+\..+$/
+const BASE_URL_FIELD = 'base.url'
+const initialFormState = { [BASE_URL_FIELD]: '', enabled: false }
+
+const PerformanceSettings = () => {
+  const { id } = useParams<{ id: string }>()
+  const [formData, setFormData] = useState(initialFormState)
+  const [baseline, setBaseline] = useState(initialFormState)
+  const [errors, setErrors] = useState({ [BASE_URL_FIELD]: '' })
+  const initializedForId = useRef<string | null>(null)
+
+  const { data: setting, isLoading, error } = useGetSettingById(id ?? '')
+  const updateSettingMutation = useUpdateSettingMutation()
+
+  useEffect(() => {
+    if (setting && id && initializedForId.current !== id) {
+      const currentUrl = setting.data?.config?.[BASE_URL_FIELD]
+      const initial = {
+        [BASE_URL_FIELD]: typeof currentUrl === 'string' ? currentUrl : '',
+        enabled: setting.enabled,
+      }
+      setFormData(initial)
+      setBaseline(initial)
+      initializedForId.current = id
+    }
+  }, [setting, id])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+
+    if (name === BASE_URL_FIELD) {
+      if (value && !urlRegex.test(value)) {
+        setErrors((prev) => ({
+          ...prev,
+          [BASE_URL_FIELD]:
+            'Please enter a valid URL (must start with http:// or https://)',
+        }))
+      } else {
+        setErrors((prev) => ({ ...prev, [BASE_URL_FIELD]: '' }))
+      }
+    }
+  }
+
+  const handleEnabledChange = (enabled: boolean) => {
+    setFormData((prev) => ({ ...prev, enabled }))
+  }
+
+  const isValid =
+    formData[BASE_URL_FIELD].trim() !== '' &&
+    urlRegex.test(formData[BASE_URL_FIELD]) &&
+    !errors[BASE_URL_FIELD]
+
+  const isDirty =
+    formData[BASE_URL_FIELD] !== baseline[BASE_URL_FIELD] ||
+    formData.enabled !== baseline.enabled
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!id || !setting || !isValid || !isDirty) {
+      return
+    }
+
+    updateSettingMutation.mutate(
+      {
+        id,
+        payload: {
+          data: {
+            config: {
+              [BASE_URL_FIELD]: formData[BASE_URL_FIELD].trim(),
+            },
+          },
+          enabled: formData.enabled,
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success('Performance settings saved successfully')
+          setBaseline(formData)
+        },
+        onError: (err: Error) => {
+          toast.error(`Failed to save performance settings: ${err.message}`)
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        title={setting?.data.label || 'Performance View'}
+        subtitle={
+          setting?.data.description ||
+          'Configure the Grafana instance used to embed tenant performance dashboards'
+        }
+        className="mb-1 pb-1"
+        navigateTo={{ label: 'Back to Settings', to: '/settings' }}
+      />
+
+      {isLoading ? (
+        <div className="loading-container">
+          <LoadingSpinner size="md" />
+        </div>
+      ) : error ? (
+        <ErrorDisplay error={error} context="performance settings" />
+      ) : !setting ? (
+        <ErrorDisplay
+          error="Setting not found"
+          context="performance settings"
+        />
+      ) : (
+        <>
+          <div className="flex justify-end mb-4">
+            <Button
+              variant="primary"
+              size="md"
+              onClick={handleSubmit}
+              disabled={updateSettingMutation.isPending || !isValid || !isDirty}
+            >
+              {updateSettingMutation.isPending ? 'Saving...' : 'Save'}
+            </Button>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-7">
+            <div className={sectionClass}>
+              <div className="pt-2 pl-2">
+                <h2 className="section-title">Grafana configuration</h2>
+                <p className="section-description">
+                  Enable and configure the hosted Grafana service
+                </p>
+              </div>
+
+              <div className={sectionContentClass}>
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="toggle toggle-brand"
+                    checked={formData.enabled}
+                    onChange={() => handleEnabledChange(!formData.enabled)}
+                  />
+                  <p className="text-sm font-semibold text-body">
+                    {formData.enabled ? 'Enabled' : 'Disabled'}
+                  </p>
+                </label>
+
+                <div className="flex flex-col">
+                  <label className="text-sm font-medium text-body mb-1">
+                    Grafana base URL <span className="required">*</span>
+                  </label>
+                  <input
+                    type="url"
+                    name={BASE_URL_FIELD}
+                    value={formData[BASE_URL_FIELD]}
+                    onChange={handleChange}
+                    placeholder="Enter Grafana base URL"
+                    required
+                  />
+                  {errors[BASE_URL_FIELD] && (
+                    <span className="text-red-400 text-sm mt-1">
+                      {errors[BASE_URL_FIELD]}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </form>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default PerformanceSettings

--- a/src/pages/configuration-settings/Settings.tsx
+++ b/src/pages/configuration-settings/Settings.tsx
@@ -1,0 +1,56 @@
+import { useGetSettings } from '@/hooks/useSettings'
+import { Link } from 'react-router-dom'
+import PageHeader from '@/components/PageHeader'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import Card from '@/components/Card'
+
+const Settings = () => {
+  const { data: settings, isLoading, error } = useGetSettings()
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        title="Settings"
+        subtitle="Configure system settings and manage application components"
+        className="mb-6"
+      />
+
+      {isLoading ? (
+        <div className="loading-container">
+          <LoadingSpinner size="md" />
+        </div>
+      ) : error ? (
+        <ErrorDisplay error={error} context="settings" />
+      ) : !settings?.length ? (
+        <p className="text-sm text-muted">No settings configured yet.</p>
+      ) : (
+        <>
+          <p className="text-xs font-semibold tracking-widest uppercase text-subtle mb-2">
+            Monitoring
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {settings.map((setting) => (
+              <Link
+                key={setting.id}
+                to={`/settings/${setting.id}`}
+                className="no-underline"
+              >
+                <Card className="px-6 py-4 h-full hover:border-brand transition-colors">
+                  <h3 className="text-base font-medium text-foreground mb-1">
+                    {setting.data.label}
+                  </h3>
+                  <p className="text-sm text-muted">
+                    {setting.data.description}
+                  </p>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default Settings

--- a/src/pages/configuration-settings/index.ts
+++ b/src/pages/configuration-settings/index.ts
@@ -1,0 +1,2 @@
+export { default as Settings } from './Settings'
+export { default as PerformanceSettings } from './PerformanceSettings'

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,18 @@
+export interface SettingData {
+  label: string
+  description: string
+  config?: { [key: string]: unknown }
+}
+
+export interface Setting {
+  id: string
+  data: SettingData
+  enabled: boolean
+  updated_by?: string
+  updated_on?: string
+}
+
+export interface SettingUpdateRequest {
+  data: { config: { [key: string]: unknown } }
+  enabled: boolean
+}


### PR DESCRIPTION
**⚠️ This PR should not be merged before [ARGO-5724](https://github.com/ARGOeu/argo-mon-api/pull/191) is merged**

This PR adds an admin-only Settings page for managing dynamic application configuration, including the setting to configure the hosted Grafana service's base URL.

- Added a Settings page listing configurable settings with a page to edit value and enabled state of a setting
- Added the Grafana base URL as a configurable setting
- Implemented save protection so changes can only be submitted when valid and actually changed
- Added a "Settings" option to the sidebar navigation restricted to super admins