### PR TITLE
[ARGO-5726] - Add performance view for admins and external users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import CreateProject from './pages/CreateProject'
 import Administration from './pages/administration'
 import EndpointsAccess from './pages/endpoints-access'
 import { Settings, PerformanceSettings } from './pages/configuration-settings'
+import TenantPerformance from './pages/TenantPerformance'
 import ManageTenantMembers from './pages/manage-tenant-members'
 import MyInvitations from './pages/MyInvitations'
 import { InvitationReview } from './pages/InvitationReview'
@@ -37,6 +38,7 @@ import {
   PublicTenantLayout,
   PublicDashboardContainer,
   PublicCapabilitiesContainer,
+  PublicPerformanceContainer,
 } from './pages/public-tenant'
 import { AuthProvider } from './auth/AuthProvider'
 import NotFound from './pages/NotFound'
@@ -80,6 +82,7 @@ function PlatformRoutes() {
         <Route index element={<Navigate to="dashboard" replace />} />
         <Route path="dashboard" element={<PublicDashboardContainer />} />
         <Route path="capabilities" element={<PublicCapabilitiesContainer />} />
+        <Route path="performance" element={<PublicPerformanceContainer />} />
         <Route path="*" element={<NotFound />} />
       </Route>
       <Route element={<AuthLayout />}>
@@ -148,6 +151,14 @@ function PlatformRoutes() {
               <AuthProtected>
                 <TenantCapabilities />
               </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/performance"
+            element={
+              <ProtectedRoute requiredRoles={['super_admin']}>
+                <TenantPerformance />
+              </ProtectedRoute>
             }
           />
           <Route
@@ -306,6 +317,7 @@ function CustomDomainRoutes() {
         />
         <Route path="/dashboard" element={<PublicDashboardContainer />} />
         <Route path="/capabilities" element={<PublicCapabilitiesContainer />} />
+        <Route path="/performance" element={<PublicPerformanceContainer />} />
       </Route>
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -43,6 +43,25 @@ export const fetchSettingById = async (
   return response.json()
 }
 
+export const fetchPublicPerformanceSetting = async (): Promise<Setting> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/public/settings/performance`,
+    {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}
+
 export const updateSetting = async (
   id: string,
   data: SettingUpdateRequest,

--- a/src/components/PerformanceEmbed.tsx
+++ b/src/components/PerformanceEmbed.tsx
@@ -1,0 +1,85 @@
+import PageHeader from '@/components/PageHeader'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import type { Setting } from '@/types/settings'
+
+const noticeContainerClass = 'text-center bg-surface-muted rounded-lg'
+const noticeTextClass = 'text-sm text-subtle italic py-6 px-12'
+const BASE_URL_FIELD = 'base.url'
+
+interface PerformanceEmbedProps {
+  tenantName: string
+  isTenantLoading: boolean
+  tenantError?: Error | null
+  performanceSetting: Setting | undefined
+  isSettingsLoading: boolean
+  settingsError: Error | null
+}
+
+const PerformanceEmbed = ({
+  tenantName,
+  isTenantLoading,
+  tenantError,
+  performanceSetting,
+  isSettingsLoading,
+  settingsError,
+}: PerformanceEmbedProps) => {
+  const isLoading = isTenantLoading || isSettingsLoading
+  const error = tenantError || settingsError
+
+  const grafanaBaseUrl = performanceSetting?.data.config?.[BASE_URL_FIELD] as
+    | string
+    | undefined
+
+  const isPerformanceEnabled = performanceSetting?.enabled ?? false
+
+  const iframeSrc =
+    grafanaBaseUrl && tenantName
+      ? `${grafanaBaseUrl.replace(/\/+$/, '')}/${encodeURIComponent(tenantName)}`
+      : null
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        title="Performance"
+        subtitle={
+          tenantName ? `Grafana dashboard for ${tenantName}` : undefined
+        }
+        className="mb-3"
+      />
+
+      {isLoading ? (
+        <div className="loading-container">
+          <LoadingSpinner size="md" />
+        </div>
+      ) : error ? (
+        <ErrorDisplay error={error} context="performance dashboard" />
+      ) : !tenantName ? (
+        <ErrorDisplay
+          error="Tenant could not be resolved"
+          context="performance dashboard"
+        />
+      ) : !grafanaBaseUrl ? (
+        <div className={noticeContainerClass}>
+          <p className={noticeTextClass}>
+            The Grafana base URL has not been configured yet
+          </p>
+        </div>
+      ) : !isPerformanceEnabled ? (
+        <div className={noticeContainerClass}>
+          <p className={noticeTextClass}>
+            Performance monitoring setting is currently disabled
+          </p>
+        </div>
+      ) : (
+        <iframe
+          src={iframeSrc ?? undefined}
+          title={`Grafana dashboard for ${tenantName}`}
+          className="w-full h-[calc(100vh-160px)] border-0 rounded-lg"
+        />
+      )}
+    </div>
+  )
+}
+
+export default PerformanceEmbed

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   CircleStackIcon,
   LockClosedIcon,
   Cog6ToothIcon,
+  ChartBarIcon,
 } from '@heroicons/react/16/solid'
 import { ChartNetwork } from 'lucide-react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -50,6 +51,12 @@ const tenantNavItems: TenantNavItem[] = [
     label: 'Capabilities',
     icon: ShieldCheckIcon,
     requiredRoles: ['tenant_admin'],
+  },
+  {
+    path: 'performance',
+    label: 'Performance',
+    icon: ChartBarIcon,
+    requiredRoles: ['super_admin'],
   },
   {
     path: 'members',

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,6 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/auth/useAuth'
-import { fetchSettings, fetchSettingById, updateSetting } from '@/api/settings'
+import {
+  fetchSettings,
+  fetchSettingById,
+  fetchPublicPerformanceSetting,
+  updateSetting,
+} from '@/api/settings'
 import type { Setting, SettingUpdateRequest } from '@/types/settings'
 
 export const useGetSettings = (enabled: boolean = true) => {
@@ -53,5 +58,15 @@ export const useUpdateSettingMutation = () => {
     onError: (error) => {
       console.error('Setting update error:', error)
     },
+  })
+}
+
+export const useGetPerformanceSettings = () => {
+  return useQuery<Setting, Error>({
+    queryKey: ['public-performance-setting'],
+    queryFn: () => {
+      return fetchPublicPerformanceSetting()
+    },
+    retry: false,
   })
 }

--- a/src/pages/TenantPerformance.tsx
+++ b/src/pages/TenantPerformance.tsx
@@ -1,0 +1,27 @@
+import { useSelectedTenant } from '@/contexts/selected-tenant/useSelectedTenant'
+import { useGetPerformanceSettings } from '@/hooks/useSettings'
+import PerformanceEmbed from '@/components/PerformanceEmbed'
+
+const TenantPerformance = () => {
+  const { tenant, isTenantLoading, tenantError } = useSelectedTenant()
+  const tenantName = tenant?.info?.name ?? ''
+
+  const {
+    data: setting,
+    isLoading: settingsLoading,
+    error: settingsError,
+  } = useGetPerformanceSettings()
+
+  return (
+    <PerformanceEmbed
+      tenantName={tenantName}
+      isTenantLoading={isTenantLoading}
+      tenantError={tenantError}
+      performanceSetting={setting}
+      isSettingsLoading={settingsLoading}
+      settingsError={settingsError}
+    />
+  )
+}
+
+export default TenantPerformance

--- a/src/pages/public-tenant/PublicPerformanceContainer.tsx
+++ b/src/pages/public-tenant/PublicPerformanceContainer.tsx
@@ -1,0 +1,26 @@
+import { useTenantName } from '@/hooks/useTenantName'
+import { useGetPerformanceSettings } from '@/hooks/useSettings'
+import PerformanceEmbed from '@/components/PerformanceEmbed'
+
+const PublicPerformanceContainer = () => {
+  const { tenantName, loading: tenantLoading } = useTenantName()
+
+  const {
+    data: setting,
+    isLoading: settingsLoading,
+    error: settingsError,
+  } = useGetPerformanceSettings()
+
+  return (
+    <PerformanceEmbed
+      tenantName={tenantName ?? ''}
+      isTenantLoading={tenantLoading}
+      tenantError={null}
+      performanceSetting={setting}
+      isSettingsLoading={settingsLoading}
+      settingsError={settingsError}
+    />
+  )
+}
+
+export default PublicPerformanceContainer

--- a/src/pages/public-tenant/PublicTenantLayout.tsx
+++ b/src/pages/public-tenant/PublicTenantLayout.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react'
 import { useTenantName } from '@/hooks/useTenantName'
 import { Outlet } from 'react-router-dom'
-import { CircleStackIcon, ShieldCheckIcon } from '@heroicons/react/16/solid'
+import {
+  CircleStackIcon,
+  ShieldCheckIcon,
+  ChartBarIcon,
+} from '@heroicons/react/16/solid'
 import MobileMenuToggle from '@/components/sidebar/MobileMenuToggle'
 import SidebarHeader from '@/components/sidebar/SidebarHeader'
 import SidebarNavItem from '@/components/sidebar/SidebarNavItem'
@@ -32,6 +36,10 @@ const PublicTenantLayout = () => {
   const capabilitiesPath = isPlatformDomain()
     ? `/public/tenants/${tenantName}/capabilities`
     : '/capabilities'
+
+  const performancePath = isPlatformDomain()
+    ? `/public/tenants/${tenantName}/performance`
+    : '/performance'
 
   return (
     <div className="h-screen flex overflow-hidden">
@@ -76,6 +84,14 @@ const PublicTenantLayout = () => {
           >
             <ShieldCheckIcon className="size-4" aria-hidden />
             Capabilities
+          </SidebarNavItem>
+
+          <SidebarNavItem
+            to={performancePath}
+            onClick={() => setIsMobileMenuOpen(false)}
+          >
+            <ChartBarIcon className="size-4" aria-hidden />
+            Performance
           </SidebarNavItem>
         </nav>
       </aside>

--- a/src/pages/public-tenant/index.ts
+++ b/src/pages/public-tenant/index.ts
@@ -1,3 +1,4 @@
 export { default as PublicTenantLayout } from './PublicTenantLayout'
 export { default as PublicDashboardContainer } from './PublicDashboardContainer'
 export { default as PublicCapabilitiesContainer } from './PublicCapabilitiesContainer'
+export { default as PublicPerformanceContainer } from './PublicPerformanceContainer'


### PR DESCRIPTION
This PR includes both the tasks ARGO-5726 and ARGO-5725, and adds a Performance view that embeds the tenant's Grafana dashboard for both authenticated admins and external users.

- Added an admin-only Performance page for a tenant embedding its Grafana dashboard iframe
- Added a public Performance page for external users available on both platform and custom domains
- Added navigation entries for Performance in both the tenant and public sidebars
- Integrated the new public unauthenticated endpoint for fetching the performance configuration