### PR TITLE
[ARGO-5753] - Hide performance navigation option when the setting is disabled

### DIFF
--- a/src/components/PerformanceEmbed.tsx
+++ b/src/components/PerformanceEmbed.tsx
@@ -43,7 +43,10 @@ const PerformanceEmbed = ({
       <PageHeader
         title="Performance"
         subtitle={
-          tenantName ? `Grafana dashboard for ${tenantName}` : undefined
+          <>
+            Dashboard for tenant{' '}
+            <strong>{tenantName ? tenantName : '...'}</strong>
+          </>
         }
         className="mb-3"
       />

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useGetUserInvitations } from '@/hooks/useInvitations'
+import { useGetPerformanceSettings } from '@/hooks/useSettings'
 import {
   RectangleStackIcon,
   UserGroupIcon,
@@ -12,9 +13,8 @@ import {
   CircleStackIcon,
   LockClosedIcon,
   Cog6ToothIcon,
-  ChartBarIcon,
 } from '@heroicons/react/16/solid'
-import { ChartNetwork } from 'lucide-react'
+import { ChartNetwork, Medal } from 'lucide-react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import TenantPicker from './TenantPicker'
 import SidebarNavItem from './SidebarNavItem'
@@ -55,7 +55,7 @@ const tenantNavItems: TenantNavItem[] = [
   {
     path: 'performance',
     label: 'Performance',
-    icon: ChartBarIcon,
+    icon: Medal,
     requiredRoles: ['super_admin'],
   },
   {
@@ -99,12 +99,19 @@ function Sidebar({
 }: SidebarProps) {
   const navigate = useNavigate()
   const { pathname } = useLocation()
+  const { data: performanceSetting } = useGetPerformanceSettings()
 
-  const isItemVisible = (item: TenantNavItem) =>
-    !item.requiredRoles ||
-    isSuperAdmin ||
-    (roleInSelectedTenant !== null &&
-      item.requiredRoles.includes(roleInSelectedTenant))
+  const isItemVisible = (item: TenantNavItem) => {
+    if (item.path === 'performance' && !performanceSetting?.enabled) {
+      return false
+    }
+    return (
+      !item.requiredRoles ||
+      isSuperAdmin ||
+      (roleInSelectedTenant !== null &&
+        item.requiredRoles.includes(roleInSelectedTenant))
+    )
+  }
 
   const visibleTenantNavItems = tenantNavItems.filter(isItemVisible)
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -54,6 +54,9 @@ export const useUpdateSettingMutation = () => {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['settings'] })
       queryClient.invalidateQueries({ queryKey: ['setting', variables.id] })
+      queryClient.invalidateQueries({
+        queryKey: ['public-performance-setting'],
+      })
     },
     onError: (error) => {
       console.error('Setting update error:', error)

--- a/src/pages/public-tenant/PublicTenantLayout.tsx
+++ b/src/pages/public-tenant/PublicTenantLayout.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTenantName } from '@/hooks/useTenantName'
+import { useGetPerformanceSettings } from '@/hooks/useSettings'
 import { Outlet } from 'react-router-dom'
 import {
   CircleStackIcon,
@@ -16,6 +17,7 @@ import { isPlatformDomain } from '@/utils/domains'
 const PublicTenantLayout = () => {
   const { tenantName, loading: tenantLoading } = useTenantName()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const { data: performanceSetting } = useGetPerformanceSettings()
 
   if (tenantLoading) {
     return (
@@ -86,13 +88,15 @@ const PublicTenantLayout = () => {
             Capabilities
           </SidebarNavItem>
 
-          <SidebarNavItem
-            to={performancePath}
-            onClick={() => setIsMobileMenuOpen(false)}
-          >
-            <ChartBarIcon className="size-4" aria-hidden />
-            Performance
-          </SidebarNavItem>
+          {performanceSetting?.enabled && (
+            <SidebarNavItem
+              to={performancePath}
+              onClick={() => setIsMobileMenuOpen(false)}
+            >
+              <ChartBarIcon className="size-4" aria-hidden />
+              Performance
+            </SidebarNavItem>
+          )}
         </nav>
       </aside>
 


### PR DESCRIPTION
This PR hides the Performance navigation option when performance monitoring setting is disabled.

- Updated the admin and public sidebars to hide the Performance option whenever performance monitoring is disabled
- Updated the icon used for the Performance navigation option