### PR TITLE
[ARGO-5751] - Create group monthly A/R view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import BuildStatusPage from './pages/build-status-page'
 import TenantStatusPages from './pages/status-pages'
 import CreateTenant from './pages/create-tenant'
 import TenantReports from './pages/tenant-reports'
+import { AvailabilityReliability } from './pages/availability-reliability'
 import TenantCapabilities from './pages/tenant-capabilities'
 import TenantDetails from './pages/tenant-details'
 import AssignProjects from './pages/AssignProjects'
@@ -142,6 +143,14 @@ function PlatformRoutes() {
             element={
               <AuthProtected>
                 <TenantReports />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/ar-groups"
+            element={
+              <AuthProtected>
+                <AvailabilityReliability />
               </AuthProtected>
             }
           />

--- a/src/api/availabilityReliability.ts
+++ b/src/api/availabilityReliability.ts
@@ -1,0 +1,34 @@
+import type {
+  GroupsAvailabilityReliabilityResponse,
+  ResultGranularity,
+} from '@/types/availabilityReliability'
+
+const BACKEND_API = import.meta.env.VITE_BACKEND_URI
+
+export const fetchGroupsAvailabilityReliability = async (
+  tenantId: string,
+  reportName: string,
+  granularity: ResultGranularity,
+  startTime: string,
+  endTime: string,
+  token: string,
+): Promise<GroupsAvailabilityReliabilityResponse> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/results/${encodeURIComponent(reportName)}/groups?granularity=${granularity}&start-time=${encodeURIComponent(startTime)}&end-time=${encodeURIComponent(endTime)}`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   ShieldCheckIcon,
   UsersIcon,
   DocumentChartBarIcon,
+  TableCellsIcon,
   ServerStackIcon,
   CircleStackIcon,
   LockClosedIcon,
@@ -38,6 +39,11 @@ const tenantNavItems: TenantNavItem[] = [
     icon: CircleStackIcon,
   },
   { path: 'details', label: 'Overview', icon: HomeIcon },
+  {
+    path: 'ar-groups',
+    label: 'Availability & Reliability',
+    icon: TableCellsIcon,
+  },
   {
     path: 'topology',
     label: 'Topology',

--- a/src/hooks/useAvailabilityReliability.ts
+++ b/src/hooks/useAvailabilityReliability.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query'
+import { useAuth } from '@/auth/useAuth'
+import { fetchGroupsAvailabilityReliability } from '@/api/availabilityReliability'
+import type {
+  GroupsAvailabilityReliabilityResponse,
+  ResultGranularity,
+} from '@/types/availabilityReliability'
+
+export const useGetGroupsAvailabilityReliability = (
+  tenantId: string,
+  reportName: string,
+  granularity: ResultGranularity,
+  startTime: string,
+  endTime: string,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+
+  return useQuery<GroupsAvailabilityReliabilityResponse, Error>({
+    queryKey: [
+      'availability-reliability-groups',
+      tenantId,
+      reportName,
+      granularity,
+      startTime,
+      endTime,
+    ],
+    queryFn: () => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      if (!tenantId) {
+        throw new Error('Tenant ID is required')
+      }
+      if (!reportName) {
+        throw new Error('Report name is required')
+      }
+      return fetchGroupsAvailabilityReliability(
+        tenantId,
+        reportName,
+        granularity,
+        startTime,
+        endTime,
+        token,
+      )
+    },
+    retry: false,
+    enabled:
+      enabled &&
+      !!token &&
+      !!tenantId &&
+      !!reportName &&
+      !!startTime &&
+      !!endTime,
+  })
+}

--- a/src/pages/availability-reliability/AvailabilityReliability.tsx
+++ b/src/pages/availability-reliability/AvailabilityReliability.tsx
@@ -1,0 +1,145 @@
+import { useState, useMemo, useEffect } from 'react'
+import { useGetGroupsAvailabilityReliability } from '@/hooks/useAvailabilityReliability'
+import { useGetTenantReports } from '@/hooks/useTenants'
+import { useSelectedTenant } from '@/contexts/selected-tenant'
+import { useParams, useSearchParams } from 'react-router-dom'
+import PageHeader from '@/components/PageHeader'
+import SearchInput from '@/components/SearchInput'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import SelectDropdown from '@/components/SelectDropdown'
+import MonthlyAvailabilityTable from './MonthlyAvailabilityTable'
+
+const toW3CTimestamp = (date: Date): string =>
+  date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+
+const getLastThreeMonthsRange = (): { startTime: string; endTime: string } => {
+  const now = new Date()
+  const start = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 2, 1, 0, 0, 0),
+  )
+  return { startTime: toW3CTimestamp(start), endTime: toW3CTimestamp(now) }
+}
+
+const AvailabilityReliability = () => {
+  const { id } = useParams<{ id: string }>()
+  const tenantId = id || ''
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { tenant: tenantData } = useSelectedTenant()
+
+  const [search, setSearch] = useState('')
+
+  const { data: reports } = useGetTenantReports(tenantId)
+
+  const selectedReportName = searchParams.get('report') || reports?.[0]?.name
+
+  useEffect(() => {
+    if (!searchParams.get('report') && reports?.[0]?.name) {
+      setSearchParams({ report: reports[0].name }, { replace: true })
+    }
+  }, [reports, searchParams, setSearchParams])
+
+  const { startTime, endTime } = useMemo(() => getLastThreeMonthsRange(), [])
+
+  const {
+    data: groupsData,
+    isLoading,
+    error,
+  } = useGetGroupsAvailabilityReliability(
+    tenantId,
+    selectedReportName || '',
+    'monthly',
+    startTime,
+    endTime,
+    !!selectedReportName,
+  )
+
+  const groups = useMemo(() => {
+    if (!groupsData) {
+      return []
+    }
+    return groupsData.results.flatMap((projectGroup) =>
+      projectGroup.groups.map((group) => ({
+        name: group.name,
+        monthly: group.results.map((result) => ({
+          month: result.timestamp,
+          availability: parseFloat(result.availability),
+          reliability: parseFloat(result.reliability),
+        })),
+      })),
+    )
+  }, [groupsData])
+
+  const months = useMemo(
+    () => groups[0]?.monthly.map((m) => m.month) ?? [],
+    [groups],
+  )
+
+  const filteredGroups = useMemo(
+    () =>
+      groups.filter((group) =>
+        group.name.toLowerCase().includes(search.toLowerCase()),
+      ),
+    [groups, search],
+  )
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        title="Availability & Reliability"
+        subtitle={
+          <>
+            Monthly availability and reliability results for tenant{' '}
+            <strong>
+              {tenantData?.info.name ? tenantData.info.name : '...'}
+            </strong>
+          </>
+        }
+        className="pb-2 mb-4"
+      />
+
+      <div className="flex items-start justify-between gap-4 mb-1.5 flex-wrap">
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          onClear={() => setSearch('')}
+          placeholder="Search groups..."
+        />
+
+        {reports && reports.length > 1 && (
+          <div className="flex items-center gap-2">
+            <span className="text-[15px] font-semibold text-body">
+              Select a report:
+            </span>
+            <SelectDropdown
+              value={selectedReportName || ''}
+              onChange={(value) =>
+                setSearchParams({ report: value }, { replace: true })
+              }
+              options={reports.map((report) => ({
+                value: report.name,
+                label: report.name,
+              }))}
+              className="w-[220px]"
+            />
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="loading-container">
+          <LoadingSpinner size="md" />
+        </div>
+      ) : error ? (
+        <ErrorDisplay
+          error={error}
+          context="loading availability and reliability results"
+        />
+      ) : (
+        <MonthlyAvailabilityTable groups={filteredGroups} months={months} />
+      )}
+    </div>
+  )
+}
+
+export default AvailabilityReliability

--- a/src/pages/availability-reliability/MonthlyAvailabilityTable.tsx
+++ b/src/pages/availability-reliability/MonthlyAvailabilityTable.tsx
@@ -1,0 +1,111 @@
+import { ArrowUpRightIcon } from '@heroicons/react/16/solid'
+import { toneForPercentage } from './availabilityBadge'
+import type { GroupAvailabilityReliability } from '@/types/availabilityReliability'
+
+const thBase =
+  'px-4 py-2.5 text-xs font-semibold text-muted uppercase tracking-wider whitespace-nowrap'
+const badgeClass =
+  'inline-flex items-center justify-self-center rounded-lg px-2.5 py-1 text-xs font-semibold'
+const valueColumns = 'grid-cols-[3.5rem_3.5rem_0.25rem]'
+
+const formatMonthLabel = (month: string): string => {
+  const [year, mon] = month.split('-').map(Number)
+  return new Date(year, mon - 1, 1).toLocaleDateString('en-US', {
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+interface MonthlyAvailabilityTableProps {
+  groups: GroupAvailabilityReliability[]
+  months: string[]
+}
+
+const MonthlyAvailabilityTable = ({
+  groups,
+  months,
+}: MonthlyAvailabilityTableProps) => {
+  return (
+    <div className="bg-white border border-line rounded-lg shadow-sm overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr>
+              <th rowSpan={2} className={`${thBase} text-left pb-2`}>
+                Service
+              </th>
+              {months.map((month) => (
+                <th key={month} className={`${thBase} text-center`}>
+                  {formatMonthLabel(month)}
+                </th>
+              ))}
+            </tr>
+            <tr className="border-b border-line">
+              {months.map((month) => (
+                <th
+                  key={month}
+                  className="px-4 pb-2 text-xs font-semibold text-subtle"
+                >
+                  <div className={`grid gap-2 justify-center ${valueColumns}`}>
+                    <span className="text-center">Av</span>
+                    <span className="text-center">Re</span>
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-line">
+            {groups.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={1 + months.length}
+                  className="text-center text-subtle italic py-8 px-4 text-sm"
+                >
+                  No groups found
+                </td>
+              </tr>
+            ) : (
+              groups.map((group) => (
+                <tr key={group.name}>
+                  <td className="px-4 py-3 text-sm font-medium text-body whitespace-nowrap">
+                    {group.name}
+                  </td>
+                  {months.map((month) => {
+                    const monthly = group.monthly.find((m) => m.month === month)
+                    if (!monthly) {
+                      return <td key={month} className="px-4 py-3" />
+                    }
+                    return (
+                      <td key={month} className="px-2 py-2">
+                        <button
+                          type="button"
+                          onClick={() => {}}
+                          data-tip={`View daily breakdown for ${formatMonthLabel(month)}`}
+                          className={`tooltip group grid ${valueColumns} gap-2 items-center justify-center mx-auto rounded-md border border-transparent px-2 py-1 cursor-pointer bg-transparent transition-all hover:border-line-strong hover:bg-surface-muted`}
+                        >
+                          <span
+                            className={`${badgeClass} ${toneForPercentage(monthly.availability)}`}
+                          >
+                            {monthly.availability}
+                          </span>
+                          <span
+                            className={`${badgeClass} ${toneForPercentage(monthly.reliability)}`}
+                          >
+                            {monthly.reliability}
+                          </span>
+                          <ArrowUpRightIcon className="size-4 text-subtle justify-self-center transition-colors group-hover:text-brand" />
+                        </button>
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export default MonthlyAvailabilityTable

--- a/src/pages/availability-reliability/availabilityBadge.ts
+++ b/src/pages/availability-reliability/availabilityBadge.ts
@@ -1,0 +1,9 @@
+export const toneForPercentage = (value: number): string => {
+  if (value >= 99.5) {
+    return 'bg-emerald-50 text-emerald-600'
+  }
+  if (value >= 95) {
+    return 'bg-amber-50 text-amber-600'
+  }
+  return 'bg-red-50 text-red-600'
+}

--- a/src/pages/availability-reliability/index.ts
+++ b/src/pages/availability-reliability/index.ts
@@ -1,0 +1,1 @@
+export { default as AvailabilityReliability } from './AvailabilityReliability'

--- a/src/types/availabilityReliability.ts
+++ b/src/types/availabilityReliability.ts
@@ -1,0 +1,37 @@
+export type ResultGranularity = 'daily' | 'monthly'
+
+export type GroupMonthlyResult = {
+  month: string
+  availability: number
+  reliability: number
+}
+
+export type GroupAvailabilityReliability = {
+  name: string
+  monthly: GroupMonthlyResult[]
+}
+
+export type GroupResult = {
+  timestamp: string
+  availability: string
+  reliability: string
+  unknown: string
+  uptime: string
+  downtime: string
+}
+
+export type GroupEndpoints = {
+  name: string
+  type: string
+  results: GroupResult[]
+}
+
+export type GroupData = {
+  name: string
+  type: string
+  groups: GroupEndpoints[]
+}
+
+export type GroupsAvailabilityReliabilityResponse = {
+  results: GroupData[]
+}


### PR DESCRIPTION
This PR adds a new Availability & Reliability page showing monthly availability and reliability scores per service group for a tenant.

- Added an Availability & Reliability page listing each service group's availability and reliability scores for the last three months
- Implemented the API integration for fetching monthly group results
- Added a report selector and a search box to filter groups by name
- Added a new sidebar item for navigating to the Availability & Reliability page
