### PR TITLE
[ARGO-5752] - Create daily A/R results for group

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,10 @@ import BuildStatusPage from './pages/build-status-page'
 import TenantStatusPages from './pages/status-pages'
 import CreateTenant from './pages/create-tenant'
 import TenantReports from './pages/tenant-reports'
-import { AvailabilityReliability } from './pages/availability-reliability'
+import {
+  AvailabilityReliability,
+  AvailabilityReliabilityDaily,
+} from './pages/availability-reliability'
 import TenantCapabilities from './pages/tenant-capabilities'
 import TenantDetails from './pages/tenant-details'
 import AssignProjects from './pages/AssignProjects'
@@ -151,6 +154,22 @@ function PlatformRoutes() {
             element={
               <AuthProtected>
                 <AvailabilityReliability />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/ar-groups/report/:reportName"
+            element={
+              <AuthProtected>
+                <AvailabilityReliability />
+              </AuthProtected>
+            }
+          />
+          <Route
+            path="tenants/:id/ar-groups/:groupName/report/:reportName/:month"
+            element={
+              <AuthProtected>
+                <AvailabilityReliabilityDaily />
               </AuthProtected>
             }
           />

--- a/src/api/availabilityReliability.ts
+++ b/src/api/availabilityReliability.ts
@@ -32,3 +32,32 @@ export const fetchGroupsAvailabilityReliability = async (
 
   return response.json()
 }
+
+export const fetchGroupAvailabilityReliability = async (
+  tenantId: string,
+  reportName: string,
+  groupName: string,
+  granularity: ResultGranularity,
+  startTime: string,
+  endTime: string,
+  token: string,
+): Promise<GroupsAvailabilityReliabilityResponse> => {
+  const response = await fetch(
+    `${BACKEND_API}/v1/tenants/${tenantId}/results/${encodeURIComponent(reportName)}/groups/${encodeURIComponent(groupName)}?granularity=${granularity}&start-time=${encodeURIComponent(startTime)}&end-time=${encodeURIComponent(endTime)}`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      errorData.message || `HTTP error! status: ${response.status}`,
+    )
+  }
+
+  return response.json()
+}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -13,6 +13,7 @@ interface PageHeaderProps {
   subtitle?: ReactNode
   children?: ReactNode
   className?: string
+  titleClassName?: string
   navigateTo?: NavigateTo
 }
 
@@ -21,6 +22,7 @@ const PageHeader = ({
   subtitle,
   children,
   className,
+  titleClassName = 'text-[1.75rem]',
   navigateTo,
 }: PageHeaderProps) => (
   <div className={`flex justify-between items-center ${className ?? ''}`}>
@@ -35,7 +37,7 @@ const PageHeader = ({
           {navigateTo.label}
         </Link>
       )}
-      <h1 className="text-[1.75rem] leading-8 font-bold text-gray-800">
+      <h1 className={`${titleClassName} leading-8 font-bold text-gray-800`}>
         {title}
       </h1>
       {subtitle && <p className="text-base text-muted">{subtitle}</p>}

--- a/src/hooks/useAvailabilityReliability.ts
+++ b/src/hooks/useAvailabilityReliability.ts
@@ -1,6 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '@/auth/useAuth'
-import { fetchGroupsAvailabilityReliability } from '@/api/availabilityReliability'
+import {
+  fetchGroupsAvailabilityReliability,
+  fetchGroupAvailabilityReliability,
+} from '@/api/availabilityReliability'
 import type {
   GroupsAvailabilityReliabilityResponse,
   ResultGranularity,
@@ -50,6 +53,62 @@ export const useGetGroupsAvailabilityReliability = (
       !!token &&
       !!tenantId &&
       !!reportName &&
+      !!startTime &&
+      !!endTime,
+  })
+}
+
+export const useGetGroupAvailabilityReliability = (
+  tenantId: string,
+  reportName: string,
+  groupName: string,
+  granularity: ResultGranularity,
+  startTime: string,
+  endTime: string,
+  enabled: boolean = true,
+) => {
+  const { token } = useAuth()
+
+  return useQuery<GroupsAvailabilityReliabilityResponse, Error>({
+    queryKey: [
+      'availability-reliability-group-daily',
+      tenantId,
+      reportName,
+      groupName,
+      granularity,
+      startTime,
+      endTime,
+    ],
+    queryFn: () => {
+      if (!token) {
+        throw new Error('No authentication token available')
+      }
+      if (!tenantId) {
+        throw new Error('Tenant ID is required')
+      }
+      if (!reportName) {
+        throw new Error('Report name is required')
+      }
+      if (!groupName) {
+        throw new Error('Group name is required')
+      }
+      return fetchGroupAvailabilityReliability(
+        tenantId,
+        reportName,
+        groupName,
+        granularity,
+        startTime,
+        endTime,
+        token,
+      )
+    },
+    retry: false,
+    enabled:
+      enabled &&
+      !!token &&
+      !!tenantId &&
+      !!reportName &&
+      !!groupName &&
       !!startTime &&
       !!endTime,
   })

--- a/src/pages/availability-reliability/AvailabilityReliability.tsx
+++ b/src/pages/availability-reliability/AvailabilityReliability.tsx
@@ -2,42 +2,55 @@ import { useState, useMemo, useEffect } from 'react'
 import { useGetGroupsAvailabilityReliability } from '@/hooks/useAvailabilityReliability'
 import { useGetTenantReports } from '@/hooks/useTenants'
 import { useSelectedTenant } from '@/contexts/selected-tenant'
-import { useParams, useSearchParams } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import PageHeader from '@/components/PageHeader'
 import SearchInput from '@/components/SearchInput'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
 import SelectDropdown from '@/components/SelectDropdown'
+import Pagination from '@/components/Pagination'
 import MonthlyAvailabilityTable from './MonthlyAvailabilityTable'
+
+const pageSize = 20
 
 const toW3CTimestamp = (date: Date): string =>
   date.toISOString().replace(/\.\d{3}Z$/, 'Z')
 
 const getLastThreeMonthsRange = (): { startTime: string; endTime: string } => {
   const now = new Date()
-  const start = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 2, 1, 0, 0, 0),
+  const todayUtcDate = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
   )
-  return { startTime: toW3CTimestamp(start), endTime: toW3CTimestamp(now) }
+  const start = new Date(
+    Date.UTC(todayUtcDate.getUTCFullYear(), todayUtcDate.getUTCMonth() - 2, 1),
+  )
+  return {
+    startTime: toW3CTimestamp(start),
+    endTime: toW3CTimestamp(todayUtcDate),
+  }
 }
 
 const AvailabilityReliability = () => {
-  const { id } = useParams<{ id: string }>()
+  const { id, reportName } = useParams<{ id: string; reportName?: string }>()
   const tenantId = id || ''
-  const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
   const { tenant: tenantData } = useSelectedTenant()
 
   const [search, setSearch] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
 
   const { data: reports } = useGetTenantReports(tenantId)
 
-  const selectedReportName = searchParams.get('report') || reports?.[0]?.name
+  const selectedReportName = reportName
 
   useEffect(() => {
-    if (!searchParams.get('report') && reports?.[0]?.name) {
-      setSearchParams({ report: reports[0].name }, { replace: true })
+    if (!reportName && reports?.[0]?.name) {
+      navigate(
+        `/tenants/${tenantId}/ar-groups/report/${encodeURIComponent(reports[0].name)}`,
+        { replace: true },
+      )
     }
-  }, [reports, searchParams, setSearchParams])
+  }, [reportName, reports, tenantId, navigate])
 
   const { startTime, endTime } = useMemo(() => getLastThreeMonthsRange(), [])
 
@@ -83,8 +96,34 @@ const AvailabilityReliability = () => {
     [groups, search],
   )
 
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [search, selectedReportName])
+
+  const totalElements = filteredGroups.length
+  const totalPages = Math.max(1, Math.ceil(totalElements / pageSize))
+
+  useEffect(() => {
+    setCurrentPage((prev) => Math.min(prev, totalPages))
+  }, [totalPages])
+
+  const paginatedGroups = useMemo(
+    () =>
+      filteredGroups.slice(
+        (currentPage - 1) * pageSize,
+        currentPage * pageSize,
+      ),
+    [filteredGroups, currentPage],
+  )
+
+  const handleDrillDown = (groupName: string, month: string) => {
+    navigate(
+      `/tenants/${tenantId}/ar-groups/${encodeURIComponent(groupName)}/report/${encodeURIComponent(selectedReportName || '')}/${month}`,
+    )
+  }
+
   return (
-    <div className="page-container">
+    <div className="page-container mb-8">
       <PageHeader
         title="Availability & Reliability"
         subtitle={
@@ -98,7 +137,7 @@ const AvailabilityReliability = () => {
         className="pb-2 mb-4"
       />
 
-      <div className="flex items-start justify-between gap-4 mb-1.5 flex-wrap">
+      <div className="flex items-start justify-between gap-4 mb-1 flex-wrap">
         <SearchInput
           value={search}
           onChange={setSearch}
@@ -113,8 +152,11 @@ const AvailabilityReliability = () => {
             </span>
             <SelectDropdown
               value={selectedReportName || ''}
-              onChange={(value) =>
-                setSearchParams({ report: value }, { replace: true })
+              onChange={(report) =>
+                navigate(
+                  `/tenants/${tenantId}/ar-groups/report/${encodeURIComponent(report)}`,
+                  { replace: true },
+                )
               }
               options={reports.map((report) => ({
                 value: report.name,
@@ -136,7 +178,23 @@ const AvailabilityReliability = () => {
           context="loading availability and reliability results"
         />
       ) : (
-        <MonthlyAvailabilityTable groups={filteredGroups} months={months} />
+        <>
+          <MonthlyAvailabilityTable
+            groups={paginatedGroups}
+            months={months}
+            onDrillDown={handleDrillDown}
+          />
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalElements={totalElements}
+            itemLabel="groups"
+            onPrev={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+            onNext={() =>
+              setCurrentPage((prev) => Math.min(totalPages, prev + 1))
+            }
+          />
+        </>
       )}
     </div>
   )

--- a/src/pages/availability-reliability/AvailabilityReliabilityDaily.tsx
+++ b/src/pages/availability-reliability/AvailabilityReliabilityDaily.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react'
+import { useGetGroupAvailabilityReliability } from '@/hooks/useAvailabilityReliability'
+import { useParams } from 'react-router-dom'
+import PageHeader from '@/components/PageHeader'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorDisplay from '@/components/ErrorDisplay'
+import DailyAvailabilityTable from './DailyAvailabilityTable'
+
+const formatMonthLabel = (month: string): string => {
+  const [year, mon] = month.split('-').map(Number)
+  return new Date(year, mon - 1, 1).toLocaleDateString('en-GB', {
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+const toW3CTimestamp = (date: Date): string =>
+  date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+
+const getMonthRange = (
+  month: string,
+): { startTime: string; endTime: string } => {
+  const [year, mon] = month.split('-').map(Number)
+  const start = new Date(Date.UTC(year, mon - 1, 1))
+  const end = new Date(Date.UTC(year, mon, 0, 23, 59, 59))
+  return { startTime: toW3CTimestamp(start), endTime: toW3CTimestamp(end) }
+}
+
+const AvailabilityReliabilityDaily = () => {
+  const { id, groupName, reportName, month } = useParams<{
+    id: string
+    groupName: string
+    reportName: string
+    month: string
+  }>()
+  const tenantId = id || ''
+
+  const { startTime, endTime } = useMemo(
+    () => (month ? getMonthRange(month) : { startTime: '', endTime: '' }),
+    [month],
+  )
+
+  const {
+    data: rawData,
+    isLoading,
+    error,
+  } = useGetGroupAvailabilityReliability(
+    tenantId,
+    reportName || '',
+    groupName || '',
+    'daily',
+    startTime,
+    endTime,
+    !!month,
+  )
+
+  const rows = useMemo(() => {
+    if (!rawData) {
+      return []
+    }
+    return rawData.results.flatMap((projectGroup) =>
+      projectGroup.groups.flatMap((group) =>
+        group.results.map((result) => ({
+          date: result.timestamp,
+          availability: parseFloat(result.availability),
+          reliability: parseFloat(result.reliability),
+          unknown: parseFloat(result.unknown),
+          downtime: parseFloat(result.downtime),
+        })),
+      ),
+    )
+  }, [rawData])
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        title={`${decodeURIComponent(groupName || '')} - ${month ? formatMonthLabel(month) : ''}`}
+        className="pb-2 mb-1"
+        titleClassName="text-2xl"
+        navigateTo={{
+          label: 'Back to Monthly Group Results',
+          to: `/tenants/${tenantId}/ar-groups/report/${encodeURIComponent(reportName || '')}`,
+        }}
+      />
+
+      {isLoading ? (
+        <div className="loading-container">
+          <LoadingSpinner size="md" />
+        </div>
+      ) : error ? (
+        <ErrorDisplay error={error} context="daily results" />
+      ) : (
+        <DailyAvailabilityTable rows={rows} />
+      )}
+    </div>
+  )
+}
+
+export default AvailabilityReliabilityDaily

--- a/src/pages/availability-reliability/DailyAvailabilityTable.tsx
+++ b/src/pages/availability-reliability/DailyAvailabilityTable.tsx
@@ -1,0 +1,82 @@
+import { availabilityTone, downtimeTone } from './availabilityBadge'
+import type { GroupDailyResult } from '@/types/availabilityReliability'
+
+const thBase =
+  'px-4 py-3 text-xs font-semibold text-muted uppercase tracking-wider whitespace-nowrap'
+const badgeClass =
+  'inline-flex items-center rounded-lg px-2.5 py-1 text-xs font-semibold'
+const tdBase = 'px-4 py-2 text-center'
+
+interface DailyAvailabilityTableProps {
+  rows: GroupDailyResult[]
+}
+
+const DailyAvailabilityTable = ({ rows }: DailyAvailabilityTableProps) => {
+  return (
+    <div className="bg-white border border-line rounded-lg shadow-sm overflow-hidden mb-8">
+      <div className="overflow-x-auto">
+        <table className="w-full table-fixed border-collapse">
+          <thead>
+            <tr className="border-b border-line">
+              <th className={`${thBase} w-1/5 text-left`}>Timestamp</th>
+              <th className={`${thBase} w-1/5 text-center`}>Availability</th>
+              <th className={`${thBase} w-1/5 text-center`}>Reliability</th>
+              <th className={`${thBase} w-1/5 text-center`}>Unknown</th>
+              <th className={`${thBase} w-1/5 text-center`}>Downtime</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-line">
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="text-center text-subtle italic py-8 px-4 text-sm"
+                >
+                  No daily results found
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => (
+                <tr key={row.date}>
+                  <td className="px-4 py-2 text-sm text-body whitespace-nowrap">
+                    {row.date}
+                  </td>
+                  <td className={tdBase}>
+                    <span
+                      className={`${badgeClass} ${availabilityTone(row.availability)}`}
+                    >
+                      {row.availability}
+                    </span>
+                  </td>
+                  <td className={tdBase}>
+                    <span
+                      className={`${badgeClass} ${availabilityTone(row.reliability)}`}
+                    >
+                      {row.reliability}
+                    </span>
+                  </td>
+                  <td className={tdBase}>
+                    <span
+                      className={`${badgeClass} ${downtimeTone(row.unknown)}`}
+                    >
+                      {row.unknown}
+                    </span>
+                  </td>
+                  <td className={tdBase}>
+                    <span
+                      className={`${badgeClass} ${downtimeTone(row.downtime)}`}
+                    >
+                      {row.downtime}
+                    </span>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export default DailyAvailabilityTable

--- a/src/pages/availability-reliability/MonthlyAvailabilityTable.tsx
+++ b/src/pages/availability-reliability/MonthlyAvailabilityTable.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRightIcon } from '@heroicons/react/16/solid'
-import { toneForPercentage } from './availabilityBadge'
+import { availabilityTone } from './availabilityBadge'
 import type { GroupAvailabilityReliability } from '@/types/availabilityReliability'
 
 const thBase =
@@ -10,7 +10,7 @@ const valueColumns = 'grid-cols-[3.5rem_3.5rem_0.25rem]'
 
 const formatMonthLabel = (month: string): string => {
   const [year, mon] = month.split('-').map(Number)
-  return new Date(year, mon - 1, 1).toLocaleDateString('en-US', {
+  return new Date(year, mon - 1, 1).toLocaleDateString('en-GB', {
     month: 'short',
     year: 'numeric',
   })
@@ -19,11 +19,13 @@ const formatMonthLabel = (month: string): string => {
 interface MonthlyAvailabilityTableProps {
   groups: GroupAvailabilityReliability[]
   months: string[]
+  onDrillDown: (groupName: string, month: string) => void
 }
 
 const MonthlyAvailabilityTable = ({
   groups,
   months,
+  onDrillDown,
 }: MonthlyAvailabilityTableProps) => {
   return (
     <div className="bg-white border border-line rounded-lg shadow-sm overflow-hidden">
@@ -76,20 +78,20 @@ const MonthlyAvailabilityTable = ({
                       return <td key={month} className="px-4 py-3" />
                     }
                     return (
-                      <td key={month} className="px-2 py-2">
+                      <td key={month} className="px-2 py-1">
                         <button
                           type="button"
-                          onClick={() => {}}
+                          onClick={() => onDrillDown(group.name, month)}
                           data-tip={`View daily breakdown for ${formatMonthLabel(month)}`}
                           className={`tooltip group grid ${valueColumns} gap-2 items-center justify-center mx-auto rounded-md border border-transparent px-2 py-1 cursor-pointer bg-transparent transition-all hover:border-line-strong hover:bg-surface-muted`}
                         >
                           <span
-                            className={`${badgeClass} ${toneForPercentage(monthly.availability)}`}
+                            className={`${badgeClass} ${availabilityTone(monthly.availability)}`}
                           >
                             {monthly.availability}
                           </span>
                           <span
-                            className={`${badgeClass} ${toneForPercentage(monthly.reliability)}`}
+                            className={`${badgeClass} ${availabilityTone(monthly.reliability)}`}
                           >
                             {monthly.reliability}
                           </span>

--- a/src/pages/availability-reliability/availabilityBadge.ts
+++ b/src/pages/availability-reliability/availabilityBadge.ts
@@ -1,8 +1,18 @@
-export const toneForPercentage = (value: number): string => {
+export const availabilityTone = (value: number): string => {
   if (value >= 99.5) {
     return 'bg-emerald-50 text-emerald-600'
   }
   if (value >= 95) {
+    return 'bg-amber-50 text-amber-600'
+  }
+  return 'bg-red-50 text-red-600'
+}
+
+export const downtimeTone = (value: number): string => {
+  if (value <= 0) {
+    return 'bg-emerald-50 text-emerald-600'
+  }
+  if (value <= 1) {
     return 'bg-amber-50 text-amber-600'
   }
   return 'bg-red-50 text-red-600'

--- a/src/pages/availability-reliability/index.ts
+++ b/src/pages/availability-reliability/index.ts
@@ -1,1 +1,2 @@
 export { default as AvailabilityReliability } from './AvailabilityReliability'
+export { default as AvailabilityReliabilityDaily } from './AvailabilityReliabilityDaily'

--- a/src/types/availabilityReliability.ts
+++ b/src/types/availabilityReliability.ts
@@ -11,6 +11,14 @@ export type GroupAvailabilityReliability = {
   monthly: GroupMonthlyResult[]
 }
 
+export type GroupDailyResult = {
+  date: string
+  availability: number
+  reliability: number
+  unknown: number
+  downtime: number
+}
+
 export type GroupResult = {
   timestamp: string
   availability: string
@@ -20,7 +28,7 @@ export type GroupResult = {
   downtime: string
 }
 
-export type GroupEndpoints = {
+export type GroupItem = {
   name: string
   type: string
   results: GroupResult[]
@@ -29,7 +37,7 @@ export type GroupEndpoints = {
 export type GroupData = {
   name: string
   type: string
-  groups: GroupEndpoints[]
+  groups: GroupItem[]
 }
 
 export type GroupsAvailabilityReliabilityResponse = {


### PR DESCRIPTION
This PR adds a daily availability and reliability breakdown page for a group, reached by drilling down from a month in the monthly view.

- Added a daily results page showing per-day Availability, Reliability, Unknown and Downtime for a group's selected month
- Implemented the API integration for fetching daily group results
- Added a dedicated route for the daily view linked from each month's result in the monthly table