### PR TITLE
[ARGO-5755] - Show Not Found page for invalid tenant in public URLs

### DIFF
--- a/src/pages/public-tenant/PublicTenantLayout.tsx
+++ b/src/pages/public-tenant/PublicTenantLayout.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTenantName } from '@/hooks/useTenantName'
 import { useGetPerformanceSettings } from '@/hooks/useSettings'
+import { useGetPublicTenantReports } from '@/hooks/useTenants'
 import { Outlet } from 'react-router-dom'
 import {
   CircleStackIcon,
@@ -18,8 +19,10 @@ const PublicTenantLayout = () => {
   const { tenantName, loading: tenantLoading } = useTenantName()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const { data: performanceSetting } = useGetPerformanceSettings()
+  const { isLoading: reportsLoading, error: reportsError } =
+    useGetPublicTenantReports(tenantName ?? '', undefined, !!tenantName)
 
-  if (tenantLoading) {
+  if (tenantLoading || (!!tenantName && reportsLoading)) {
     return (
       <div className="h-screen flex items-center justify-center text-subtle">
         Loading…
@@ -27,7 +30,7 @@ const PublicTenantLayout = () => {
     )
   }
 
-  if (!tenantName) {
+  if (!tenantName || reportsError) {
     return <NotFound />
   }
 


### PR DESCRIPTION
This PR shows the Not Found page for public tenant URLs (dashboard, capabilities, performance) when the tenant name is invalid.

- Added Not Found handling for public tenant pages when the tenant name does not exist