### PR TITLE
[ARGO-5767] - Show Not Found page for invalid public status page URLs

### DIFF
--- a/src/api/status.ts
+++ b/src/api/status.ts
@@ -12,9 +12,11 @@ export const fetchStatus = async (slug: string): Promise<PageConfig> => {
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}))
-    throw new Error(
+    const error = new Error(
       errorData.message || `HTTP error! status: ${response.status}`,
-    )
+    ) as Error & { status?: number }
+    error.status = response.status
+    throw error
   }
 
   return response.json()

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,6 +1,10 @@
 import Button from '@/components/Button'
 
-const NotFound = () => (
+interface NotFoundProps {
+  showHomeButton?: boolean
+}
+
+const NotFound = ({ showHomeButton = true }: NotFoundProps) => (
   <div className="page-container flex flex-col items-center justify-center min-h-[60vh] text-center py-16">
     <p className="text-7xl font-bold text-gray-300 leading-none select-none">
       404
@@ -11,9 +15,11 @@ const NotFound = () => (
     <p className="text-muted mb-4 max-w-sm">
       The page you're looking for doesn't exist or has been moved.
     </p>
-    <Button href="/" size="sm">
-      Go to Home
-    </Button>
+    {showHomeButton && (
+      <Button href="/" size="sm">
+        Go to Home
+      </Button>
+    )}
   </div>
 )
 

--- a/src/pages/PublicStatusPage.tsx
+++ b/src/pages/PublicStatusPage.tsx
@@ -2,6 +2,7 @@ import { useParams, Link } from 'react-router-dom'
 import { useGetStatusQuery } from '@/hooks/useStatus'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorDisplay from '@/components/ErrorDisplay'
+import NotFound from '@/pages/NotFound'
 import { ExpandableStatus } from './ExpandableStatus'
 import { Status } from './Status'
 
@@ -27,6 +28,9 @@ const PublicStatusPage = () => {
 
   const { data: statusData, isLoading, error } = useGetStatusQuery(slug || '')
 
+  const isNotFoundError =
+    (error as (Error & { status?: number }) | null)?.status === 404
+
   const errorMessage = error?.message
     ? resolveErrorMessage(error.message)
     : 'This status page could not be loaded.'
@@ -40,6 +44,8 @@ const PublicStatusPage = () => {
               <LoadingSpinner />
               <div className="text-lg text-muted">Loading status page...</div>
             </div>
+          ) : isNotFoundError ? (
+            <NotFound showHomeButton={false} />
           ) : statusData ? (
             statusData.theming?.option === 'theme_2' ? (
               <Status


### PR DESCRIPTION
This PR shows a Not Found page for invalid public status page URLs instead of a generic error message.

- Added Not Found handling to the public status page when a status page URL does not exist
- Updated the status page API call to return the actual HTTP status code from failed requests